### PR TITLE
Fix Sparkle updater API usage in macOS app

### DIFF
--- a/desktop/macos/llamapool/llamapool/AppDelegate.swift
+++ b/desktop/macos/llamapool/llamapool/AppDelegate.swift
@@ -74,7 +74,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         menu.addItem(NSMenuItem(title: "Quit", action: #selector(quit), keyEquivalent: "q"))
         statusItem.menu = menu
 
-        updaterController.checkForUpdatesInBackground()
+        updaterController.updater.checkForUpdatesInBackground()
 
         statusClient = StatusClient()
         statusClient?.onUpdate = { [weak self] result in
@@ -219,7 +219,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     @objc func checkForUpdates(_ sender: Any?) {
-        updaterController.checkForUpdates()
+        updaterController.checkForUpdates(sender)
     }
 
     @objc func quit(_ sender: Any?) {


### PR DESCRIPTION
## Summary
- use `updaterController.updater.checkForUpdatesInBackground()` to align with Sparkle 2.7 API
- pass sender parameter to `checkForUpdates` to avoid build error

## Testing
- `make lint`
- `make build`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_689f6f535348832ca13710ec4d5f63d8