### PR TITLE
Track worker metrics and expose Prometheus stats

### DIFF
--- a/internal/api/generate.go
+++ b/internal/api/generate.go
@@ -13,7 +13,7 @@ import (
 )
 
 // GenerateHandler handles POST /api/generate.
-func GenerateHandler(reg *ctrl.Registry, sched ctrl.Scheduler, timeout time.Duration) http.HandlerFunc {
+func GenerateHandler(reg *ctrl.Registry, metrics *ctrl.MetricsRegistry, sched ctrl.Scheduler, timeout time.Duration) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		var req relay.GenerateRequest
 		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
@@ -25,12 +25,12 @@ func GenerateHandler(reg *ctrl.Registry, sched ctrl.Scheduler, timeout time.Dura
 		if req.Stream {
 			w.Header().Set("Content-Type", "application/json")
 			w.Header().Set("Cache-Control", "no-store")
-			if err := relay.RelayGenerateStream(ctx, reg, sched, req, w); err != nil {
+			if err := relay.RelayGenerateStream(ctx, reg, metrics, sched, req, w); err != nil {
 				handleRelayErr(w, err)
 			}
 			return
 		}
-		res, err := relay.RelayGenerateOnce(ctx, reg, sched, req)
+		res, err := relay.RelayGenerateOnce(ctx, reg, metrics, sched, req)
 		if err != nil {
 			handleRelayErr(w, err)
 			return

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -14,7 +14,7 @@ func NewRouter(reg *ctrl.Registry, metrics *ctrl.MetricsRegistry, sched ctrl.Sch
 	for _, m := range middlewareChain() {
 		r.Use(m)
 	}
-	r.Post("/generate", GenerateHandler(reg, sched, timeout))
+	r.Post("/generate", GenerateHandler(reg, metrics, sched, timeout))
 	r.Get("/tags", TagsHandler(reg))
 
 	stateHandler := &StateHandler{Metrics: metrics}

--- a/internal/ctrl/metrics.go
+++ b/internal/ctrl/metrics.go
@@ -259,7 +259,10 @@ func (m *MetricsRegistry) Snapshot() StateResponse {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
-	resp := StateResponse{}
+	resp := StateResponse{
+		Models:  []ModelCount{},
+		Workers: []WorkerSnapshot{},
+	}
 	resp.Server = ServerSnapshot{
 		Now:                time.Now(),
 		Version:            m.serverVer,

--- a/internal/ctrl/ws_workername_test.go
+++ b/internal/ctrl/ws_workername_test.go
@@ -13,7 +13,8 @@ import (
 
 func TestRegisterStoresWorkerName(t *testing.T) {
 	reg := NewRegistry()
-	srv := httptest.NewServer(WSHandler(reg, ""))
+	metricsReg := NewMetricsRegistry("test", "", "")
+	srv := httptest.NewServer(WSHandler(reg, metricsReg, ""))
 	defer srv.Close()
 
 	ctx := context.Background()
@@ -47,7 +48,8 @@ func TestRegisterStoresWorkerName(t *testing.T) {
 
 func TestRegisterFallbackName(t *testing.T) {
 	reg := NewRegistry()
-	srv := httptest.NewServer(WSHandler(reg, ""))
+	metricsReg := NewMetricsRegistry("test", "", "")
+	srv := httptest.NewServer(WSHandler(reg, metricsReg, ""))
 	defer srv.Close()
 
 	ctx := context.Background()

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -30,7 +30,7 @@ func New(reg *ctrl.Registry, metrics *ctrl.MetricsRegistry, sched ctrl.Scheduler
 		r.Get("/models/{id}", api.GetModelHandler(reg))
 		r.Post("/chat/completions", api.ChatCompletionsHandler(reg, sched))
 	})
-	r.Handle(cfg.WSPath, ctrl.WSHandler(reg, cfg.WorkerKey))
+	r.Handle(cfg.WSPath, ctrl.WSHandler(reg, metrics, cfg.WorkerKey))
 	r.Get("/healthz", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		if _, err := w.Write([]byte(`{"status":"ok"}`)); err != nil {


### PR DESCRIPTION
## Summary
- register workers in metrics and record heartbeats so `/api/v1/state` reports connected workers
- record per-request durations, outcomes and token counts for Prometheus metrics
- return empty model/worker lists instead of null in state snapshots

## Testing
- `make build`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_689d3c8cb620832c9aaf9ae323ad83e0