### PR TITLE
Add metrics registry and state endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,15 @@ The server also exposes a basic health check:
 curl http://localhost:8080/healthz
 ```
 
+For server administration and monitoring:
+
+```bash
+curl -H "Authorization: Bearer test123" http://localhost:8080/api/v1/state
+curl -H "Authorization: Bearer test123" http://localhost:8080/api/v1/state/stream
+# Prometheus metrics
+curl http://localhost:8080/metrics
+```
+
 The server also exposes OpenAI-style model listing endpoints:
 
 ```bash

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 require (
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
+	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.19 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -9,12 +9,17 @@ import (
 )
 
 // NewRouter builds the API router.
-func NewRouter(reg *ctrl.Registry, sched ctrl.Scheduler, timeout time.Duration) chi.Router {
+func NewRouter(reg *ctrl.Registry, metrics *ctrl.MetricsRegistry, sched ctrl.Scheduler, timeout time.Duration) chi.Router {
 	r := chi.NewRouter()
 	for _, m := range middlewareChain() {
 		r.Use(m)
 	}
 	r.Post("/generate", GenerateHandler(reg, sched, timeout))
 	r.Get("/tags", TagsHandler(reg))
+
+	stateHandler := &StateHandler{Metrics: metrics}
+	r.Get("/v1/state", stateHandler.GetState)
+	r.Get("/v1/state/stream", stateHandler.GetStateStream)
+
 	return r
 }

--- a/internal/api/state.go
+++ b/internal/api/state.go
@@ -1,0 +1,46 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"time"
+
+	"github.com/you/llamapool/internal/ctrl"
+)
+
+// StateHandler serves state snapshots and streams.
+type StateHandler struct{ Metrics *ctrl.MetricsRegistry }
+
+// GetState returns a JSON snapshot of metrics.
+func (h *StateHandler) GetState(w http.ResponseWriter, r *http.Request) {
+	state := h.Metrics.Snapshot()
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(state)
+}
+
+// GetStateStream streams state snapshots as Server-Sent Events.
+func (h *StateHandler) GetStateStream(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("Connection", "keep-alive")
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		http.Error(w, "streaming unsupported", http.StatusInternalServerError)
+		return
+	}
+	ticker := time.NewTicker(2 * time.Second)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-r.Context().Done():
+			return
+		case <-ticker.C:
+			state := h.Metrics.Snapshot()
+			b, _ := json.Marshal(state)
+			w.Write([]byte("data: "))
+			w.Write(b)
+			w.Write([]byte("\n\n"))
+			flusher.Flush()
+		}
+	}
+}

--- a/internal/api/state_test.go
+++ b/internal/api/state_test.go
@@ -1,0 +1,58 @@
+package api
+
+import (
+	"bufio"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+
+	"github.com/you/llamapool/internal/ctrl"
+)
+
+func TestGetState(t *testing.T) {
+	metricsReg := ctrl.NewMetricsRegistry("v", "sha", "date")
+	metricsReg.UpsertWorker("w1", "1", "a", "d", []string{"m"})
+	metricsReg.SetWorkerStatus("w1", ctrl.StatusConnected)
+	metricsReg.RecordJobStart("w1")
+	metricsReg.RecordJobEnd("w1", "m", 50*time.Millisecond, 5, 7, true, "")
+
+	h := &StateHandler{Metrics: metricsReg}
+	r := httptest.NewRequest(http.MethodGet, "/api/v1/state", nil)
+	w := httptest.NewRecorder()
+	h.GetState(w, r)
+	var resp ctrl.StateResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(resp.Workers) != 1 || resp.Server.JobsCompletedTotal != 1 {
+		t.Fatalf("bad response %+v", resp)
+	}
+}
+
+func TestGetStateStream(t *testing.T) {
+	metricsReg := ctrl.NewMetricsRegistry("v", "sha", "date")
+	h := &StateHandler{Metrics: metricsReg}
+
+	r := chi.NewRouter()
+	r.Get("/api/v1/state/stream", h.GetStateStream)
+	srv := httptest.NewServer(r)
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL + "/api/v1/state/stream")
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	defer resp.Body.Close()
+	reader := bufio.NewReader(resp.Body)
+	line, err := reader.ReadString('\n')
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if line == "" {
+		t.Fatalf("empty stream")
+	}
+}

