### PR TITLE
Fix server build and worker connect path

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ The tray can start or stop the local `llamapool` Windows service, toggle whether
   - Swagger UI: `GET /api/client/`
   - OpenAPI schema: `GET /api/client/openapi.json`
   - Update schema: edit `api/openapi.yaml` then run `make generate`
-- Web dashboard: `GET /status` (real-time view of workers)
+- Web dashboard: `GET /state` (real-time view of workers)
 
 
 ## Security
@@ -158,7 +158,7 @@ The tray can start or stop the local `llamapool` Windows service, toggle whether
   - per-worker totals (processed, inflight, failures, avg duration)
   - per-model availability (how many workers support each model)
   - versions/build info for server & workers
-- **Web status page** (`/status`): lightweight dashboard powered by the state stream
+- **Web state page** (`/state`): lightweight dashboard powered by the state stream
 - **Logs**:
   - `Info` — lifecycle details like connections, disconnections, draining, and job dispatch/completion.
   - `Warn` — expected failures such as missing models or no available workers.
@@ -218,6 +218,8 @@ PORT=8080 WORKER_KEY=secret API_KEY=test123 go run ./cmd/llamapool-server
 # or to expose metrics on a different port:
 # PORT=8080 METRICS_PORT=9090 WORKER_KEY=secret API_KEY=test123 go run ./cmd/llamapool-server
 ```
+
+Workers register with the server at `/api/workers/connect`.
 
 On Windows (CMD)
 
@@ -457,5 +459,5 @@ For manual end-to-end verification on a clean VM, see [desktop/windows/ACCEPTANC
 | Draining | ✅ | Workers can be configured to drain before exiting to avoid interrupting an ongoing request with `--drain-timeout` |
 | Linux Deamons | ✅ | Debian packages are provided to install the worker and server as daemons |
 | Desktop Trays | In Progress | Windows and macOS tray applications to launch, configure and monitor the worker |
-| Server dashboard | ✅ | `/status` HTML page visualizes workers via SSE |
+| Server dashboard | ✅ | `/state` HTML page visualizes workers via SSE |
 | Private MCP Endpoints | ✅ | Allow clients to expose an ephemeral MCP server through the `llamapool-mcp` relay |

--- a/api/generated/spec.gen.go
+++ b/api/generated/spec.gen.go
@@ -18,19 +18,18 @@ import (
 // Base64 encoded, gzipped, json marshaled Swagger object
 var swaggerSpec = []string{
 
-	"H4sIAAAAAAAC/+RXYU/bPBD+K9F9Ailv0768eoXyDRBiaJuGxMQXVE1ufDRmie3Zl46syn+fbKdp2kJL",
-	"BWia+ES4e86+57n4cTqHTJVaSZRkIZ2DxawygurrLMcSfegUmUFzUlHuAT4BKUx8GGKgWrv/cyINTdPE",
-	"IOSdclASVLhMUbCSaaWK6OTqEmKYobFCSUhhNBgOhtDEoDRKpgWkcDQYDo4gBs0o99snTItkihINI3QB",
-	"rSy5v0q7kFDykkMKV8rSiRYXC2AMBn9UaOlU8drBMyUJpa9kWhci87XJvXWdtLyYz3IuXIoVV8btQcLp",
-	"QKbCjqua3GNGga3bRhjkAeIDVitpg3j/DodvuTlHmxmhKci5IM+jRQ/gQLYqS2bqHiBa9OPSXmBiU9/v",
-	"FB/R9gKdtF8d5IX0dI/UHErFsfBPgrC0mwDJSj/ylrklI+QUVlW/Dajxhj5dgBnD6o2qdvPxM3T9JCxF",
-	"6i5qS1Y19cmQiQ6cjIdB1RxZQfmvbaJ+aCGvKqolRpXdrVqLew7/Lx/XOIfGoyzH7HtgOxslWc4ocW5S",
-	"oKuz28/qzegsZ3TWg7+DExsD4QMlOENJ/1gyyMrVxdZH9uQoWpuG9HbVoG/Hzbg/KSdy1BtKdKCNeqgP",
-	"u6lhOUHOhZzunNf5EvkezXVf5ZdybWi+9L2nnOFm9DlgXtUaOCO2xW0zg+7ycI93ypSMIAUh6f//lpe8",
-	"kIRTNM5cBX/khY0XAj6a+imRf5vUu71JcOhWiru+eivs7fae+vgNxtyz/7X5JnPBm+cM+ZL77x3DSiQ0",
-	"1m8pXC/uGwji9hYMoqweiHiLdYxf9dX5q9+Nl0/5AtshdzN21ydun+41LT5E/5RnhQ72ZmrRzNBEtqvu",
-	"CCfLS2sH7+sA3Mn+pRfiuSuN2tK9mIYO18n6FVwknMPKFO1vmzRJCpWxIleW0uPh8RCacfM7AAD//xCH",
-	"7M0/DQAA",
+	"H4sIAAAAAAAC/+RWX2vbOhT/KuY8teAbO7eXS/FbW8q9ZRsLBNqHEoYincZqbUmTTtJmwd99SHLitMnS",
+	"jLSDsSdh6ejo90c6PgvgujZaoSIHxQIc8qmVNB/yEmsMU+fILNqzKZUhICxAAeMwDSnQ3PjvkshA0zQp",
+	"SHWnfShJqvxKVbGaGa2r5GxwBSnM0DqpFRTQ7+W9HJoUtEHFjIQCTnp57wRSMIzKcHzGjMwcMUL/NUHy",
+	"gzZoGUmtrgQU8B/SmZHDEJOCRWe0chH833nuB64VoQpbmTGV5GFzdu88jJYUC6tCSL/EqoH1h5D0echO",
+	"cUVUj++RU6Qq0HErDUU6EYGfX8oIxe1zAW9HzSgFN61rZucReuLQztAmbrW7o5w5ssjqfZgPY+Sr/Amf",
+	"KMMZKvqrS94J0JJ0ZKWabCN56bcm7daf4hoR/oDuo7YPaF3GtVJe3t2Mb2L0RRv8gnQ/7/vhhTmPkngp",
+	"1SQZWE2a68pF+Ct8MWnSIkiObnA81PwB6TjCLJFVVH7bBe3/NuTAW2jW7t4CvFJTt80cf8zXqbQooLhd",
+	"xo32uKmfP7zgHoEnvET+ENnO+hkvGWW+PlTo9wUIRrst1Afa0XX/omR0sRYe4aGjcy3m7/kMOxV8SPML",
+	"a0B68HtaWrHvK/IiJ2umJEfG6qf58co1rMcohFSTV/267CL/AKsOVr6Ta0PzWgus3K7KcN3/FGPetDQI",
+	"RmFWEtZuc5lbZOS1XsCdtjUjKEAq+vef7rctFeEErf8JS7HlwqZLAbcuPSoUX8bz12uTFLDKlK5wrWXY",
+	"rFqrCWYtm29kDNRH72DzR+koaQ197m+2kKLZx+QrEToYy2oktC4cKT0W39VACoqFFiqI8vxBpDtKx+hN",
+	"r85vfTcOd9k3XsHVmCw2JdGpqa3afrbIskpzVpXaUXGan+bQjJrvAQAA//8HWlRXMwsAAA==",
 }
 
 // GetSwagger returns the content of the embedded swagger specification file

--- a/internal/api/embeddings.go
+++ b/internal/api/embeddings.go
@@ -56,7 +56,7 @@ func EmbeddingsHandler(reg *ctrl.Registry, sched ctrl.Scheduler) http.HandlerFun
 		worker.AddJob(reqID, ch)
 		defer func() {
 			worker.RemoveJob(reqID)
-			defer func() { recover() }()
+			_ = recover()
 			close(ch)
 		}()
 

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -47,7 +47,7 @@ func TestMetricsEndpointSeparatePort(t *testing.T) {
 	}
 }
 
-func TestStatusPage(t *testing.T) {
+func TestStatePage(t *testing.T) {
 	reg := ctrl.NewRegistry()
 	metricsReg := ctrl.NewMetricsRegistry("test", "", "")
 	sched := &ctrl.LeastBusyScheduler{Reg: reg}
@@ -56,9 +56,9 @@ func TestStatusPage(t *testing.T) {
 	ts := httptest.NewServer(h)
 	defer ts.Close()
 
-	resp, err := http.Get(ts.URL + "/status")
+	resp, err := http.Get(ts.URL + "/state")
 	if err != nil {
-		t.Fatalf("GET /status: %v", err)
+		t.Fatalf("GET /state: %v", err)
 	}
 	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("expected 200, got %d", resp.StatusCode)

--- a/internal/server/state.html
+++ b/internal/server/state.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<title>llamapool Status</title>
+<title>llamapool State</title>
 <style>
 :root {
   --bg: #fff;
@@ -56,7 +56,7 @@ h1 {
 </style>
 </head>
 <body>
-<h1>llamapool status</h1>
+<h1>llamapool state</h1>
 <div id="summary">Loading…</div>
 <div id="workers"></div>
 <script>

--- a/internal/server/state_page.go
+++ b/internal/server/state_page.go
@@ -5,13 +5,13 @@ import (
 	"net/http"
 )
 
-//go:embed status.html
-var statusHTML string
+//go:embed state.html
+var stateHTML string
 
-// StatusHandler serves the embedded status page.
-func StatusHandler() http.HandlerFunc {
+// StateHandler serves the embedded state page.
+func StateHandler() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "text/html; charset=utf-8")
-		_, _ = w.Write([]byte(statusHTML))
+		_, _ = w.Write([]byte(stateHTML))
 	}
 }

--- a/test/e2e_embeddings_proxy_test.go
+++ b/test/e2e_embeddings_proxy_test.go
@@ -21,7 +21,7 @@ import (
 func TestE2EEmbeddingsProxy(t *testing.T) {
 	reg := ctrl.NewRegistry()
 	sched := &ctrl.LeastBusyScheduler{Reg: reg}
-	cfg := config.ServerConfig{WorkerKey: "secret", APIKey: "apikey", WSPath: "/workers/connect", RequestTimeout: 5 * time.Second}
+	cfg := config.ServerConfig{WorkerKey: "secret", APIKey: "apikey", RequestTimeout: 5 * time.Second}
 	metricsReg := ctrl.NewMetricsRegistry("test", "", "")
 	handler := server.New(reg, metricsReg, sched, cfg)
 	srv := httptest.NewServer(handler)
@@ -52,7 +52,7 @@ func TestE2EEmbeddingsProxy(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	wsURL := strings.Replace(srv.URL, "http", "ws", 1) + "/workers/connect"
+	wsURL := strings.Replace(srv.URL, "http", "ws", 1) + "/api/workers/connect"
 	go func() {
 		_ = worker.Run(ctx, config.WorkerConfig{ServerURL: wsURL, WorkerKey: "secret", OllamaBaseURL: ollama.URL, OllamaAPIKey: "secret-123", WorkerID: "w1", WorkerName: "w1", MaxConcurrency: 2})
 	}()


### PR DESCRIPTION
## Summary
- remove leftover `WS_PATH`/`--ws-path` option
- fix worker registration to always use `/api/workers/connect`
- serve HTML state dashboard at `/state` with state APIs under `/api/state`

## Testing
- `make lint`
- `make build`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_689ee8b15e3c832cb4577c5cc2698676