### PR TITLE
Prompt for access token on unauthorized state dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ The Windows service runs `llamapool-worker` with the `--reconnect` flag and shut
   - Swagger UI: `GET /api/client/`
   - OpenAPI schema: `GET /api/client/openapi.json`
   - Update schema: edit `api/openapi.yaml` then run `make generate`
-- Web dashboard: `GET /state` (real-time view of workers with names, status indicators and sortable columns)
+- Web dashboard: `GET /state` (real-time view of workers with names, status indicators and sortable columns; prompts for an access token on 401)
 
 
 ## Security

--- a/internal/server/state.html
+++ b/internal/server/state.html
@@ -96,6 +96,7 @@ h1 {
 <script>
 let workers = [];
 let sortBy = 'oldest';
+let token = null;
 
 function render() {
   const container = document.getElementById('workers');
@@ -172,15 +173,42 @@ document.getElementById('sort').addEventListener('change', (e) => {
   render();
 });
 
-const es = new EventSource('/api/state/stream');
-es.onmessage = (e) => {
+async function connect() {
+  const headers = token ? { 'Authorization': 'Bearer ' + token } : {};
   try {
-    const data = JSON.parse(e.data);
-    update(data);
+    const resp = await fetch('/api/state/stream', { headers });
+    if (resp.status === 401) {
+      token = prompt('Access token:');
+      if (token) connect();
+      return;
+    }
+    const reader = resp.body.getReader();
+    const decoder = new TextDecoder();
+    let buf = '';
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      buf += decoder.decode(value, { stream: true });
+      const lines = buf.split('\n');
+      buf = lines.pop();
+      lines.forEach(line => {
+        if (line.startsWith('data:')) {
+          try {
+            const data = JSON.parse(line.slice(5));
+            update(data);
+          } catch (err) {
+            console.error('parse', err);
+          }
+        }
+      });
+    }
   } catch (err) {
-    console.error('parse', err);
+    console.error('stream', err);
   }
-};
+  setTimeout(connect, 1000);
+}
+
+connect();
 </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Prompt user for an access token if the /state dashboard's stream returns 401
- Retry the stream using Authorization: Bearer <token>
- Document the dashboard's authentication prompt in README

## Testing
- `make lint`
- `make build`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68a29b04c814832ca05a52b26a6a24e8