### PR TITLE
Add macOS packaging and notarization scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,21 @@ A typical deployment looks like this:
 
 An early-stage macOS menu bar companion lives under `desktop/macos/llamapool/`. It polls `http://127.0.0.1:4555/status` every two seconds to display live worker status and can manage a per-user LaunchAgent to start or stop a local `llamapool-worker` and toggle launching at login. A simple preferences window lets you edit worker connection settings which are written to `~/Library/Application Support/Llamapool/worker.yaml`, and the menu offers quick links to open the config and logs folders, view live logs, copy diagnostics to the Desktop, and check for updates via Sparkle.
 
+### Packaging
+
+The macOS app can be distributed as a signed and notarized DMG. After building the `Llamapool` scheme in Release, create the disk image and submit it for notarization:
+
+```bash
+# Create a DMG with an /Applications symlink
+ci/create-dmg.sh path/to/Llamapool.app build/Llamapool.dmg
+
+# Notarize (requires AC_API_KEY_ID, AC_API_ISSUER_ID and AC_API_P8)
+ci/notarize.sh build/Llamapool.dmg
+xcrun stapler staple build/Llamapool.dmg
+```
+
+`AC_API_P8` must contain a base64-encoded App Store Connect API key. Once notarization completes, the DMG can be distributed and will pass Gatekeeper on clean systems.
+
 ## Windows Tray App
 
 A Windows tray companion lives under `desktop/windows/`. It polls `http://127.0.0.1:4555/status` every two seconds to display worker status.

--- a/ci/create-dmg.sh
+++ b/ci/create-dmg.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+set -euo pipefail
+
+if [ $# -ne 2 ]; then
+  echo "Usage: $0 <app-bundle> <dmg-path>" >&2
+  exit 1
+fi
+
+APP="$1"
+DMG="$2"
+VOL_NAME=$(basename "$APP" .app)
+
+TMP_DIR=$(mktemp -d)
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+cp -R "$APP" "$TMP_DIR"/
+ln -s /Applications "$TMP_DIR"/Applications
+
+hdiutil create -volname "$VOL_NAME" -srcfolder "$TMP_DIR" -ov -format UDZO "$DMG"

--- a/ci/notarize.sh
+++ b/ci/notarize.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+set -euo pipefail
+
+if [ $# -ne 1 ]; then
+  echo "Usage: $0 <dmg-path>" >&2
+  exit 1
+fi
+
+DMG="$1"
+
+# Ensure required environment variables are present
+: "${AC_API_KEY_ID:?Need AC_API_KEY_ID}"
+: "${AC_API_ISSUER_ID:?Need AC_API_ISSUER_ID}"
+: "${AC_API_P8:?Need AC_API_P8}"  # base64-encoded API key
+
+P8_FILE="$(mktemp)"
+# Decode the base64-encoded key into a temporary file
+printf '%s' "$AC_API_P8" | base64 --decode > "$P8_FILE"
+
+# Submit for notarization and wait for completion
+xcrun notarytool submit "$DMG" \
+  --key "$P8_FILE" \
+  --key-id "$AC_API_KEY_ID" \
+  --issuer "$AC_API_ISSUER_ID" \
+  --wait
+
+rm -f "$P8_FILE"


### PR DESCRIPTION
## Summary
- document how to package the macOS menu bar app as a signed and notarized DMG
- add helper scripts to create a DMG and submit it to Apple notarization

## Testing
- `make lint`
- `make build`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_689eb80e06d8832cbba2eb83b42e247e