--- a/internal/ctrl/metrics_test.go
+++ b/internal/ctrl/metrics_test.go
@@ -1,0 +1,95 @@
+package ctrl
+
+import (
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestSnapshotEmpty(t *testing.T) {
+	reg := NewMetricsRegistry("v", "sha", "date")
+	snap := reg.Snapshot()
+	if snap.Server.Version != "v" {
+		t.Fatalf("version mismatch")
+	}
+	if snap.Server.JobsInflight != 0 || snap.Server.JobsCompletedTotal != 0 {
+		t.Fatalf("expected zero jobs")
+	}
+	if snap.Server.UptimeSeconds < 0 {
+		t.Fatalf("invalid uptime")
+	}
+}
+
+func TestWorkerLifecycle(t *testing.T) {
+	reg := NewMetricsRegistry("v", "sha", "date")
+	reg.UpsertWorker("w1", "1.0", "a", "today", []string{"llama3:8b"})
+	reg.SetWorkerStatus("w1", StatusConnected)
+	reg.RecordHeartbeat("w1")
+	reg.RecordJobStart("w1")
+	reg.RecordJobEnd("w1", "llama3:8b", 100*time.Millisecond, 10, 20, true, "")
+
+	snap := reg.Snapshot()
+	if len(snap.Workers) != 1 {
+		t.Fatalf("expected one worker")
+	}
+	w := snap.Workers[0]
+	if w.ProcessedTotal != 1 || w.Inflight != 0 {
+		t.Fatalf("bad worker counts %+v", w)
+	}
+	if w.PerModel["llama3:8b"].SuccessTotal != 1 {
+		t.Fatalf("expected per-model success")
+	}
+	if snap.Server.JobsCompletedTotal != 1 {
+		t.Fatalf("expected job completed")
+	}
+}
+
+func TestErrorPaths(t *testing.T) {
+	reg := NewMetricsRegistry("v", "sha", "date")
+	reg.UpsertWorker("w1", "1.0", "a", "today", nil)
+	reg.RecordJobStart("w1")
+	reg.RecordJobEnd("w1", "m", 0, 0, 0, false, "boom")
+
+	snap := reg.Snapshot()
+	w := snap.Workers[0]
+	if w.FailuresTotal != 1 || w.LastError != "boom" {
+		t.Fatalf("expected failure recorded")
+	}
+	if snap.Server.JobsFailedTotal != 1 {
+		t.Fatalf("expected global failure")
+	}
+}
+
+func TestWorkersSummaryAndModels(t *testing.T) {
+	reg := NewMetricsRegistry("v", "sha", "date")
+	reg.UpsertWorker("a", "1", "", "", []string{"m1", "m2"})
+	reg.SetWorkerStatus("a", StatusConnected)
+	reg.UpsertWorker("b", "1", "", "", []string{"m2"})
+	reg.SetWorkerStatus("b", StatusIdle)
+
+	snap := reg.Snapshot()
+	if snap.WorkersSummary.Connected != 1 || snap.WorkersSummary.Idle != 1 {
+		t.Fatalf("bad summary %+v", snap.WorkersSummary)
+	}
+	if len(snap.Models) != 2 {
+		t.Fatalf("expected two models")
+	}
+}
+
+func TestRegistryRace(t *testing.T) {
+	reg := NewMetricsRegistry("v", "sha", "date")
+	reg.UpsertWorker("w", "1", "", "", []string{"m"})
+	var wg sync.WaitGroup
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 100; j++ {
+				reg.RecordHeartbeat("w")
+				reg.RecordJobStart("w")
+				reg.RecordJobEnd("w", "m", time.Millisecond, 0, 0, true, "")
+			}
+		}()
+	}
+	wg.Wait()
+}

--- a/internal/metrics/prom.go
+++ b/internal/metrics/prom.go
@@ -1,0 +1,72 @@
+package metrics
+
+import (
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+var (
+	buildInfo = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name:        "llamapool_build_info",
+			Help:        "Build information",
+			ConstLabels: prometheus.Labels{"component": "server"},
+		},
+		[]string{"date", "sha", "version"},
+	)
+
+	modelRequests = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "llamapool_model_requests_total",
+			Help: "Number of model requests",
+		},
+		[]string{"model", "outcome"},
+	)
+
+	modelTokens = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "llamapool_model_tokens_total",
+			Help: "Tokens processed per model",
+		},
+		[]string{"kind", "model"},
+	)
+
+	requestDuration = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name:    "llamapool_request_duration_seconds",
+			Help:    "Request duration",
+			Buckets: prometheus.DefBuckets,
+		},
+		[]string{"worker_id", "model"},
+	)
+)
+
+// Register registers all metrics with the provided registerer.
+func Register(r prometheus.Registerer) {
+	r.MustRegister(buildInfo, modelRequests, modelTokens, requestDuration)
+}
+
+// SetServerBuildInfo sets the build info metric for the server.
+func SetServerBuildInfo(version, sha, date string) {
+	buildInfo.WithLabelValues(date, sha, version).Set(1)
+}
+
+// RecordModelRequest increments the model request counter.
+func RecordModelRequest(model string, success bool) {
+	outcome := "success"
+	if !success {
+		outcome = "error"
+	}
+	modelRequests.WithLabelValues(model, outcome).Inc()
+}
+
+// RecordModelTokens increments token counters for a model.
+func RecordModelTokens(model, kind string, n uint64) {
+	modelTokens.WithLabelValues(kind, model).Add(float64(n))
+}
+
+// ObserveRequestDuration records the duration of a request.
+func ObserveRequestDuration(workerID, model string, d time.Duration) {
+	requestDuration.WithLabelValues(workerID, model).Observe(d.Seconds())
+}

