### PR TITLE
Improve MCP provider error reporting

### DIFF
--- a/cmd/infero-mcp/main.go
+++ b/cmd/infero-mcp/main.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+	"io"
 	"net/http"
 	"os"
 	"strings"
@@ -26,6 +27,7 @@ var (
 )
 
 func probeProvider(ctx context.Context, url string) error {
+	logx.Log.Debug().Str("url", url).Msg("probing mcp provider")
 	payload := map[string]any{
 		"jsonrpc": "2.0",
 		"id":      "1",
@@ -47,7 +49,13 @@ func probeProvider(ctx context.Context, url string) error {
 		return err
 	}
 	defer func() { _ = resp.Body.Close() }()
+	logx.Log.Debug().Str("status", resp.Status).Msg("probe response")
 	if resp.StatusCode >= http.StatusBadRequest {
+		b, _ := io.ReadAll(resp.Body)
+		msg := strings.TrimSpace(string(b))
+		if msg != "" {
+			return fmt.Errorf("status %s: %s", resp.Status, msg)
+		}
 		return fmt.Errorf("status %s", resp.Status)
 	}
 	return nil
@@ -56,6 +64,7 @@ func probeProvider(ctx context.Context, url string) error {
 func monitorProvider(ctx context.Context, url string, shouldReconnect bool) {
 	attempt := 0
 	for {
+		logx.Log.Debug().Int("attempt", attempt).Str("url", url).Msg("checking mcp provider")
 		err := probeProvider(ctx, url)
 		if err != nil {
 			lvl := logx.Log.Warn()

--- a/cmd/infero-mcp/main_test.go
+++ b/cmd/infero-mcp/main_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 )
 
@@ -20,5 +21,18 @@ func TestProbeProviderSetsAcceptHeader(t *testing.T) {
 
 	if err := probeProvider(context.Background(), srv.URL); err != nil {
 		t.Fatalf("probeProvider returned error: %v", err)
+	}
+}
+
+func TestProbeProviderReturnsBodyOnError(t *testing.T) {
+	msg := "nope"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotAcceptable)
+		_, _ = w.Write([]byte(msg))
+	}))
+	defer srv.Close()
+	err := probeProvider(context.Background(), srv.URL)
+	if err == nil || !strings.Contains(err.Error(), msg) {
+		t.Fatalf("expected error containing %q got %v", msg, err)
 	}
 }

--- a/doc/env.md
+++ b/doc/env.md
@@ -1,12 +1,13 @@
 # Configuration reference
 
-This document lists configuration options for the infero tools. Settings can be supplied via environment variables, command line flags, or configuration files. Sample config templates with defaults live under `examples/config/`. `DEBUG` affects logging across all binaries.
+This document lists configuration options for the infero tools. Settings can be supplied via environment variables, command line flags, or configuration files. Sample config templates with defaults live under `examples/config/`. Logging is controlled globally via `DEBUG` or `LOG_LEVEL`.
 
 ## Common
 
 | Variable | Config key | Purpose | Default | CLI flag |
 |----------|------------|---------|---------|----------|
 | `DEBUG` | — | enable verbose logging | info level when unset | — |
+| `LOG_LEVEL` | — | set logging verbosity (`trace`, `debug`, `info`, `warn`, `error`) | `info` | — |
 
 ## infero
 

--- a/internal/logx/log.go
+++ b/internal/logx/log.go
@@ -11,13 +11,29 @@ import (
 // Log is the shared logger used throughout the project.
 var Log = log.Logger
 
-func init() {
-	if strings.ToLower(os.Getenv("DEBUG")) == "true" {
-		zerolog.SetGlobalLevel(zerolog.DebugLevel)
-	} else {
-		zerolog.SetGlobalLevel(zerolog.InfoLevel)
+// Configure sets the global log level based on environment variables.
+// LOG_LEVEL takes precedence and accepts zerolog levels (trace, debug, info,
+// warn, error, fatal, panic). When unset, DEBUG=true maps to debug level,
+// otherwise info is used. Invalid values fall back to info.
+func Configure() {
+	lvlStr := strings.ToLower(os.Getenv("LOG_LEVEL"))
+	if lvlStr == "" {
+		if strings.ToLower(os.Getenv("DEBUG")) == "true" {
+			lvlStr = "debug"
+		} else {
+			lvlStr = "info"
+		}
 	}
+	lvl, err := zerolog.ParseLevel(lvlStr)
+	if err != nil {
+		lvl = zerolog.InfoLevel
+	}
+	zerolog.SetGlobalLevel(lvl)
 
 	// Optional: make logs human-readable in dev
 	Log = log.Output(zerolog.ConsoleWriter{Out: os.Stderr})
+}
+
+func init() {
+	Configure()
 }

--- a/internal/logx/log_test.go
+++ b/internal/logx/log_test.go
@@ -1,0 +1,31 @@
+package logx_test
+
+import (
+	"testing"
+
+	"github.com/gaspardpetit/infero/internal/logx"
+	"github.com/rs/zerolog"
+)
+
+func TestConfigureLogLevel(t *testing.T) {
+	t.Setenv("LOG_LEVEL", "trace")
+	t.Setenv("DEBUG", "")
+	logx.Configure()
+	if zerolog.GlobalLevel() != zerolog.TraceLevel {
+		t.Fatalf("expected trace level, got %s", zerolog.GlobalLevel())
+	}
+
+	t.Setenv("LOG_LEVEL", "")
+	t.Setenv("DEBUG", "true")
+	logx.Configure()
+	if zerolog.GlobalLevel() != zerolog.DebugLevel {
+		t.Fatalf("expected debug level, got %s", zerolog.GlobalLevel())
+	}
+
+	t.Setenv("LOG_LEVEL", "bogus")
+	t.Setenv("DEBUG", "")
+	logx.Configure()
+	if zerolog.GlobalLevel() != zerolog.InfoLevel {
+		t.Fatalf("expected info level, got %s", zerolog.GlobalLevel())
+	}
+}

--- a/internal/mcp/relay.go
+++ b/internal/mcp/relay.go
@@ -144,16 +144,20 @@ func (r *RelayClient) callProvider(ctx context.Context, payload []byte) ([]byte,
 		return nil, err
 	}
 	if resp.StatusCode != http.StatusOK {
+		data := map[string]any{
+			"mcp":    "MCP_UPSTREAM_ERROR",
+			"status": resp.StatusCode,
+		}
+		if len(body) > 0 {
+			data["body"] = string(body)
+		}
 		errObj := map[string]any{
 			"jsonrpc": "2.0",
 			"id":      env.ID,
 			"error": map[string]any{
 				"code":    -32000,
 				"message": "Provider error",
-				"data": map[string]any{
-					"mcp":    "MCP_UPSTREAM_ERROR",
-					"status": resp.StatusCode,
-				},
+				"data":    data,
 			},
 		}
 		b, _ := json.Marshal(errObj)

--- a/internal/mcp/relay_test.go
+++ b/internal/mcp/relay_test.go
@@ -25,7 +25,8 @@ func TestCallProviderNon200(t *testing.T) {
 	var msg struct {
 		Error struct {
 			Data struct {
-				MCP string `json:"mcp"`
+				MCP  string `json:"mcp"`
+				Body string `json:"body"`
 			} `json:"data"`
 		} `json:"error"`
 	}
@@ -34,5 +35,8 @@ func TestCallProviderNon200(t *testing.T) {
 	}
 	if msg.Error.Data.MCP != "MCP_UPSTREAM_ERROR" {
 		t.Fatalf("expected MCP_UPSTREAM_ERROR got %s", msg.Error.Data.MCP)
+	}
+	if msg.Error.Data.Body != "boom" {
+		t.Fatalf("expected body 'boom' got %q", msg.Error.Data.Body)
 	}
 }


### PR DESCRIPTION
## Summary
- include MCP provider response body in probe errors
- forward non-200 provider responses through relay
- add tests for provider error propagation
- add `LOG_LEVEL` env var and debug provider probe logs

## Testing
- `make lint`
- `make build`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68a94c7da1dc832c8d8b03bcec10338b