### PR TITLE
Add Windows CI build and acceptance docs

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,0 +1,65 @@
+name: Windows Build
+on:
+  push:
+    branches: [ main ]
+  release:
+    types: [ published ]
+
+jobs:
+  build:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Compute version metadata
+        id: meta
+        shell: bash
+        run: |
+          SHA=$(git rev-parse --short HEAD)
+          DATE=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+          if [[ "${GITHUB_REF_TYPE}" == "tag" ]]; then
+            VERSION="${GITHUB_REF_NAME}"
+            DESCRIBE="${GITHUB_REF_NAME}"
+          else
+            DESCRIBE="$(git describe --tags --always --dirty)"
+            VERSION="${DESCRIBE}"
+          fi
+          echo "version=${VERSION}"   >> $GITHUB_OUTPUT
+          echo "describe=${DESCRIBE}" >> $GITHUB_OUTPUT
+          echo "sha=${SHA}"           >> $GITHUB_OUTPUT
+          echo "date=${DATE}"         >> $GITHUB_OUTPUT
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.23'
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '8.0.x'
+      - name: Build worker
+        run: |
+          go build -trimpath -o cmd/llamapool-worker/llamapool-worker.exe -ldflags "-s -w -X main.version=${{ steps.meta.outputs.version }} -X main.buildSHA=${{ steps.meta.outputs.sha }} -X main.buildDate=${{ steps.meta.outputs.date }}" ./cmd/llamapool-worker
+      - name: Build .NET projects
+        run: dotnet build desktop/windows/Llamapool.Windows.sln -c Release
+      - name: Install WiX
+        run: choco install wixtoolset --no-progress -y
+      - name: Build MSI
+        run: |
+          New-Item -ItemType Directory -Path build | Out-Null
+          candle.exe desktop/windows/Installer/Product.wxs -dWorkerExe="cmd\llamapool-worker\llamapool-worker.exe" -dServiceExe="desktop\windows\WindowsService\bin\Release\net8.0-windows\WindowsService.exe" -dTrayExe="desktop\windows\TrayApp\bin\Release\net8.0-windows\TrayApp.exe" -dDefaultConfig="desktop\windows\Installer\worker.yaml" -out build\
+          light.exe build\Product.wixobj -out build\llamapool.msi
+      - name: Code Sign (EXEs & MSI)
+        if: ${{ secrets.WIN_CODE_SIGN_PFX_B64 != '' }}
+        shell: cmd
+        env:
+          PFX_B64: ${{ secrets.WIN_CODE_SIGN_PFX_B64 }}
+          PFX_PASS: ${{ secrets.WIN_CODE_SIGN_PFX_PASS }}
+        run: |
+          echo %PFX_B64% > build\cert.b64
+          certutil -decode build\cert.b64 build\codesign.pfx
+          signtool sign /f build\codesign.pfx /p %PFX_PASS% /fd SHA256 /tr http://timestamp.digicert.com /td SHA256 desktop\windows\TrayApp\bin\Release\net8.0-windows\TrayApp.exe
+          signtool sign /f build\codesign.pfx /p %PFX_PASS% /fd SHA256 /tr http://timestamp.digicert.com /td SHA256 desktop\windows\WindowsService\bin\Release\net8.0-windows\WindowsService.exe
+          signtool sign /f build\codesign.pfx /p %PFX_PASS% /fd SHA256 /tr http://timestamp.digicert.com /td SHA256 cmd\llamapool-worker\llamapool-worker.exe
+          signtool sign /f build\codesign.pfx /p %PFX_PASS% /fd SHA256 /tr http://timestamp.digicert.com /td SHA256 build\llamapool.msi
+      - name: Upload Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: llamapool-Windows
+          path: build\llamapool.msi

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 [![Docker](https://github.com/gaspardpetit/llamapool/actions/workflows/docker-publish.yml/badge.svg)](https://github.com/gaspardpetit/llamapool/actions/workflows/docker-publish.yml)
 [![.deb](https://github.com/gaspardpetit/llamapool/actions/workflows/release-deb.yml/badge.svg)](https://github.com/gaspardpetit/llamapool/actions/workflows/release-deb.yml)
 [![macOS Build](https://github.com/gaspardpetit/llamapool/actions/workflows/macos.yml/badge.svg)](https://github.com/gaspardpetit/llamapool/actions/workflows/macos.yml)
+[![Windows Build](https://github.com/gaspardpetit/llamapool/actions/workflows/windows.yml/badge.svg)](https://github.com/gaspardpetit/llamapool/actions/workflows/windows.yml)
 
 
 # llamapool
@@ -428,6 +429,7 @@ The service wrapper launches `llamapool-worker.exe` installed at
 every two seconds and updates its menu and tooltip to reflect the current status.
 A details dialog shows connection information, job counts, and any last error. A preferences window can edit the worker configuration and write it back to the YAML file, and the menu offers quick links to open the config and logs folders, view live logs, and collect diagnostics.
 The tray app also supports automatic updates via Squirrel.Windows.
+For manual end-to-end verification on a clean VM, see [desktop/windows/ACCEPTANCE.md](desktop/windows/ACCEPTANCE.md).
 
 ## Currently Supported
 

--- a/desktop/windows/ACCEPTANCE.md
+++ b/desktop/windows/ACCEPTANCE.md
@@ -1,0 +1,14 @@
+# Windows Tray App Acceptance Test
+
+Use these steps to verify the signed MSI on a clean Windows VM.
+
+1. Install the generated `llamapool.msi`.
+2. Confirm the **llamapool** service is installed with *Delayed Auto Start* and running.
+3. Launch the tray app from the Start Menu and verify the tooltip shows `Connected Idle` when the worker is up.
+4. Send a request through the server; the tray should switch to `Busy` and then back to `Idle` once the job completes.
+5. Use **Start Worker** / **Stop Worker** from the tray to control the service and observe status changes.
+6. Open **Preferences...**, change a setting such as the status port, save, and restart the service when prompted; the tray should reconnect on the new port.
+7. Toggle **Start with Windows**, reboot, and confirm the service follows the selected mode.
+8. Choose **Logs...** and **Collect diagnostics** to verify log viewing and the zip output (config, logs, `sc qc llamapool`, `sc query llamapool`).
+
+Successful completion of the above steps validates the end-to-end Windows integration.


### PR DESCRIPTION
## Summary
- add Windows build workflow that compiles worker and tray, packages a signed MSI, and uploads the artifact
- document end-to-end Windows validation steps and link from README

## Testing
- `make lint`
- `make build`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_689ecd3e56ac832c8a4874518cbcc6f8