### PR TITLE
Fix lint issues and document lint requirement

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,7 +20,8 @@ requests to local Ollama instances. The repository contains two binaries:
 ## Testing Guidelines
 - Unit tests live alongside the code using `*_test.go` files
 - End-to-end tests are in the `test/` directory
-- Always run `make build` and `make test` before submitting a change
+- Always run `make lint`, `make build`, and `make test` before submitting a change
+- Fix any lint errors before completing your task
 - If the Dockerfiles under `deploy/` are updated, ensure they still build:
   ```bash
   docker build -f deploy/Dockerfile.server .

--- a/README.md
+++ b/README.md
@@ -314,12 +314,14 @@ curl -H "Authorization: Bearer test123" http://localhost:8080/v1/models/llama3:8
 On Linux:
 
 ```bash
+make lint
 make test
 ```
 
 On Windows:
 
 ```
+golangci-lint run
 go test ./...
 ```
 

--- a/cmd/llamapool-server/main.go
+++ b/cmd/llamapool-server/main.go
@@ -39,7 +39,7 @@ func main() {
 	var cfg config.ServerConfig
 	cfg.BindFlags()
 	flag.Usage = func() {
-		fmt.Fprintf(flag.CommandLine.Output(), "llamapool-%s version=%s sha=%s date=%s\n\n", binaryName(), version, buildSHA, buildDate)
+		_, _ = fmt.Fprintf(flag.CommandLine.Output(), "llamapool-%s version=%s sha=%s date=%s\n\n", binaryName(), version, buildSHA, buildDate)
 		flag.PrintDefaults()
 	}
 	flag.Parse()

--- a/cmd/llamapool-worker/main.go
+++ b/cmd/llamapool-worker/main.go
@@ -34,7 +34,7 @@ func main() {
 	var cfg config.WorkerConfig
 	cfg.BindFlags()
 	flag.Usage = func() {
-		fmt.Fprintf(flag.CommandLine.Output(), "llamapool-%s version=%s sha=%s date=%s\n\n", binaryName(), version, buildSHA, buildDate)
+		_, _ = fmt.Fprintf(flag.CommandLine.Output(), "llamapool-%s version=%s sha=%s date=%s\n\n", binaryName(), version, buildSHA, buildDate)
 		flag.PrintDefaults()
 	}
 	flag.Parse()


### PR DESCRIPTION
## Summary
- ignore fmt.Fprintf return values in CLI usage handlers
- document running `make lint` and fixing issues before committing

## Testing
- `make lint`
- `make build`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_689d509ad184832cabca2d0d4712b0a9