### PR TITLE
worker: exit immediately when idle during drain

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,7 +277,8 @@ When started with `--status-addr <addr>`, the worker serves local endpoints:
 - `POST /control/undrain` resumes accepting jobs.
 - `POST /control/shutdown` drains and exits.
 
-Sending `SIGTERM` causes the worker to stop accepting new jobs and wait up to
+Sending `SIGTERM` causes the worker to stop accepting new jobs. If no work is in
+progress, the worker exits immediately; otherwise it waits up to
 `--drain-timeout` (default 1m) for in-flight work to finish before exiting.
 Send `SIGTERM` again to terminate immediately. Set `--drain-timeout=0` to exit
 without waiting or `--drain-timeout=-1` to wait indefinitely.

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -102,6 +102,9 @@ func Run(ctx context.Context, cfg config.WorkerConfig) error {
 			cancel()
 		}
 	}
+	setDrainCheck(checkDrain)
+	defer setDrainCheck(nil)
+	checkDrain()
 
 	for {
 		_, data, err := ws.Read(ctx)


### PR DESCRIPTION
## Summary
- exit worker as soon as draining with no active jobs
- document immediate exit on SIGTERM
- test idle drain shutdown

## Testing
- `make lint`
- `make build`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_689e74def160832cad3830066d48c998