### PR TITLE
docs: add docker usage instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,11 @@ requests to local Ollama instances. The repository contains two binaries:
 - Unit tests live alongside the code using `*_test.go` files
 - End-to-end tests are in the `test/` directory
 - Always run `make build` and `make test` before submitting a change
+- If the Dockerfiles under `deploy/` are updated, ensure they still build:
+  ```bash
+  docker build -f deploy/Dockerfile.server .
+  docker build -f deploy/Dockerfile.worker .
+  ```
 
 ## Further Reading
 - @README.md for project usage and examples

--- a/README.md
+++ b/README.md
@@ -83,6 +83,30 @@ go run .\cmd\llamapool-worker
 
 
 
+## Run with Docker
+
+Pre-built images are available:
+
+- Server: `ghcr.io/gaspardpetit/llamapool-server:main`
+- Client: `ghcr.io/gaspardpetit/llamapool-client:main`
+
+### Server
+
+```bash
+docker run --rm -p 8080:8080 -e WORKER_TOKEN=secret \
+  ghcr.io/gaspardpetit/llamapool-server:main
+```
+
+### Client
+
+```bash
+docker run --rm \
+  -e SERVER_URL=ws://localhost:8080/workers/connect \
+  -e TOKEN=secret \
+  -e OLLAMA_URL=http://host.docker.internal:11434 \
+  ghcr.io/gaspardpetit/llamapool-client:main
+```
+
 ## Example request
 
 On Linux:


### PR DESCRIPTION
## Summary
- document how to run server and client via pre-built docker images
- require testing dockerfile builds in AGENTS guidelines

## Testing
- `make build`
- `make test`
- `docker build -f deploy/Dockerfile.server -t llamapool-server-test .` *(fails: Cannot connect to the Docker daemon at unix:///var/run/docker.sock)*
- `docker build -f deploy/Dockerfile.worker -t llamapool-worker-test .` *(fails: Cannot connect to the Docker daemon at unix:///var/run/docker.sock)*

------
https://chatgpt.com/codex/tasks/task_e_689aa2e42168832c992d2a843d3cc148