### PR TITLE
worker: add control endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,6 +269,9 @@ When started with `--status-addr <addr>`, the worker serves local endpoints:
 
 - `GET /status` returns the current worker state.
 - `GET /version` returns build information.
+- `POST /control/drain` begins graceful draining.
+- `POST /control/undrain` resumes accepting jobs.
+- `POST /control/shutdown` drains and exits.
 
 Sending `SIGTERM` causes the worker to stop accepting new jobs and wait up to
 `--drain-timeout` (default 1m) for in-flight work to finish before exiting.
@@ -277,6 +280,9 @@ without waiting or `--drain-timeout=-1` to wait indefinitely.
 
 The worker periodically checks the local Ollama instance so that
 `connected_to_ollama` and `models` stay current in the `/status` output.
+
+Control endpoints require an `X-Auth-Token` header. The token is generated on
+first run and stored alongside the worker config as `worker.token`.
 
 ## Configuration
 

--- a/internal/worker/drain_integration_test.go
+++ b/internal/worker/drain_integration_test.go
@@ -6,6 +6,7 @@ import (
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -53,7 +54,7 @@ func TestDrainAndTerminate(t *testing.T) {
 	statusAddr := ln.Addr().String()
 	_ = ln.Close()
 
-	cfg := config.WorkerConfig{ServerURL: wsURL, OllamaBaseURL: ollama.URL, MaxConcurrency: 1, StatusAddr: statusAddr}
+	cfg := config.WorkerConfig{ServerURL: wsURL, OllamaBaseURL: ollama.URL, MaxConcurrency: 1, StatusAddr: statusAddr, ConfigFile: filepath.Join(t.TempDir(), "worker.yaml")}
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	errCh := make(chan error, 1)

--- a/internal/worker/health_test.go
+++ b/internal/worker/health_test.go
@@ -9,6 +9,7 @@ import (
 
 	"net/http"
 	"net/http/httptest"
+	"path/filepath"
 	"sync/atomic"
 
 	"github.com/you/llamapool/internal/ollama"
@@ -63,7 +64,8 @@ func TestHealthProbeIntegration(t *testing.T) {
 	client := ollama.New(srv.URL)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	addr, err := StartStatusServer(ctx, "127.0.0.1:0")
+	cfgFile := filepath.Join(t.TempDir(), "worker.yaml")
+	addr, err := StartStatusServer(ctx, "127.0.0.1:0", cfgFile, time.Second, cancel)
 	if err != nil {
 		t.Fatalf("start status server: %v", err)
 	}

--- a/internal/worker/status.go
+++ b/internal/worker/status.go
@@ -137,6 +137,21 @@ func StartDrain() {
 	SetState("draining")
 }
 
+func StopDrain() {
+	draining.Store(false)
+	stateMu.Lock()
+	if stateData.ConnectedToServer {
+		if stateData.CurrentJobs > 0 {
+			stateData.State = "connected_busy"
+		} else {
+			stateData.State = "connected_idle"
+		}
+	} else {
+		stateData.State = "disconnected"
+	}
+	stateMu.Unlock()
+}
+
 func IsDraining() bool {
 	return draining.Load()
 }

--- a/internal/worker/status_http.go
+++ b/internal/worker/status_http.go
@@ -2,17 +2,54 @@ package worker
 
 import (
 	"context"
+	"crypto/rand"
+	"encoding/hex"
 	"encoding/json"
 	"net"
 	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
 	"time"
 
 	"github.com/you/llamapool/internal/logx"
 )
 
-// StartStatusServer starts an HTTP server exposing /status and /version.
+// StartStatusServer starts an HTTP server exposing status, version, and control endpoints.
+// The token for control endpoints is stored alongside the config file.
 // It returns the address it is listening on.
-func StartStatusServer(ctx context.Context, addr string) (string, error) {
+func StartStatusServer(ctx context.Context, addr, configFile string, drainTimeout time.Duration, shutdown func()) (string, error) {
+	tokenPath := filepath.Join(filepath.Dir(defaultConfigPath(configFile)), "worker.token")
+	token, err := loadOrCreateToken(tokenPath)
+	if err != nil {
+		return "", err
+	}
+
+	var (
+		mu    sync.Mutex
+		timer *time.Timer
+	)
+
+	auth := func(h http.HandlerFunc) http.HandlerFunc {
+		return func(w http.ResponseWriter, r *http.Request) {
+			if r.Method != http.MethodPost {
+				w.WriteHeader(http.StatusMethodNotAllowed)
+				return
+			}
+			host, _, _ := net.SplitHostPort(r.RemoteAddr)
+			if ip := net.ParseIP(host); ip == nil || !ip.IsLoopback() {
+				w.WriteHeader(http.StatusForbidden)
+				return
+			}
+			if r.Header.Get("X-Auth-Token") != token {
+				w.WriteHeader(http.StatusUnauthorized)
+				return
+			}
+			h(w, r)
+		}
+	}
+
 	mux := http.NewServeMux()
 	mux.HandleFunc("/status", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
@@ -22,6 +59,40 @@ func StartStatusServer(ctx context.Context, addr string) (string, error) {
 		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(GetVersionInfo())
 	})
+	mux.HandleFunc("/control/drain", auth(func(w http.ResponseWriter, r *http.Request) {
+		StartDrain()
+		mu.Lock()
+		if timer != nil {
+			timer.Stop()
+		}
+		if drainTimeout > 0 {
+			timer = time.AfterFunc(drainTimeout, func() {
+				if IsDraining() {
+					SetState("terminating")
+					shutdown()
+				}
+			})
+		} else {
+			timer = nil
+		}
+		mu.Unlock()
+		w.WriteHeader(http.StatusOK)
+	}))
+	mux.HandleFunc("/control/undrain", auth(func(w http.ResponseWriter, r *http.Request) {
+		StopDrain()
+		mu.Lock()
+		if timer != nil {
+			timer.Stop()
+			timer = nil
+		}
+		mu.Unlock()
+		w.WriteHeader(http.StatusOK)
+	}))
+	mux.HandleFunc("/control/shutdown", auth(func(w http.ResponseWriter, r *http.Request) {
+		SetState("terminating")
+		shutdown()
+		w.WriteHeader(http.StatusOK)
+	}))
 
 	srv := &http.Server{Handler: mux}
 	ln, err := net.Listen("tcp", addr)
@@ -41,4 +112,33 @@ func StartStatusServer(ctx context.Context, addr string) (string, error) {
 		}
 	}()
 	return actual, nil
+}
+
+func defaultConfigPath(p string) string {
+	if strings.TrimSpace(p) == "" {
+		return "worker.yaml"
+	}
+	return p
+}
+
+func loadOrCreateToken(path string) (string, error) {
+	b, err := os.ReadFile(path)
+	if err == nil {
+		tok := strings.TrimSpace(string(b))
+		if tok != "" {
+			return tok, nil
+		}
+	}
+	buf := make([]byte, 32)
+	if _, err := rand.Read(buf); err != nil {
+		return "", err
+	}
+	tok := hex.EncodeToString(buf)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return "", err
+	}
+	if err := os.WriteFile(path, []byte(tok), 0o600); err != nil {
+		return "", err
+	}
+	return tok, nil
 }

--- a/internal/worker/status_http_test.go
+++ b/internal/worker/status_http_test.go
@@ -4,7 +4,11 @@ import (
 	"context"
 	"encoding/json"
 	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
+	"time"
 )
 
 func TestStatusHTTP(t *testing.T) {
@@ -13,7 +17,8 @@ func TestStatusHTTP(t *testing.T) {
 	SetWorkerInfo("id1", "worker", 2, []string{"m1"})
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	addr, err := StartStatusServer(ctx, "127.0.0.1:0")
+	cfgFile := filepath.Join(t.TempDir(), "worker.yaml")
+	addr, err := StartStatusServer(ctx, "127.0.0.1:0", cfgFile, time.Second, cancel)
 	if err != nil {
 		t.Fatalf("start server: %v", err)
 	}
@@ -42,5 +47,58 @@ func TestStatusHTTP(t *testing.T) {
 	}
 	if vi.Version != "v1" || vi.BuildSHA != "sha1" {
 		t.Fatalf("unexpected version info: %+v", vi)
+	}
+}
+
+func TestControlEndpoints(t *testing.T) {
+	resetState()
+	SetConnectedToServer(true)
+	SetState("connected_idle")
+	ctx, cancel := context.WithCancel(context.Background())
+	cfgFile := filepath.Join(t.TempDir(), "worker.yaml")
+	addr, err := StartStatusServer(ctx, "127.0.0.1:0", cfgFile, 100*time.Millisecond, cancel)
+	if err != nil {
+		t.Fatalf("start server: %v", err)
+	}
+	tokenBytes, err := os.ReadFile(filepath.Join(filepath.Dir(cfgFile), "worker.token"))
+	if err != nil {
+		t.Fatalf("read token: %v", err)
+	}
+	token := strings.TrimSpace(string(tokenBytes))
+
+	req, _ := http.NewRequest(http.MethodPost, "http://"+addr+"/control/drain", nil)
+	req.Header.Set("X-Auth-Token", token)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil || resp.StatusCode != http.StatusOK {
+		t.Fatalf("drain request failed: %v %v", err, resp.Status)
+	}
+	_ = resp.Body.Close()
+	if !IsDraining() {
+		t.Fatalf("expected draining")
+	}
+
+	req, _ = http.NewRequest(http.MethodPost, "http://"+addr+"/control/undrain", nil)
+	req.Header.Set("X-Auth-Token", token)
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil || resp.StatusCode != http.StatusOK {
+		t.Fatalf("undrain request failed: %v %v", err, resp.Status)
+	}
+	_ = resp.Body.Close()
+	if IsDraining() {
+		t.Fatalf("expected not draining")
+	}
+
+	req, _ = http.NewRequest(http.MethodPost, "http://"+addr+"/control/shutdown", nil)
+	req.Header.Set("X-Auth-Token", token)
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil || resp.StatusCode != http.StatusOK {
+		t.Fatalf("shutdown request failed: %v %v", err, resp.Status)
+	}
+	_ = resp.Body.Close()
+
+	select {
+	case <-ctx.Done():
+	case <-time.After(time.Second):
+		t.Fatalf("context not canceled")
 	}
 }


### PR DESCRIPTION
## Summary
- add token-protected drain/undrain/shutdown endpoints to worker status server
- store auth token next to worker config and expose loopback-only control
- document new local control API

## Testing
- `make lint`
- `make build`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_689e591abecc832cafab58bc2f77f601