### PR TITLE
Configure team ID for macOS GitHub Action

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -10,6 +10,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Build (Release)
+        env:
+          DEVELOPMENT_TEAM: ${{ secrets.AC_TEAM_ID }}
         run: |
           xcodebuild -project desktop/macos/llamapool/llamapool.xcodeproj -scheme llamapool -configuration Release -archivePath build/llamapool.xcarchive archive
           xcodebuild -exportArchive -archivePath build/llamapool.xcarchive -exportOptionsPlist ci/exportOptions.plist -exportPath build/export

--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ xcrun stapler staple build/Llamapool.dmg
 
 `AC_API_P8` must contain a base64-encoded App Store Connect API key. Once notarization completes, the DMG can be distributed and will pass Gatekeeper on clean systems.
 
+When using the GitHub Actions workflow, provide the `AC_TEAM_ID` secret with your Apple Developer Team ID so the archive can be signed and exported.
+
 ## Windows Tray App
 
 A Windows tray companion lives under `desktop/windows/`. It polls `http://127.0.0.1:4555/status` every two seconds to display worker status.


### PR DESCRIPTION
## Summary
- pass `AC_TEAM_ID` secret as `DEVELOPMENT_TEAM` to xcodebuild
- document the required `AC_TEAM_ID` secret for macOS builds

## Testing
- `make lint`
- `make build`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_689f82a7b9f0832cbb4c24fd692cf859