### PR TITLE
feat: poll worker status in macOS menu app

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,7 @@ A typical deployment looks like this:
 
 ## macOS Menu Bar App
 
-An early-stage macOS menu bar companion lives under `desktop/macos/llamapool/`. It offers a
-status item with placeholder controls for managing a local `llamapool-worker`.
+An early-stage macOS menu bar companion lives under `desktop/macos/llamapool/`. It polls `http://127.0.0.1:4555/status` every two seconds to display live worker status and offers placeholder controls for managing a local `llamapool-worker`.
 The app icon is stored as a base64 file (`AppIcon.png.b64`); decode it to `AppIcon.png` before building.
 
 ### Key features

--- a/desktop/macos/llamapool/llamapool.xcodeproj/project.pbxproj
+++ b/desktop/macos/llamapool/llamapool.xcodeproj/project.pbxproj
@@ -8,6 +8,8 @@
 /* Begin PBXBuildFile section */
     0CC07EE6BD4045DDAE821661FA6666E4 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B993A0AF20C45B9BFF02576573C7A4D /* AppDelegate.swift */; };
     77EE2F6323744EB4AF1E26772BAA8DF7 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = DB20D9050486454BA6F1464F12F231D1 /* Assets.xcassets */; };
+    4AB0C8F71A2346C8B30B5E02 /* StatusClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6F8C39D6E9C4E14A5D0E2D9 /* StatusClient.swift */; };
+    B21ACD2F315B40E38B7B6A6E /* StatusClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4EAD688B5AC2497F99047482 /* StatusClientTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -15,10 +17,14 @@
     9B993A0AF20C45B9BFF02576573C7A4D /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
     DB20D9050486454BA6F1464F12F231D1 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
     24B6B6BC5ECD4E9CA7C7F7E8086B9FA5 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+    D6F8C39D6E9C4E14A5D0E2D9 /* StatusClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatusClient.swift; sourceTree = "<group>"; };
+    4EAD688B5AC2497F99047482 /* StatusClientTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatusClientTests.swift; sourceTree = "<group>"; };
+    9FDC5B0B495D4A6C8C96F2E9 /* llamapoolTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = llamapoolTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
     0A44A43592684603805C437737106041 /* Frameworks */ = {isa = PBXFrameworksBuildPhase; buildActionMask = 2147483647; files = (); runOnlyForDeploymentPostprocessing = 0; };
+    AA1F75C905AB4286842F4F6B /* Frameworks */ = {isa = PBXFrameworksBuildPhase; buildActionMask = 2147483647; files = (); runOnlyForDeploymentPostprocessing = 0; };
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
@@ -26,6 +32,7 @@
       isa = PBXGroup;
       children = (
         141EB2E1593C4112932B0389AB5F9296,
+        B6510F4A0DAF4274A96E1F24 /* llamapoolTests */,
         44CFCA963667432983C404F9C521016F,
       );
       sourceTree = "<group>";
@@ -34,16 +41,26 @@
       isa = PBXGroup;
       children = (
         9B993A0AF20C45B9BFF02576573C7A4D /* AppDelegate.swift */,
+        D6F8C39D6E9C4E14A5D0E2D9 /* StatusClient.swift */,
         DB20D9050486454BA6F1464F12F231D1 /* Assets.xcassets */,
         24B6B6BC5ECD4E9CA7C7F7E8086B9FA5 /* Info.plist */,
       );
       path = llamapool;
       sourceTree = "<group>";
     };
+    B6510F4A0DAF4274A96E1F24 /* llamapoolTests */ = {
+      isa = PBXGroup;
+      children = (
+        4EAD688B5AC2497F99047482 /* StatusClientTests.swift */,
+      );
+      path = llamapoolTests;
+      sourceTree = "<group>";
+    };
     44CFCA963667432983C404F9C521016F /* Products */ = {
       isa = PBXGroup;
       children = (
         E9B117E139B24CC89E7EDB0E95964914 /* llamapool.app */,
+        9FDC5B0B495D4A6C8C96F2E9 /* llamapoolTests.xctest */,
       );
       name = Products;
       sourceTree = "<group>";
@@ -68,7 +85,32 @@
       productReference = E9B117E139B24CC89E7EDB0E95964914 /* llamapool.app */;
       productType = "com.apple.product-type.application";
     };
