### PR TITLE
Improve MCP provider error reporting

### DIFF
--- a/cmd/infero-mcp/main.go
+++ b/cmd/infero-mcp/main.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+	"io"
 	"net/http"
 	"os"
 	"strings"
@@ -48,6 +49,11 @@ func probeProvider(ctx context.Context, url string) error {
 	}
 	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode >= http.StatusBadRequest {
+		b, _ := io.ReadAll(resp.Body)
+		msg := strings.TrimSpace(string(b))
+		if msg != "" {
+			return fmt.Errorf("status %s: %s", resp.Status, msg)
+		}
 		return fmt.Errorf("status %s", resp.Status)
 	}
 	return nil

--- a/cmd/infero-mcp/main_test.go
+++ b/cmd/infero-mcp/main_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 )
 
@@ -20,5 +21,18 @@ func TestProbeProviderSetsAcceptHeader(t *testing.T) {
 
 	if err := probeProvider(context.Background(), srv.URL); err != nil {
 		t.Fatalf("probeProvider returned error: %v", err)
+	}
+}
+
+func TestProbeProviderReturnsBodyOnError(t *testing.T) {
+	msg := "nope"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotAcceptable)
+		_, _ = w.Write([]byte(msg))
+	}))
+	defer srv.Close()
+	err := probeProvider(context.Background(), srv.URL)
+	if err == nil || !strings.Contains(err.Error(), msg) {
+		t.Fatalf("expected error containing %q got %v", msg, err)
 	}
 }

--- a/internal/mcp/relay.go
+++ b/internal/mcp/relay.go
@@ -144,16 +144,20 @@ func (r *RelayClient) callProvider(ctx context.Context, payload []byte) ([]byte,
 		return nil, err
 	}
 	if resp.StatusCode != http.StatusOK {
+		data := map[string]any{
+			"mcp":    "MCP_UPSTREAM_ERROR",
+			"status": resp.StatusCode,
+		}
+		if len(body) > 0 {
+			data["body"] = string(body)
+		}
 		errObj := map[string]any{
 			"jsonrpc": "2.0",
 			"id":      env.ID,
 			"error": map[string]any{
 				"code":    -32000,
 				"message": "Provider error",
-				"data": map[string]any{
-					"mcp":    "MCP_UPSTREAM_ERROR",
-					"status": resp.StatusCode,
-				},
+				"data":    data,
 			},
 		}
 		b, _ := json.Marshal(errObj)

--- a/internal/mcp/relay_test.go
+++ b/internal/mcp/relay_test.go
@@ -25,7 +25,8 @@ func TestCallProviderNon200(t *testing.T) {
 	var msg struct {
 		Error struct {
 			Data struct {
-				MCP string `json:"mcp"`
+				MCP  string `json:"mcp"`
+				Body string `json:"body"`
 			} `json:"data"`
 		} `json:"error"`
 	}
@@ -34,5 +35,8 @@ func TestCallProviderNon200(t *testing.T) {
 	}
 	if msg.Error.Data.MCP != "MCP_UPSTREAM_ERROR" {
 		t.Fatalf("expected MCP_UPSTREAM_ERROR got %s", msg.Error.Data.MCP)
+	}
+	if msg.Error.Data.Body != "boom" {
+		t.Fatalf("expected body 'boom' got %q", msg.Error.Data.Body)
 	}
 }


### PR DESCRIPTION
## Summary
- include MCP provider response body in probe errors
- forward non-200 provider responses through relay
- add tests for provider error propagation

## Testing
- `make lint`
- `make build`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68a94c7da1dc832c8d8b03bcec10338b