### PR TITLE
docs: list server endpoints

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,5 +36,8 @@ requests to local Ollama instances. The repository contains two binaries:
   docker build -f deploy/Dockerfile.worker .
   ```
 
+## Documentation
+- Keep `docs/server-endpoints.md` current whenever HTTP or WebSocket endpoints change in any component.
+
 ## Further Reading
 - @README.md for project usage and examples

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ The Windows service runs `llamapool-worker` with the `--reconnect` flag and shut
   - Separate authentication keys for clients (`API_KEY`) and workers (`WORKER_KEY`).
   - Workers typically run behind firewalls and connect outbound over HTTPS/WSS.  
   - All traffic is encrypted end-to-end.
-- **Protocol compatibility** – Accepts and forwards OpenAI-style `POST /v1/chat/completions` and `POST /v1/embeddings` without altering JSON payloads.
+- **Protocol compatibility** – Canonical endpoints are `/api/v1/*`, but the server also accepts OpenAI-style `POST /v1/chat/completions` and `POST /v1/embeddings` without altering JSON payloads.
 
 ### How it works
 - The **server** accepts incoming HTTP requests from clients, authenticates them, and routes them to workers via WebSocket connections.
@@ -92,9 +92,9 @@ The Windows service runs `llamapool-worker` with the `--reconnect` flag and shut
 │                                                                       │
 │  ┌──────────────────────────┐                     ┌───────────────┐   │
 │  │  OpenAI-compatible API   │                     │  Observability│   │
-│  │  /v1/chat/completions    │                     │  /metrics     │   │
-│  │  /v1/embeddings          │                     └───────────────┘   │
-│  │  /v1/models (+/{id})     │                                         │
+│  │  /api/v1/chat/completions│                     │  /metrics     │   │
+│  │  /api/v1/embeddings      │                     └───────────────┘   │
+│  │  /api/v1/models (+/{id}) │                                         │
 │  └──────────────┬────────── ┘                                         │
 │                 │                                                     │
 │          ┌──────▼──────────────────────────────────────────────────┐  │
@@ -124,14 +124,14 @@ The Windows service runs `llamapool-worker` with the `--reconnect` flag and shut
 
 - Health: `GET /healthz`
 - OpenAI Models:
-  - `GET /v1/models`
-  - `GET /v1/models/{id}`
-- OpenAI Chat Completions: `POST /v1/chat/completions`
-- OpenAI Embeddings: `POST /v1/embeddings`
+  - `GET /api/v1/models` (also `/v1/models`)
+  - `GET /api/v1/models/{id}` (also `/v1/models/{id}`)
+- OpenAI Chat Completions: `POST /api/v1/chat/completions` (also `/v1/chat/completions`)
+- OpenAI Embeddings: `POST /api/v1/embeddings` (also `/v1/embeddings`)
 - llamapool API:
   - **State (JSON):** `GET /api/state`
   - **State (SSE):** `GET /api/state/stream`
-- Prometheus metrics: `GET /metrics` (can run on a separate port via `--metrics-port`)
+- Prometheus metrics: `GET /metrics` (serve on separate port via `METRICS_PORT` or `--metrics-port`)
 - API docs:
   - Swagger UI: `GET /api/client/`
   - OpenAPI schema: `GET /api/client/openapi.json`
@@ -141,7 +141,7 @@ The Windows service runs `llamapool-worker` with the `--reconnect` flag and shut
 
 ## Security
 
-- **Client authentication**: `API_KEY` required for `/api` and `/v1` routes via `Authorization: Bearer <API_KEY>`.
+- **Client authentication**: `API_KEY` required for `/api` routes (including `/api/v1`) and legacy `/v1` paths via `Authorization: Bearer <API_KEY>`.
 - **Worker authentication**: `WORKER_KEY` required for worker WebSocket registration.
 - **Transport**: run behind TLS (HTTPS/WSS) via reverse proxy or terminate TLS in-process.
 - **CORS**: cross-origin requests are denied unless explicitly allowed via `ALLOWED_ORIGINS` (comma separated) or the `--allowed-origins` flag.
@@ -152,7 +152,7 @@ The Windows service runs `llamapool-worker` with the `--reconnect` flag and shut
 
 ## Monitoring & Observability
 
-- **Prometheus** (`/metrics`, configurable port via `--metrics-port`):
+- **Prometheus** (`/metrics`, configurable port via `METRICS_PORT` or `--metrics-port`):
   - `llamapool_build_info{component="server",version,sha,date}`
   - `llamapool_model_requests_total{model,outcome}`
   - `llamapool_model_tokens_total{model,kind}`
@@ -340,7 +340,7 @@ without waiting or `--drain-timeout=-1` to wait indefinitely.
 The worker polls the local Ollama instance (default every 1m) so that
 `connected_to_ollama` and `models` stay current in the `/status` output.
 If the model list changes, the worker proactively notifies the server so
-`/v1/models` reflects the latest information. Configure the poll interval
+`/api/v1/models` reflects the latest information. Configure the poll interval
 with `MODEL_POLL_INTERVAL` or `--model-poll-interval`.
 
 Control endpoints require an `X-Auth-Token` header. The token is generated on
@@ -380,7 +380,7 @@ Ollama instance. If the model is missing, the server responds with `no worker`.
 On Linux:
 
 ```bash
-curl -N -X POST http://localhost:8080/v1/chat/completions \
+curl -N -X POST http://localhost:8080/api/v1/chat/completions \
   -H 'Content-Type: application/json' \
   -H 'Authorization: Bearer test123' \
   -d '{"model":"llama3","messages":[{"role":"user","content":"Hello"}],"stream":true}'
@@ -389,7 +389,7 @@ curl -N -X POST http://localhost:8080/v1/chat/completions \
 On Windows (CMD):
 
 ```
-curl -N -X POST "http://localhost:8080/v1/chat/completions" ^
+curl -N -X POST "http://localhost:8080/api/v1/chat/completions" ^
   -H "Content-Type: application/json" ^
   -H "Authorization: Bearer test123" ^
   -d "{ \"model\": \"llama3\", \"messages\": [ { \"role\": \"user\", \"content\": \"Hello\" } ], \"stream\": true }"
@@ -398,7 +398,7 @@ curl -N -X POST "http://localhost:8080/v1/chat/completions" ^
 On Windows (Powershell):
 
 ```
-curl -N -X POST http://localhost:8080/v1/chat/completions `
+curl -N -X POST http://localhost:8080/api/v1/chat/completions `
   -H "Content-Type: application/json" `
   -H "Authorization: Bearer test123" `
   -d '{ "model": "llama3", "messages": [ { "role": "user", "content": "Hello" } ], "stream": true }'
@@ -419,16 +419,18 @@ curl -H "Authorization: Bearer test123" http://localhost:8080/api/state
 curl -H "Authorization: Bearer test123" http://localhost:8080/api/state/stream
 # Prometheus metrics
 curl http://localhost:8080/metrics
-# or if `--metrics-port` is set:
+# or if `METRICS_PORT`/`--metrics-port` is set:
 curl http://localhost:9090/metrics
 ```
 
 The server also exposes OpenAI-style model listing endpoints:
 
 ```bash
-curl -H "Authorization: Bearer test123" http://localhost:8080/v1/models
-curl -H "Authorization: Bearer test123" http://localhost:8080/v1/models/llama3:8b
+curl -H "Authorization: Bearer test123" http://localhost:8080/api/v1/models
+curl -H "Authorization: Bearer test123" http://localhost:8080/api/v1/models/llama3:8b
 ```
+
+For a full list of server endpoints, see [docs/server-endpoints.md](docs/server-endpoints.md).
 
 ## Testing
 
@@ -465,16 +467,16 @@ For manual end-to-end verification on a clean VM, see [desktop/windows/ACCEPTANC
 
 | Feature | Supported | Notes |
 | --- | --- | --- |
-| OpenAI-compatible `POST /v1/chat/completions` | ✅ | Proxied to workers without payload mutation |
-| OpenAI-compatible `POST /v1/embeddings` | ✅ | Proxied to workers without payload mutation |
+| OpenAI-compatible `POST /api/v1/chat/completions` | ✅ | Proxied to workers without payload mutation (also `/v1/chat/completions`) |
+| OpenAI-compatible `POST /api/v1/embeddings` | ✅ | Proxied to workers without payload mutation (also `/v1/embeddings`) |
 | Multiple worker registration | ✅ | Workers can join/leave dynamically; models registered on connect |
 | Model-based routing (least-busy) | ✅ | `LeastBusyScheduler` selects worker by current load |
 | Model alias fallback | ✅ | Falls back to base model when exact quantization not available |
-| API key authentication for clients | ✅ | `Authorization: Bearer <API_KEY>` for `/api` and `/v1` routes |
+| API key authentication for clients | ✅ | `Authorization: Bearer <API_KEY>` for `/api` (including `/api/v1`) and `/v1` routes |
 | Worker key authentication | ✅ | Workers authenticate over WebSocket using `WORKER_KEY` |
 | Dynamic model discovery | ✅ | Workers advertise supported models; server aggregates |
 | HTTPS/WSS transport | ✅ | Use TLS terminator or run behind reverse proxy; WS path configurable |
-| Prometheus metrics endpoint | ✅ | `/metrics`; includes build info, per-model counters, histograms; supports separate `--metrics-port` |
+| Prometheus metrics endpoint | ✅ | `/metrics`; includes build info, per-model counters, histograms; supports `METRICS_PORT`/`--metrics-port` |
 | Real-time state API (JSON) | ✅ | `GET /api/state` returns full server/worker snapshot |
 | Real-time state stream (SSE) | ✅ | `GET /api/state/stream` for dashboards |
 | Token usage tracking | ✅ | Per-model and per-worker token totals (in/out) |

--- a/docs/server-endpoints.md
+++ b/docs/server-endpoints.md
@@ -1,0 +1,70 @@
+# Server Endpoints
+
+Endpoints are grouped by functional area.
+
+## System & Documentation
+
+| Verb & Endpoint | Parameters | Description | Auth |
+| --- | --- | --- | --- |
+| `GET /healthz` | – | Basic health check. | Public |
+| `GET /metrics` | – | Prometheus metrics (`METRICS_PORT` env or `--metrics-port` flag for separate port). | Public |
+| `GET /api/client/openapi.json` | – | OpenAPI schema. | Public |
+| `GET /api/client/*` | – | Swagger UI. | Public |
+
+## State API
+
+| Verb & Endpoint | Parameters | Description | Auth |
+| --- | --- | --- | --- |
+| `GET /state` | – | HTML status dashboard (prompts for API key). | API key |
+| `GET /api/state` | – | Server state snapshot (JSON). | API key |
+| `GET /api/state/stream` | – | Server state stream (SSE). | API key |
+
+## Inference API
+
+### `/api/v1` (preferred)
+
+| Verb & Endpoint | Parameters | Description | Auth |
+| --- | --- | --- | --- |
+| `POST /api/v1/chat/completions` | Body `{ model: string, messages: [{role: string, content: string}], stream?: bool, ... }` | Proxy OpenAI chat completions. | API key |
+| `POST /api/v1/embeddings` | Body `{ model: string, input: any, ... }` | Proxy OpenAI embeddings. | API key |
+| `GET /api/v1/models` | – | List models. | API key |
+| `GET /api/v1/models/{id}` | Path `{id}` | Get model details. | API key |
+
+### `/v1` (legacy)
+
+| Verb & Endpoint | Parameters | Description | Auth |
+| --- | --- | --- | --- |
+| `POST /v1/chat/completions` | Body `{ model: string, messages: [{role: string, content: string}], stream?: bool, ... }` | Legacy path for chat completions. | API key |
+| `POST /v1/embeddings` | Body `{ model: string, input: any, ... }` | Legacy path for embeddings. | API key |
+| `GET /v1/models` | – | Legacy path for list models. | API key |
+| `GET /v1/models/{id}` | Path `{id}` | Legacy path for model details. | API key |
+
+### Workers
+
+| Verb & Endpoint | Parameters | Description | Auth |
+| --- | --- | --- | --- |
+| `GET /api/workers/connect` (WS) | Initial message `{ type: "register", worker_key: string, worker_id?: string, worker_name?: string, models?: [string], max_concurrency?: int }` | Worker connects to server. | Worker key |
+
+## MCP Endpoints
+
+| Verb & Endpoint | Parameters | Description | Auth |
+| --- | --- | --- | --- |
+| `POST /api/mcp/id/{id}` | Path `{id}`; Body `{ jsonrpc: "2.0", id: number|string, method: string, params?: object }` | Forward MCP JSON-RPC request to relay. | MCP token |
+| `GET /api/mcp/connect` (WS) | Initial message `{ id: string }` | Register MCP relay over WebSocket. | MCP token |
+
+### Authentication schemes
+- **Public** – No authentication required.
+- **API key** – `Authorization: Bearer <API_KEY>`.
+- **Worker key** – WebSocket `register` message must include `worker_key` matching server configuration.
+- **MCP token** – Optional `Authorization: Bearer <AUTH_TOKEN>` forwarded to MCP relay; server does not validate.
+
+## Deprecated / Redundant Endpoints
+
+| Endpoint | Reason |
+| --- | --- |
+| `POST /v1/chat/completions` | Superseded by `/api/v1/chat/completions`. |
+| `POST /v1/embeddings` | Superseded by `/api/v1/embeddings`. |
+| `GET /v1/models` | Superseded by `/api/v1/models`. |
+| `GET /v1/models/{id}` | Superseded by `/api/v1/models/{id}`. |
+| `POST /mcp` | Early MCP streaming endpoint, replaced by `/api/mcp/id/{id}`. |
+| `GET /mcp` | Early MCP event stream (SSE), replaced by `/api/mcp/connect`. |


### PR DESCRIPTION
## Summary
- note `GET /metrics` can bind to a dedicated port via `METRICS_PORT`/`--metrics-port`
- move `/state` to State API table and mark API key requirement
- make `/api/v1` the canonical inference paths and flag legacy `/v1` and `/mcp` routes as deprecated
- remind contributors to keep `docs/server-endpoints.md` updated when endpoints change

## Testing
- `make lint`
- `make build`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68a67f643df8832ca1364bbfa5139fda