### PR TITLE
feat: consolidate log level and trace HTTP traffic

### DIFF
--- a/cmd/infero-llm/main.go
+++ b/cmd/infero-llm/main.go
@@ -50,6 +50,7 @@ func main() {
 			logx.Log.Fatal().Err(err).Str("path", cfg.ConfigFile).Msg("load config")
 		}
 	}
+	logx.Configure(cfg.LogLevel)
 
 	worker.SetBuildInfo(version, buildSHA, buildDate)
 

--- a/cmd/infero-mcp/main.go
+++ b/cmd/infero-mcp/main.go
@@ -108,6 +108,7 @@ func main() {
 			logx.Log.Fatal().Err(err).Str("path", cfg.ConfigFile).Msg("load config")
 		}
 	}
+	logx.Configure(cfg.LogLevel)
 
 	header := http.Header{}
 	reconnectFlag := cfg.Reconnect

--- a/cmd/infero/main.go
+++ b/cmd/infero/main.go
@@ -58,6 +58,7 @@ func main() {
 			logx.Log.Fatal().Err(err).Str("path", cfg.ConfigFile).Msg("load config")
 		}
 	}
+	logx.Configure(cfg.LogLevel)
 
 	reg := ctrl.NewRegistry()
 	metricsReg := ctrl.NewMetricsRegistry(version, buildSHA, buildDate)

--- a/doc/env.md
+++ b/doc/env.md
@@ -1,13 +1,12 @@
 # Configuration reference
 
-This document lists configuration options for the infero tools. Settings can be supplied via environment variables, command line flags, or configuration files. Sample config templates with defaults live under `examples/config/`. Logging is controlled globally via `DEBUG` or `LOG_LEVEL`.
+This document lists configuration options for the infero tools. Settings can be supplied via environment variables, command line flags, or configuration files. Sample config templates with defaults live under `examples/config/`. Logging is controlled globally via `LOG_LEVEL`.
 
 ## Common
 
 | Variable | Config key | Purpose | Default | CLI flag |
 |----------|------------|---------|---------|----------|
-| `DEBUG` | — | enable verbose logging | info level when unset | — |
-| `LOG_LEVEL` | — | set logging verbosity (`trace`, `debug`, `info`, `warn`, `error`) | `info` | — |
+| `LOG_LEVEL` | `log_level` | set logging verbosity (`all`, `debug`, `info`, `warn`, `error`, `fatal`, `none`) | `info` | `--log-level` |
 
 ## infero
 

--- a/examples/config/mcp.yaml
+++ b/examples/config/mcp.yaml
@@ -1,5 +1,6 @@
 # Example configuration for infero-mcp
 server_url: ws://localhost:8080/api/mcp/connect
+# log_level: info             # logging verbosity (all, debug, info, warn, error, fatal, none)
 # client_key: ""              # shared secret for authenticating with the server
 # client_id: ""               # client identifier; assigned when empty
 # client_name: ""             # client display name shown in logs

--- a/examples/config/server.yaml
+++ b/examples/config/server.yaml
@@ -1,6 +1,7 @@
 # Example configuration for infero
 port: 8080                    # HTTP listen port for the public API
 metrics_addr: ":8080"        # Prometheus metrics listen address
+# log_level: info             # logging verbosity (all, debug, info, warn, error, fatal, none)
 # api_key: ""                # client API key required for HTTP requests
 # client_key: ""             # shared key clients must present when registering
 request_timeout: 120s         # request timeout without worker activity

--- a/examples/config/worker.yaml
+++ b/examples/config/worker.yaml
@@ -1,5 +1,6 @@
 # Example configuration for infero-llm
 server_url: ws://localhost:8080/api/workers/connect
+# log_level: info             # logging verbosity (all, debug, info, warn, error, fatal, none)
 # client_key: ""              # shared secret for authenticating with the server
 completion_base_url: http://127.0.0.1:11434/v1
 # completion_api_key: ""      # API key for the completion API

--- a/internal/api/middleware.go
+++ b/internal/api/middleware.go
@@ -1,13 +1,56 @@
 package api
 
 import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"io"
+	"net"
 	"net/http"
 	"strings"
 
 	chiMiddleware "github.com/go-chi/chi/v5/middleware"
+	"github.com/rs/zerolog"
 
 	"github.com/gaspardpetit/infero/internal/logx"
 )