+    EBE90F3B7CBB4F6FA4A5E2D1 /* llamapoolTests */ = {
+      isa = PBXNativeTarget;
+      buildConfigurationList = 5A0F1C1F6DA7414E8C992243 /* Build configuration list for PBXNativeTarget "llamapoolTests" */;
+      buildPhases = (
+        0C7D3CF2E5B745708FA8A6F0 /* Sources */,
+        AA1F75C905AB4286842F4F6B /* Frameworks */,
+      );
+      buildRules = (
+      );
+      dependencies = (
+        D4816C4E23E8424E8AF97B64 /* PBXTargetDependency */,
+      );
+      name = llamapoolTests;
+      productName = llamapoolTests;
+      productReference = 9FDC5B0B495D4A6C8C96F2E9 /* llamapoolTests.xctest */;
+      productType = "com.apple.product-type.bundle.unit-test";
+    };
 /* End PBXNativeTarget section */
+
+/* Begin PBXTargetDependency section */
+    D4816C4E23E8424E8AF97B64 /* PBXTargetDependency */ = {isa = PBXTargetDependency; target = 7E40A3A7183646E390A7675E6A480D3A /* llamapool */; targetProxy = A3F276C72E8149D3A868DE32 /* PBXContainerItemProxy */; };
+/* End PBXTargetDependency section */
+
+/* Begin PBXContainerItemProxy section */
+    A3F276C72E8149D3A868DE32 /* PBXContainerItemProxy */ = {isa = PBXContainerItemProxy; containerPortal = EFA3DD98CD7E44A39AE163AC1EE87901 /* Project object */; proxyType = 1; remoteGlobalIDString = 7E40A3A7183646E390A7675E6A480D3A; remoteInfo = llamapool; };
+/* End PBXContainerItemProxy section */
 
 /* Begin PBXProject section */
     EFA3DD98CD7E44A39AE163AC1EE87901 /* Project object */ = {
@@ -78,6 +120,9 @@
         LastUpgradeCheck = 1430;
         TargetAttributes = {
           7E40A3A7183646E390A7675E6A480D3A = {
+            CreatedOnToolsVersion = 14.3.0;
+          };
+          EBE90F3B7CBB4F6FA4A5E2D1 = {
             CreatedOnToolsVersion = 14.3.0;
           };
         };
@@ -95,6 +140,7 @@
       projectRoot = "";
       targets = (
         7E40A3A7183646E390A7675E6A480D3A /* llamapool */,
+        EBE90F3B7CBB4F6FA4A5E2D1 /* llamapoolTests */,
       );
     };
 /* End PBXProject section */
@@ -116,6 +162,15 @@
       buildActionMask = 2147483647;
       files = (
         0CC07EE6BD4045DDAE821661FA6666E4 /* AppDelegate.swift in Sources */,
+        4AB0C8F71A2346C8B30B5E02 /* StatusClient.swift in Sources */,
+      );
+      runOnlyForDeploymentPostprocessing = 0;
+    };
+    0C7D3CF2E5B745708FA8A6F0 /* Sources */ = {
+      isa = PBXSourcesBuildPhase;
+      buildActionMask = 2147483647;
+      files = (
+        B21ACD2F315B40E38B7B6A6E /* StatusClientTests.swift in Sources */,
       );
       runOnlyForDeploymentPostprocessing = 0;
     };
@@ -158,6 +213,30 @@
       };
       name = Release;
     };
