### PR TITLE
Add systemd service templates and config docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,22 @@ docker run --rm \
   ghcr.io/gaspardpetit/llamapool-worker:main
 ```
 
+## Configuration
+
+When running as a systemd service, both components read optional configuration
+files managed by systemd. The server loads variables from
+`/etc/llamapool/server.env` while the worker reads `/etc/llamapool/worker.env`.
+Each file contains `KEY=value` pairs, for example:
+
+```bash
+# /etc/llamapool/server.env
+# API_KEY=your_api_key
+# WORKER_KEY=secret
+```
+
+Template files with commented defaults are available under
+`deploy/systemd/` and can be copied into place as needed.
+
 ## Example request
 
 Ensure that the requested `model` is installed on the connected worker's local

--- a/deploy/systemd/llamapool-server.service
+++ b/deploy/systemd/llamapool-server.service
@@ -1,0 +1,28 @@
+[Unit]
+Description=Llamapool Server
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+User=llamapool
+Group=llamapool
+EnvironmentFile=-/etc/llamapool/server.env
+ExecStart=/usr/bin/llamapool-server $SERVER_FLAGS
+Restart=on-failure
+RestartSec=3s
+AmbientCapabilities=
+NoNewPrivileges=true
+ProtectSystem=full
+ProtectHome=true
+PrivateTmp=true
+CapabilityBoundingSet=
+StateDirectory=llamapool
+RuntimeDirectory=llamapool
+# Hardening knobs (adjust as needed)
+ProtectKernelLogs=true
+ProtectKernelModules=true
+ProtectControlGroups=true
+LockPersonality=true
+
+[Install]
+WantedBy=multi-user.target

--- a/deploy/systemd/llamapool-worker.service
+++ b/deploy/systemd/llamapool-worker.service
@@ -1,0 +1,28 @@
+[Unit]
+Description=Llamapool Worker
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+User=llamapool
+Group=llamapool
+EnvironmentFile=-/etc/llamapool/worker.env
+ExecStart=/usr/bin/llamapool-worker $WORKER_FLAGS
+Restart=on-failure
+RestartSec=3s
+AmbientCapabilities=
+NoNewPrivileges=true
+ProtectSystem=full
+ProtectHome=true
+PrivateTmp=true
+CapabilityBoundingSet=
+StateDirectory=llamapool
+RuntimeDirectory=llamapool
+# Hardening knobs (adjust as needed)
+ProtectKernelLogs=true
+ProtectKernelModules=true
+ProtectControlGroups=true
+LockPersonality=true
+
+[Install]
+WantedBy=multi-user.target

--- a/deploy/systemd/server.env.example
+++ b/deploy/systemd/server.env.example
@@ -1,0 +1,5 @@
+# Example environment file for llamapool-server
+# Uncomment and set values as needed.
+# API_KEY=your_api_key
+# WORKER_KEY=your_worker_key
+# LISTEN_ADDR=:8080

--- a/deploy/systemd/worker.env.example
+++ b/deploy/systemd/worker.env.example
@@ -1,0 +1,6 @@
+# Example environment file for llamapool-worker
+# Uncomment and set values as needed.
+# SERVER_URL=ws://localhost:8080/workers/connect
+# WORKER_KEY=secret
+# OLLAMA_BASE_URL=http://127.0.0.1:11434
+# WORKER_NAME=MyWorker


### PR DESCRIPTION
## Summary
- add systemd unit templates for llamapool server and worker
- provide example environment files for server and worker configuration
- document systemd-based configuration in README

## Testing
- `make build`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_689d30cbeba0832c84fd593eb496f598