+
+type loggingResponseWriter struct {
+	http.ResponseWriter
+	status int
+}
+
+func (lw *loggingResponseWriter) WriteHeader(status int) {
+	lw.status = status
+	lw.ResponseWriter.WriteHeader(status)
+}
+
+func (lw *loggingResponseWriter) Write(b []byte) (int, error) {
+	if zerolog.GlobalLevel() <= zerolog.DebugLevel {
+		logx.Log.Debug().Bytes("body", b).Msg("http response chunk")
+	}
+	return lw.ResponseWriter.Write(b)
+}
+
+func (lw *loggingResponseWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	if h, ok := lw.ResponseWriter.(http.Hijacker); ok {
+		return h.Hijack()
+	}
+	return nil, nil, fmt.Errorf("hijacker not supported")
+}
+
+func (lw *loggingResponseWriter) Flush() {
+	if f, ok := lw.ResponseWriter.(http.Flusher); ok {
+		f.Flush()
+	}
+}
+
+func (lw *loggingResponseWriter) Push(target string, opts *http.PushOptions) error {
+	if p, ok := lw.ResponseWriter.(http.Pusher); ok {
+		return p.Push(target, opts)
+	}
+	return http.ErrNotSupported
+}
 
 func MiddlewareChain() []func(http.Handler) http.Handler {
 	return []func(http.Handler) http.Handler{
@@ -18,9 +61,22 @@ func MiddlewareChain() []func(http.Handler) http.Handler {
 
 func requestLogger(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		reqID := chiMiddleware.GetReqID(r.Context())
-		logx.Log.Info().Str("request_id", reqID).Str("method", r.Method).Str("path", r.URL.Path).Msg("request")
-		next.ServeHTTP(w, r)
+		lvl := zerolog.GlobalLevel()
+		lrw := &loggingResponseWriter{ResponseWriter: w, status: http.StatusOK}
+		if lvl <= zerolog.DebugLevel {
+			var body []byte
+			if r.Body != nil {
+				body, _ = io.ReadAll(r.Body)
+				r.Body = io.NopCloser(bytes.NewReader(body))
+			}
+			logx.Log.Debug().Str("method", r.Method).Str("url", r.URL.String()).Interface("headers", r.Header).Bytes("body", body).Msg("http request")
+		}
+		next.ServeHTTP(lrw, r)
+		if lvl <= zerolog.DebugLevel {
+			logx.Log.Debug().Str("url", r.URL.String()).Int("status", lrw.status).Interface("headers", lrw.Header()).Msg("http response")
+		} else if lvl <= zerolog.InfoLevel {
+			logx.Log.Info().Str("url", r.URL.String()).Int("status", lrw.status).Msg("http")
+		}
 	})
 }
 

--- a/internal/config/mcp.go
+++ b/internal/config/mcp.go
@@ -23,6 +23,7 @@ type MCPConfig struct {
 	RequestTimeout time.Duration
 	Reconnect      bool
 	ConfigFile     string
+	LogLevel       string
 }
 
 // BindFlags populates the struct with defaults from environment variables and
@@ -30,6 +31,7 @@ type MCPConfig struct {
 func (c *MCPConfig) BindFlags() {
 	cfgPath := DefaultConfigPath("mcp.yaml")
 	c.ConfigFile = getEnv("CONFIG_FILE", cfgPath)
+	c.LogLevel = getEnv("LOG_LEVEL", "info")
 
 	c.ServerURL = getEnv("SERVER_URL", "ws://localhost:8080/api/mcp/connect")
 	c.ClientKey = getEnv("CLIENT_KEY", "")
@@ -56,6 +58,7 @@ func (c *MCPConfig) BindFlags() {
 	}
 
 	flag.StringVar(&c.ConfigFile, "config", c.ConfigFile, "mcp config file path")
+	flag.StringVar(&c.LogLevel, "log-level", c.LogLevel, "log verbosity (all, debug, info, warn, error, fatal, none)")
 	flag.StringVar(&c.ServerURL, "server-url", c.ServerURL, "broker WebSocket URL (e.g. ws://localhost:8080/api/mcp/connect)")
 	flag.StringVar(&c.ClientKey, "client-key", c.ClientKey, "shared secret for authenticating with the server")
 	flag.StringVar(&c.ProviderURL, "provider-url", c.ProviderURL, "MCP provider URL")

--- a/internal/config/server.go
+++ b/internal/config/server.go
@@ -21,6 +21,7 @@ type ServerConfig struct {
 	DrainTimeout   time.Duration
 	AllowedOrigins []string
 	ConfigFile     string
+	LogLevel       string
 }
 
 // BindFlags populates the struct with defaults from environment variables and
@@ -28,6 +29,7 @@ type ServerConfig struct {
 func (c *ServerConfig) BindFlags() {
 	cfgPath := DefaultConfigPath("server.yaml")
 	c.ConfigFile = getEnv("CONFIG_FILE", cfgPath)
+	c.LogLevel = getEnv("LOG_LEVEL", "info")
 
 	port, _ := strconv.Atoi(getEnv("PORT", "8080"))
 	c.Port = port
@@ -54,6 +56,7 @@ func (c *ServerConfig) BindFlags() {
 	c.AllowedOrigins = splitComma(getEnv("ALLOWED_ORIGINS", strings.Join(c.AllowedOrigins, ",")))
 
 	flag.StringVar(&c.ConfigFile, "config", c.ConfigFile, "server config file path")
+	flag.StringVar(&c.LogLevel, "log-level", c.LogLevel, "log verbosity (all, debug, info, warn, error, fatal, none)")
 	flag.IntVar(&c.Port, "port", c.Port, "HTTP listen port for the public API")
 	flag.StringVar(&c.MetricsAddr, "metrics-port", c.MetricsAddr, "Prometheus metrics listen address or port; defaults to the value of --port")
 	flag.StringVar(&c.APIKey, "api-key", c.APIKey, "client API key required for HTTP requests; leave empty to disable auth")

--- a/internal/config/worker.go
+++ b/internal/config/worker.go
@@ -30,12 +30,14 @@ type WorkerConfig struct {
 	LogDir            string
 	Reconnect         bool
 	RequestTimeout    time.Duration
+	LogLevel          string
 }
 
 func (c *WorkerConfig) BindFlags() {
 	cfgPath, logDir := defaultWorkerPaths()
 	c.ConfigFile = getEnv("CONFIG_FILE", cfgPath)
 	c.LogDir = getEnv("LOG_DIR", logDir)
+	c.LogLevel = getEnv("LOG_LEVEL", "info")
 
 	c.ServerURL = getEnv("SERVER_URL", "ws://localhost:8080/api/workers/connect")
 	c.ClientKey = getEnv("CLIENT_KEY", "")
@@ -91,6 +93,7 @@ func (c *WorkerConfig) BindFlags() {
 	flag.StringVar(&c.MetricsAddr, "metrics-port", c.MetricsAddr, "Prometheus metrics listen address or port (disabled when empty; e.g. 127.0.0.1:9090 or 9090)")
 	flag.StringVar(&c.ConfigFile, "config", c.ConfigFile, "worker config file path")
 	flag.StringVar(&c.LogDir, "log-dir", c.LogDir, "directory for worker log files")
+	flag.StringVar(&c.LogLevel, "log-level", c.LogLevel, "log verbosity (all, debug, info, warn, error, fatal, none)")
 	flag.DurationVar(&c.DrainTimeout, "drain-timeout", c.DrainTimeout, "time to wait for in-flight jobs on shutdown (-1 to wait indefinitely, 0 to exit immediately)")
 	flag.DurationVar(&c.ModelPollInterval, "model-poll-interval", c.ModelPollInterval, "interval for polling backend for model changes")
 	flag.Func("request-timeout", "request timeout in seconds without backend feedback", func(v string) error {

--- a/internal/logx/log_test.go
+++ b/internal/logx/log_test.go
@@ -8,23 +8,22 @@ import (
 )
 
 func TestConfigureLogLevel(t *testing.T) {
-	t.Setenv("LOG_LEVEL", "trace")
-	t.Setenv("DEBUG", "")
-	logx.Configure()
+	logx.Configure("all")
 	if zerolog.GlobalLevel() != zerolog.TraceLevel {
 		t.Fatalf("expected trace level, got %s", zerolog.GlobalLevel())
 	}
 
-	t.Setenv("LOG_LEVEL", "")
-	t.Setenv("DEBUG", "true")
-	logx.Configure()
-	if zerolog.GlobalLevel() != zerolog.DebugLevel {
-		t.Fatalf("expected debug level, got %s", zerolog.GlobalLevel())
+	logx.Configure("WARNING")
+	if zerolog.GlobalLevel() != zerolog.WarnLevel {
+		t.Fatalf("expected warn level, got %s", zerolog.GlobalLevel())
 	}
 
-	t.Setenv("LOG_LEVEL", "bogus")
-	t.Setenv("DEBUG", "")
-	logx.Configure()
+	logx.Configure("none")
+	if zerolog.GlobalLevel() != zerolog.Disabled {
+		t.Fatalf("expected disabled level, got %s", zerolog.GlobalLevel())
+	}
+
+	logx.Configure("bogus")
 	if zerolog.GlobalLevel() != zerolog.InfoLevel {
 		t.Fatalf("expected info level, got %s", zerolog.GlobalLevel())
 	}


### PR DESCRIPTION
## Summary
- add unified `LOG_LEVEL` setting with `--log-level` flag and config support across all binaries
- trace HTTP requests and streaming responses when debug logging is enabled
- log minimal request info (URL and status) at info level

## Testing
- `make lint`
- `make build`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68a95c11d578832caa13d63477de92f9