+    9A15E67F3AD24A879EE39C77 /* Debug */ = {
+      isa = XCBuildConfiguration;
+      buildSettings = {
+        BUNDLE_LOADER = "$(TEST_HOST)";
+        GENERATE_INFOPLIST_FILE = YES;
+        LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
+        PRODUCT_BUNDLE_IDENTIFIER = io.llamapool.menubarTests;
+        SWIFT_VERSION = 5.0;
+        TEST_HOST = "$(BUILT_PRODUCTS_DIR)/llamapool.app/Contents/MacOS/llamapool";
+      };
+      name = Debug;
+    };
+    A88E8E394F9C49E3B2B0CF2D /* Release */ = {
+      isa = XCBuildConfiguration;
+      buildSettings = {
+        BUNDLE_LOADER = "$(TEST_HOST)";
+        GENERATE_INFOPLIST_FILE = YES;
+        LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
+        PRODUCT_BUNDLE_IDENTIFIER = io.llamapool.menubarTests;
+        SWIFT_VERSION = 5.0;
+        TEST_HOST = "$(BUILT_PRODUCTS_DIR)/llamapool.app/Contents/MacOS/llamapool";
+      };
+      name = Release;
+    };
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -175,6 +254,15 @@
       buildConfigurations = (
         8928F6627FB749B593B2DD95BD265C64 /* Debug */,
         6A1B8C797FA241B392CFED847DC7F7A6 /* Release */,
+      );
+      defaultConfigurationIsVisible = 0;
+      defaultConfigurationName = Release;
+    };
+    5A0F1C1F6DA7414E8C992243 /* Build configuration list for PBXNativeTarget "llamapoolTests" */ = {
+      isa = XCConfigurationList;
+      buildConfigurations = (
+        9A15E67F3AD24A879EE39C77 /* Debug */,
+        A88E8E394F9C49E3B2B0CF2D /* Release */,
       );
       defaultConfigurationIsVisible = 0;
       defaultConfigurationName = Release;

--- a/desktop/macos/llamapool/llamapool/AppDelegate.swift
+++ b/desktop/macos/llamapool/llamapool/AppDelegate.swift
@@ -3,17 +3,38 @@ import Cocoa
 @main
 class AppDelegate: NSObject, NSApplicationDelegate {
     var statusItem: NSStatusItem!
+    var statusMenuItem: NSMenuItem!
+    var workerItem: NSMenuItem!
+    var versionItem: NSMenuItem!
+    var connectionItem: NSMenuItem!
+    var jobsItem: NSMenuItem!
+    var lastErrorItem: NSMenuItem!
+    var statusClient: StatusClient?
 
     func applicationDidFinishLaunching(_ notification: Notification) {
         statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
-        if let button = statusItem.button {
-            button.image = NSImage(named: "AppIcon")
-        }
+        updateStatusDot(color: .systemRed)
 
         let menu = NSMenu()
-        let statusMenuItem = NSMenuItem(title: "Status: Disconnected", action: nil, keyEquivalent: "")
+        statusMenuItem = NSMenuItem(title: "Status: Disconnected", action: nil, keyEquivalent: "")
         statusMenuItem.isEnabled = false
         menu.addItem(statusMenuItem)
+
+        let detailsItem = NSMenuItem(title: "Details…", action: nil, keyEquivalent: "")
+        let detailsMenu = NSMenu()
+        workerItem = NSMenuItem(title: "Worker: –", action: nil, keyEquivalent: "")
+        versionItem = NSMenuItem(title: "Version: –", action: nil, keyEquivalent: "")
+        connectionItem = NSMenuItem(title: "Connected: Server –, Ollama –", action: nil, keyEquivalent: "")
+        jobsItem = NSMenuItem(title: "Jobs: 0 / 0", action: nil, keyEquivalent: "")
+        lastErrorItem = NSMenuItem(title: "Last Error: None", action: nil, keyEquivalent: "")
+        detailsMenu.addItem(workerItem)
+        detailsMenu.addItem(versionItem)
+        detailsMenu.addItem(connectionItem)
+        detailsMenu.addItem(jobsItem)
+        detailsMenu.addItem(lastErrorItem)
+        detailsItem.submenu = detailsMenu
+        menu.addItem(detailsItem)
+
         menu.addItem(NSMenuItem.separator())
         menu.addItem(NSMenuItem(title: "Start Worker", action: #selector(startWorker), keyEquivalent: ""))
         menu.addItem(NSMenuItem(title: "Stop Worker", action: #selector(stopWorker), keyEquivalent: ""))
@@ -27,6 +48,67 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         menu.addItem(NSMenuItem.separator())
         menu.addItem(NSMenuItem(title: "Quit", action: #selector(quit), keyEquivalent: "q"))
         statusItem.menu = menu
+
+        statusClient = StatusClient()
+        statusClient?.onUpdate = { [weak self] result in
+            DispatchQueue.main.async {
+                self?.handleStatusResult(result)
+            }
+        }
+        statusClient?.start()
+    }
+
+    func updateStatusDot(color: NSColor) {
+        let dot = NSAttributedString(string: "●", attributes: [.foregroundColor: color])
+        statusItem.button?.attributedTitle = dot
+    }
+
+    func handleStatusResult(_ result: Result<WorkerStatus, Error>) {
+        switch result {
+        case .success(let status):
+            statusItem.button?.toolTip = nil
+            statusMenuItem.toolTip = nil
+            statusMenuItem.title = "Status: \(text(for: status.state))"
+            updateStatusDot(color: color(for: status.state))
+            workerItem.title = "Worker: \(status.workerName) (\(status.workerId))"
+            versionItem.title = "Version: \(status.version)"
+            connectionItem.title = "Connected: Server \(status.connectedToServer ? "Yes" : "No"), Ollama \(status.connectedToOllama ? "Yes" : "No")"
+            jobsItem.title = "Jobs: \(status.currentJobs) / \(status.maxConcurrency)"
+            lastErrorItem.title = status.lastError.isEmpty ? "Last Error: None" : "Last Error: \(status.lastError)"
+        case .failure(let error):
+            statusMenuItem.title = "Status: Disconnected"
+            statusItem.button?.toolTip = error.localizedDescription
+            statusMenuItem.toolTip = error.localizedDescription
+            updateStatusDot(color: .systemRed)
+            workerItem.title = "Worker: –"
+            versionItem.title = "Version: –"
+            connectionItem.title = "Connected: Server –, Ollama –"
+            jobsItem.title = "Jobs: 0 / 0"
+            lastErrorItem.title = "Last Error: \(error.localizedDescription)"
+        }
+    }
+
+    func text(for state: WorkerStatus.State) -> String {
+        switch state {
+        case .connectedIdle: return "Connected Idle"
+        case .connectedBusy: return "Connected Busy"
+        case .connecting: return "Connecting"
+        case .disconnected: return "Disconnected"
+        case .draining: return "Draining"
+        case .terminating: return "Terminating"
+        case .error: return "Error"
+        }
+    }
+
+    func color(for state: WorkerStatus.State) -> NSColor {
+        switch state {
+        case .connectedIdle, .connectedBusy:
+            return .systemGreen
+        case .connecting, .draining, .terminating:
+            return .systemYellow
+        case .disconnected, .error:
+            return .systemRed
+        }
     }
 
     @objc func startWorker(_ sender: Any?) {

--- a/desktop/macos/llamapool/llamapool/StatusClient.swift
+++ b/desktop/macos/llamapool/llamapool/StatusClient.swift
@@ -1,0 +1,84 @@
+import Foundation
+
+struct WorkerStatus: Codable {
+    enum State: String, Codable {
+        case connectedIdle = "connected_idle"
+        case connectedBusy = "connected_busy"
+        case connecting
+        case disconnected
+        case draining
+        case terminating
+        case error
+    }
+
+    let state: State
+    let connectedToServer: Bool
+    let connectedToOllama: Bool
+    let currentJobs: Int
+    let maxConcurrency: Int
+    let models: [String]
+    let lastError: String
+    let lastHeartbeat: String
+    let workerId: String
+    let workerName: String
+    let version: String
+
+    private enum CodingKeys: String, CodingKey {
+        case state
+        case connectedToServer = "connected_to_server"
+        case connectedToOllama = "connected_to_ollama"
+        case currentJobs = "current_jobs"
+        case maxConcurrency = "max_concurrency"
+        case models
+        case lastError = "last_error"
+        case lastHeartbeat = "last_heartbeat"
+        case workerId = "worker_id"
+        case workerName = "worker_name"
+        case version
+    }
+}
+
+class StatusClient {
+    private let session: URLSession
+    private var timer: Timer?
+    private let url: URL
+    var onUpdate: ((Result<WorkerStatus, Error>) -> Void)?
+
+    init(port: Int = 4555, session: URLSession = .shared) {
+        self.session = session
+        self.url = URL(string: "http://127.0.0.1:\(port)/status")!
+    }
+
+    func start() {
+        timer = Timer.scheduledTimer(withTimeInterval: 2, repeats: true) { [weak self] _ in
+            self?.fetchStatus()
+        }
+        fetchStatus()
+    }
+
+    func stop() {
+        timer?.invalidate()
+        timer = nil
+    }
+
+    private func fetchStatus() {
+        session.dataTask(with: url) { [weak self] data, _, error in
+            guard let self = self else { return }
+            if let error = error {
+                self.onUpdate?(.failure(error))
+                return
+            }
+            guard let data = data else {
+                let err = NSError(domain: "StatusClient", code: -1, userInfo: [NSLocalizedDescriptionKey: "No data"])
+                self.onUpdate?(.failure(err))
+                return
+            }
+            do {
+                let status = try JSONDecoder().decode(WorkerStatus.self, from: data)
+                self.onUpdate?(.success(status))
+            } catch {
+                self.onUpdate?(.failure(error))
+            }
+        }.resume()
+    }
+}

--- a/desktop/macos/llamapool/llamapoolTests/StatusClientTests.swift
+++ b/desktop/macos/llamapool/llamapoolTests/StatusClientTests.swift
@@ -1,0 +1,60 @@
+import XCTest
+@testable import llamapool
+
+final class StatusClientTests: XCTestCase {
+    let sampleJSON = """
+    {
+      "state": "connected_idle",
+      "connected_to_server": true,
+      "connected_to_ollama": true,
+      "current_jobs": 1,
+      "max_concurrency": 2,
+      "models": ["llama3"],
+      "last_error": "",
+      "last_heartbeat": "2024-05-01T12:00:00Z",
+      "worker_id": "1234",
+      "worker_name": "test-worker",
+      "version": "v0.0.1"
+    }
+    """
+
+    func testDecodeSample() throws {
+        let data = Data(sampleJSON.utf8)
+        let status = try JSONDecoder().decode(WorkerStatus.self, from: data)
+        XCTAssertEqual(status.state, .connectedIdle)
+        XCTAssertEqual(status.workerName, "test-worker")
+        XCTAssertEqual(status.currentJobs, 1)
+    }
+
+    func testPollingWithMockServer() {
+        class URLProtocolMock: URLProtocol {
+            static var data: Data?
+            override class func canInit(with request: URLRequest) -> Bool { true }
+            override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+            override func startLoading() {
+                if let data = URLProtocolMock.data {
+                    self.client?.urlProtocol(self, didLoad: data)
+                    self.client?.urlProtocol(self, didReceive: HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!, cacheStoragePolicy: .notAllowed)
+                    self.client?.urlProtocolDidFinishLoading(self)
+                }
+            }
+            override func stopLoading() {}
+        }
+
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [URLProtocolMock.self]
+        URLProtocolMock.data = Data(sampleJSON.utf8)
+        let session = URLSession(configuration: config)
+        let client = StatusClient(session: session)
+        let expect = expectation(description: "Status")
+        client.onUpdate = { result in
+            if case .success(let status) = result {
+                XCTAssertEqual(status.workerId, "1234")
+                expect.fulfill()
+            }
+        }
+        client.start()
+        waitForExpectations(timeout: 1)
+        client.stop()
+    }
+}


### PR DESCRIPTION
## Summary
- poll local worker `/status` endpoint every 2 seconds
- show live status and details in the menu bar
- document status polling in README

## Testing
- `make lint`
- `go build ./cmd/llamapool-server`
- `go build ./cmd/llamapool-worker`
- `make test` *(fails: interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_689e39f5ff44832cac1402d472513057