--- a/internal/metrics/prom_test.go
+++ b/internal/metrics/prom_test.go
@@ -1,0 +1,28 @@
+package metrics
+
+import (
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+)
+
+func TestPromMetrics(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	Register(reg)
+	SetServerBuildInfo("1.0.0", "abc", "2024-01-01")
+	RecordModelRequest("llama3:8b", true)
+	RecordModelTokens("llama3:8b", "in", 10)
+	ObserveRequestDuration("w1", "llama3:8b", 100*time.Millisecond)
+
+	if v := testutil.ToFloat64(modelRequests.WithLabelValues("llama3:8b", "success")); v != 1 {
+		t.Fatalf("model requests: %v", v)
+	}
+	if v := testutil.ToFloat64(modelTokens.WithLabelValues("in", "llama3:8b")); v != 10 {
+		t.Fatalf("model tokens: %v", v)
+	}
+	if v := testutil.ToFloat64(buildInfo.WithLabelValues("2024-01-01", "abc", "1.0.0")); v != 1 {
+		t.Fatalf("build info: %v", v)
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -13,13 +13,13 @@ import (
 )
 
 // New constructs the HTTP handler for the server.
-func New(reg *ctrl.Registry, sched ctrl.Scheduler, cfg config.ServerConfig) http.Handler {
+func New(reg *ctrl.Registry, metrics *ctrl.MetricsRegistry, sched ctrl.Scheduler, cfg config.ServerConfig) http.Handler {
 	r := chi.NewRouter()
 	r.Route("/api", func(r chi.Router) {
 		if cfg.APIKey != "" {
 			r.Use(api.APIKeyMiddleware(cfg.APIKey))
 		}
-		r.Mount("/", api.NewRouter(reg, sched, cfg.RequestTimeout))
+		r.Mount("/", api.NewRouter(reg, metrics, sched, cfg.RequestTimeout))
 	})
 	r.Route("/v1", func(r chi.Router) {
 		if cfg.APIKey != "" {

--- a/test/e2e_api_key_test.go
+++ b/test/e2e_api_key_test.go
@@ -15,7 +15,8 @@ func TestAPIKeyEnforcement(t *testing.T) {
 	reg := ctrl.NewRegistry()
 	sched := &ctrl.LeastBusyScheduler{Reg: reg}
 	cfg := config.ServerConfig{APIKey: "test123", WSPath: "/workers/connect", RequestTimeout: 5 * time.Second}
-	handler := server.New(reg, sched, cfg)
+	metricsReg := ctrl.NewMetricsRegistry("test", "", "")
+	handler := server.New(reg, metricsReg, sched, cfg)
 	srv := httptest.NewServer(handler)
 	defer srv.Close()
 

--- a/test/e2e_auth_test.go
+++ b/test/e2e_auth_test.go
@@ -20,7 +20,8 @@ func TestWorkerAuth(t *testing.T) {
 	reg := ctrl.NewRegistry()
 	sched := &ctrl.LeastBusyScheduler{Reg: reg}
 	cfg := config.ServerConfig{WorkerKey: "secret", WSPath: "/workers/connect", RequestTimeout: 5 * time.Second}
-	handler := server.New(reg, sched, cfg)
+	metricsReg := ctrl.NewMetricsRegistry("test", "", "")
+	handler := server.New(reg, metricsReg, sched, cfg)
 	srv := httptest.NewServer(handler)
 	defer srv.Close()
 

--- a/test/e2e_busy_test.go
+++ b/test/e2e_busy_test.go
@@ -21,7 +21,8 @@ func TestWorkerBusy(t *testing.T) {
 	reg.Add(worker)
 	sched := &ctrl.LeastBusyScheduler{Reg: reg}
 	cfg := config.ServerConfig{WorkerKey: "secret", WSPath: "/workers/connect", RequestTimeout: 5 * time.Second}
-	handler := server.New(reg, sched, cfg)
+	metricsReg := ctrl.NewMetricsRegistry("test", "", "")
+	handler := server.New(reg, metricsReg, sched, cfg)
 	srv := httptest.NewServer(handler)
 	defer srv.Close()
 

--- a/test/e2e_cancel_test.go
+++ b/test/e2e_cancel_test.go
@@ -23,7 +23,8 @@ func TestCancelPropagates(t *testing.T) {
 	reg := ctrl.NewRegistry()
 	sched := &ctrl.LeastBusyScheduler{Reg: reg}
 	cfg := config.ServerConfig{WorkerKey: "secret", WSPath: "/workers/connect", RequestTimeout: 5 * time.Second}
-	handler := server.New(reg, sched, cfg)
+	metricsReg := ctrl.NewMetricsRegistry("test", "", "")
+	handler := server.New(reg, metricsReg, sched, cfg)
 	srv := httptest.NewServer(handler)
 	defer srv.Close()
 

--- a/test/e2e_chat_completions_proxy_test.go
+++ b/test/e2e_chat_completions_proxy_test.go
@@ -21,7 +21,8 @@ func TestE2EChatCompletionsProxy(t *testing.T) {
 	reg := ctrl.NewRegistry()
 	sched := &ctrl.LeastBusyScheduler{Reg: reg}
 	cfg := config.ServerConfig{WorkerKey: "secret", APIKey: "apikey", WSPath: "/workers/connect", RequestTimeout: 5 * time.Second}
-	handler := server.New(reg, sched, cfg)
+	metricsReg := ctrl.NewMetricsRegistry("test", "", "")
+	handler := server.New(reg, metricsReg, sched, cfg)
 	srv := httptest.NewServer(handler)
 	defer srv.Close()
 

--- a/test/e2e_models_api_test.go
+++ b/test/e2e_models_api_test.go
@@ -20,7 +20,8 @@ func TestModelsAPI(t *testing.T) {
 	reg := ctrl.NewRegistry()
 	sched := &ctrl.LeastBusyScheduler{Reg: reg}
 	cfg := config.ServerConfig{WSPath: "/workers/connect", RequestTimeout: 5 * time.Second}
-	handler := server.New(reg, sched, cfg)
+	metricsReg := ctrl.NewMetricsRegistry("test", "", "")
+	handler := server.New(reg, metricsReg, sched, cfg)
 	srv := httptest.NewServer(handler)
 	defer srv.Close()
 

--- a/test/e2e_prune_test.go
+++ b/test/e2e_prune_test.go
@@ -19,7 +19,8 @@ func TestHeartbeatPrune(t *testing.T) {
 	reg := ctrl.NewRegistry()
 	sched := &ctrl.LeastBusyScheduler{Reg: reg}
 	cfg := config.ServerConfig{WorkerKey: "secret", WSPath: "/workers/connect", RequestTimeout: 5 * time.Second}
-	handler := server.New(reg, sched, cfg)
+	metricsReg := ctrl.NewMetricsRegistry("test", "", "")
+	handler := server.New(reg, metricsReg, sched, cfg)
 	srv := httptest.NewServer(handler)
 	defer srv.Close()
 

--- a/test/e2e_routes_test.go
+++ b/test/e2e_routes_test.go
@@ -16,7 +16,8 @@ func TestRoutes(t *testing.T) {
 	reg := ctrl.NewRegistry()
 	sched := &ctrl.LeastBusyScheduler{Reg: reg}
 	cfg := config.ServerConfig{WorkerKey: "secret", WSPath: "/workers/connect", RequestTimeout: 5 * time.Second}
-	handler := server.New(reg, sched, cfg)
+	metricsReg := ctrl.NewMetricsRegistry("test", "", "")
+	handler := server.New(reg, metricsReg, sched, cfg)
 	srv := httptest.NewServer(handler)
 	defer srv.Close()
 

--- a/test/e2e_server_worker_generate_test.go
+++ b/test/e2e_server_worker_generate_test.go
@@ -23,7 +23,8 @@ func TestE2EGenerateStream(t *testing.T) {
 	reg := ctrl.NewRegistry()
 	sched := &ctrl.LeastBusyScheduler{Reg: reg}
 	cfg := config.ServerConfig{WorkerKey: "secret", WSPath: "/workers/connect", RequestTimeout: 5 * time.Second}
-	handler := server.New(reg, sched, cfg)
+	metricsReg := ctrl.NewMetricsRegistry("test", "", "")
+	handler := server.New(reg, metricsReg, sched, cfg)
 	srv := httptest.NewServer(handler)
 	defer srv.Close()
 


### PR DESCRIPTION
## Summary
- track per-worker and server metrics via thread-safe registry
- expose JSON and SSE state endpoints and Prometheus counters
- wire build info and metrics registry into server startup

## Testing
- `make build`
- `make test`
- `make lint` *(fails: staticcheck deprecation warnings)*

------
https://chatgpt.com/codex/tasks/task_e_689bb81cd308832c8cf3f6d8527fb33c