### PR TITLE
feat: add redis-backed server state

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ By default the MCP relay exits if the server is unavailable. Add `-r` or `--reco
 `infero-mcp` reads configuration from a YAML file when `CONFIG_FILE` is set. Values in the file—such as transport order, protocol version preference, or stdio working directory—are used as defaults and can be overridden by environment variables or CLI flags (e.g. `--mcp-http-url`, `--mcp-stdio-workdir`).
 
 For transport configuration, common errors, and developer guidance see [doc/mcpclient.md](doc/mcpclient.md). For a comprehensive list of configuration options, see [doc/env.md](doc/env.md). Sample YAML configuration templates with defaults are available under `examples/config/`.
+Server state can be shared across multiple infero instances by setting `REDIS_ADDR` to a Redis connection URL (including Sentinel or cluster deployments).
 For project direction and future enhancements, see [doc/roadmap.md](doc/roadmap.md).
 
 A typical deployment looks like this:

--- a/cmd/infero/main.go
+++ b/cmd/infero/main.go
@@ -60,6 +60,15 @@ func main() {
 	}
 	logx.Configure(cfg.LogLevel)
 
+	if cfg.RedisAddr != "" {
+		rs, err := serverstate.NewRedisStore(cfg.RedisAddr)
+		if err != nil {
+			logx.Log.Fatal().Err(err).Msg("connect redis")
+		}
+		serverstate.UseStore(rs)
+		logx.Log.Info().Str("addr", cfg.RedisAddr).Msg("using redis state store")
+	}
+
 	reg := ctrl.NewRegistry()
 	metricsReg := ctrl.NewMetricsRegistry(version, buildSHA, buildDate)
 	metrics.Register(prometheus.DefaultRegisterer)

--- a/doc/env.md
+++ b/doc/env.md
@@ -26,6 +26,7 @@ The server optionally reads settings from a YAML config file. Defaults:
 | `REQUEST_TIMEOUT` | — | seconds without worker or MCP activity before timing out a request | `120` | `--request-timeout` |
 | `DRAIN_TIMEOUT` | — | time to wait for in-flight requests on shutdown | `5m` | `--drain-timeout` |
 | `ALLOWED_ORIGINS` | — | comma separated list of allowed CORS origins | unset (deny all) | `--allowed-origins` |
+| `REDIS_ADDR` | `redis_addr` | Redis connection URL for server state (e.g. `redis://:pass@host:6379/0`, `redis-sentinel://host:26379/mymaster`) | unset | `--redis-addr` |
 | `BROKER_MAX_REQ_BYTES` | — | maximum MCP request size in bytes | `10485760` | — |
 | `BROKER_MAX_RESP_BYTES` | — | maximum MCP response size in bytes | `10485760` | — |
 | `BROKER_WS_HEARTBEAT_MS` | — | MCP WebSocket heartbeat interval in milliseconds | `15000` | — |

--- a/examples/config/server.yaml
+++ b/examples/config/server.yaml
@@ -7,3 +7,4 @@ metrics_addr: ":8080"        # Prometheus metrics listen address
 request_timeout: 120s         # request timeout without worker activity
 drain_timeout: 5m             # wait time for in-flight requests on shutdown
 # allowed_origins: []         # comma separated list of allowed CORS origins
+# redis_addr: redis://127.0.0.1:6379/0  # redis connection URL for server state

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.23.0
 toolchain go1.24.3
 
 require (
+	github.com/alicebob/miniredis/v2 v2.35.0
 	github.com/coder/websocket v1.8.13
 	github.com/getkin/kin-openapi v0.132.0
 	github.com/go-chi/chi/v5 v5.2.2
@@ -13,6 +14,7 @@ require (
 	github.com/mark3labs/mcp-go v0.37.0
 	github.com/oapi-codegen/runtime v1.1.2
 	github.com/prometheus/client_golang v1.23.0
+	github.com/redis/go-redis/v9 v9.12.1
 	github.com/rs/zerolog v1.34.0
 	gopkg.in/yaml.v3 v3.0.1
 )
@@ -23,6 +25,7 @@ require (
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/buger/jsonparser v1.1.1 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
+	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
 	github.com/go-openapi/jsonpointer v0.21.0 // indirect
 	github.com/go-openapi/swag v0.23.0 // indirect
 	github.com/invopop/jsonschema v0.13.0 // indirect
@@ -42,6 +45,7 @@ require (
 	github.com/spf13/cast v1.7.1 // indirect
 	github.com/wk8/go-ordered-map/v2 v2.1.8 // indirect
 	github.com/yosida95/uritemplate/v3 v3.0.2 // indirect
+	github.com/yuin/gopher-lua v1.1.1 // indirect
 	golang.org/x/sys v0.33.0 // indirect
 	google.golang.org/protobuf v1.36.6 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,6 @@
 github.com/RaveNoX/go-jsoncommentstrip v1.0.0/go.mod h1:78ihd09MekBnJnxpICcwzCMzGrKSKYe4AqU6PDYYpjk=
+github.com/alicebob/miniredis/v2 v2.35.0 h1:QwLphYqCEAo1eu1TqPRN2jgVMPBweeQcR21jeqDCONI=
+github.com/alicebob/miniredis/v2 v2.35.0/go.mod h1:TcL7YfarKPGDAthEtl5NBeHZfeUQj6OXMm/+iu5cLMM=
 github.com/apapsch/go-jsonmerge/v2 v2.0.0 h1:axGnT1gRIfimI7gJifB699GoE/oq+F2MU7Dml6nw9rQ=
 github.com/apapsch/go-jsonmerge/v2 v2.0.0/go.mod h1:lvDnEdqiQrp0O42VQGgmlKpxL1AP2+08jFMw88y4klk=
 github.com/bahlo/generic-list-go v0.2.0 h1:5sz/EEAK+ls5wF+NeqDpk5+iNdMDXrh3z3nPnH1Wvgk=
@@ -6,6 +8,10 @@ github.com/bahlo/generic-list-go v0.2.0/go.mod h1:2KvAjgMlE5NNynlg/5iLrrCCZ2+5xW
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/bmatcuk/doublestar v1.1.1/go.mod h1:UD6OnuiIn0yFxxA2le/rnRU1G4RaI4UvFv1sNto9p6w=
+github.com/bsm/ginkgo/v2 v2.12.0 h1:Ny8MWAHyOepLGlLKYmXG4IEkioBysk6GpaRTLC8zwWs=
+github.com/bsm/ginkgo/v2 v2.12.0/go.mod h1:SwYbGRRDovPVboqFv0tPTcG1sN61LM1Z4ARdbAV9g4c=
+github.com/bsm/gomega v1.27.10 h1:yeMWxP2pV2fG3FgAODIY8EiRE3dy0aeFYt4l7wh6yKA=
+github.com/bsm/gomega v1.27.10/go.mod h1:JyEr/xRbxbtgWNi8tIEVPUYZ5Dzef52k01W3YH0H+O0=
 github.com/buger/jsonparser v1.1.1 h1:2PnMjfWD7wBILjqQbt530v576A/cAbQvEW9gGIpYMUs=
 github.com/buger/jsonparser v1.1.1/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx27UK13J/0=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
@@ -16,6 +22,8 @@ github.com/coreos/go-systemd/v22 v22.5.0/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSV
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f h1:lO4WD4F/rVNCu3HqELle0jiPLLBs70cWOduZpkS1E78=
+github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f/go.mod h1:cuUVRXasLTGF7a8hSLbxyZXjz+1KgoB3wDUb6vlszIc=
 github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHkI4W8=
 github.com/frankban/quicktest v1.14.6/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
 github.com/getkin/kin-openapi v0.132.0 h1:3ISeLMsQzcb5v26yeJrBcdTCEQTag36ZjaGk7MIRUwk=
@@ -81,6 +89,8 @@ github.com/prometheus/common v0.65.0 h1:QDwzd+G1twt//Kwj/Ww6E9FQq1iVMmODnILtW1t2
 github.com/prometheus/common v0.65.0/go.mod h1:0gZns+BLRQ3V6NdaerOhMbwwRbNh9hkGINtQAsP5GS8=
 github.com/prometheus/procfs v0.16.1 h1:hZ15bTNuirocR6u0JZ6BAHHmwS1p8B4P6MRqxtzMyRg=
 github.com/prometheus/procfs v0.16.1/go.mod h1:teAbpZRB1iIAJYREa1LsoWUXykVXA1KlTmWl8x/U+Is=
+github.com/redis/go-redis/v9 v9.12.1 h1:k5iquqv27aBtnTm2tIkROUDp8JBXhXZIVu1InSgvovg=
+github.com/redis/go-redis/v9 v9.12.1/go.mod h1:huWgSWd8mW6+m0VPhJjSSQ+d6Nh1VICQ6Q5lHuCH/Iw=
 github.com/rogpeppe/go-internal v1.12.0 h1:exVL4IDcn6na9z1rAb56Vxr+CgyK3nn3O+epU5NdKM8=
 github.com/rogpeppe/go-internal v1.12.0/go.mod h1:E+RYuTGaKKdloAfM02xzb0FW3Paa99yedzYV+kq4uf4=
 github.com/rs/xid v1.6.0/go.mod h1:7XoLgs4eV+QndskICGsho+ADou8ySMSjJKDIan90Nz0=
@@ -99,6 +109,8 @@ github.com/wk8/go-ordered-map/v2 v2.1.8 h1:5h/BUHu93oj4gIdvHHHGsScSTMijfx5PeYkE/
 github.com/wk8/go-ordered-map/v2 v2.1.8/go.mod h1:5nJHM5DyteebpVlHnWMV0rPz6Zp7+xBAnxjb1X5vnTw=
 github.com/yosida95/uritemplate/v3 v3.0.2 h1:Ed3Oyj9yrmi9087+NczuL5BwkIc4wvTb5zIM+UJPGz4=
 github.com/yosida95/uritemplate/v3 v3.0.2/go.mod h1:ILOh0sOhIJR3+L/8afwt/kE++YT040gmv5BQTMR2HP4=
+github.com/yuin/gopher-lua v1.1.1 h1:kYKnWBjvbNP4XLT3+bPEwAXJx262OhaHDWDVOPjL46M=
+github.com/yuin/gopher-lua v1.1.1/go.mod h1:GBR0iDaNXjAgGg9zfCvksxSRnQx76gclCIb7kdAd1Pw=
 go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
 go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
 golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/internal/config/server.go
+++ b/internal/config/server.go
@@ -22,6 +22,7 @@ type ServerConfig struct {
 	AllowedOrigins []string
 	ConfigFile     string
 	LogLevel       string
+	RedisAddr      string
 }
 
 // BindFlags populates the struct with defaults from environment variables and
@@ -43,6 +44,7 @@ func (c *ServerConfig) BindFlags() {
 	}
 	c.APIKey = getEnv("API_KEY", "")
 	c.ClientKey = getEnv("CLIENT_KEY", "")
+	c.RedisAddr = getEnv("REDIS_ADDR", "")
 	if v, err := strconv.ParseFloat(getEnv("REQUEST_TIMEOUT", "120"), 64); err == nil {
 		c.RequestTimeout = time.Duration(v * float64(time.Second))
 	} else {
@@ -61,6 +63,7 @@ func (c *ServerConfig) BindFlags() {
 	flag.StringVar(&c.MetricsAddr, "metrics-port", c.MetricsAddr, "Prometheus metrics listen address or port; defaults to the value of --port")
 	flag.StringVar(&c.APIKey, "api-key", c.APIKey, "client API key required for HTTP requests; leave empty to disable auth")
 	flag.StringVar(&c.ClientKey, "client-key", c.ClientKey, "shared key clients must present when registering")
+	flag.StringVar(&c.RedisAddr, "redis-addr", c.RedisAddr, "redis connection URL for server state")
 	flag.Func("request-timeout", "request timeout in seconds without worker activity", func(v string) error {
 		f, err := strconv.ParseFloat(v, 64)
 		if err != nil {

--- a/internal/serverstate/redis.go
+++ b/internal/serverstate/redis.go
@@ -1,0 +1,129 @@
+package serverstate
+
+import (
+	"context"
+	"crypto/tls"
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"strconv"
+	"strings"
+
+	"github.com/redis/go-redis/v9"
+)
+
+// redisStore implements Store backed by a Redis instance.
+type redisStore struct {
+	client redis.UniversalClient
+	key    string
+	ctx    context.Context
+}
+
+const redisKey = "infero:state"
+
+// NewRedisStore connects to the given Redis URL and returns a Store.
+// The underlying key is initialized to a default state if it does not exist.
+func NewRedisStore(addr string) (*redisStore, error) {
+	opts, err := parseRedisURL(addr)
+	if err != nil {
+		return nil, err
+	}
+	c := redis.NewUniversalClient(opts)
+	rs := &redisStore{client: c, key: redisKey, ctx: context.Background()}
+	if err := c.Ping(rs.ctx).Err(); err != nil {
+		return nil, err
+	}
+	b, _ := json.Marshal(State{Status: "not_ready"})
+	_ = c.SetNX(rs.ctx, rs.key, b, 0).Err()
+	return rs, nil
+}
+
+// parseRedisURL parses addr into UniversalOptions supporting single, cluster,
+// and sentinel Redis deployments. If no scheme is present, addr is treated as
+// a plain host:port string.
+func parseRedisURL(addr string) (*redis.UniversalOptions, error) {
+	if !strings.Contains(addr, "://") {
+		return &redis.UniversalOptions{Addrs: []string{addr}}, nil
+	}
+
+	u, err := url.Parse(addr)
+	if err != nil {
+		return nil, err
+	}
+
+	opts := &redis.UniversalOptions{}
+	if u.User != nil {
+		opts.Username = u.User.Username()
+		if pw, ok := u.User.Password(); ok {
+			opts.Password = pw
+		}
+	}
+	opts.Addrs = strings.Split(u.Host, ",")
+
+	q := u.Query()
+	tlsCfg := &tls.Config{MinVersion: tls.VersionTLS12}
+	switch u.Scheme {
+	case "redis", "rediss":
+		if u.Path != "" && u.Path != "/" {
+			if db, err := strconv.Atoi(strings.TrimPrefix(u.Path, "/")); err == nil {
+				opts.DB = db
+			} else {
+				return nil, fmt.Errorf("redis: invalid db: %v", err)
+			}
+		} else if dbStr := q.Get("db"); dbStr != "" {
+			if db, err := strconv.Atoi(dbStr); err == nil {
+				opts.DB = db
+			} else {
+				return nil, fmt.Errorf("redis: invalid db: %v", err)
+			}
+		}
+		if u.Scheme == "rediss" {
+			opts.TLSConfig = tlsCfg
+		}
+	case "redis-sentinel", "rediss-sentinel":
+		opts.MasterName = strings.TrimPrefix(u.Path, "/")
+		if dbStr := q.Get("db"); dbStr != "" {
+			if db, err := strconv.Atoi(dbStr); err == nil {
+				opts.DB = db
+			} else {
+				return nil, fmt.Errorf("redis: invalid db: %v", err)
+			}
+		}
+		if v := q.Get("sentinel_username"); v != "" {
+			opts.SentinelUsername = v
+		}
+		if v := q.Get("sentinel_password"); v != "" {
+			opts.SentinelPassword = v
+		}
+		if u.Scheme == "rediss-sentinel" {
+			opts.TLSConfig = tlsCfg
+		}
+	default:
+		return nil, fmt.Errorf("redis: invalid URL scheme: %s", u.Scheme)
+	}
+
+	return opts, nil
+}
+
+func (r *redisStore) Load() State {
+	b, err := r.client.Get(r.ctx, r.key).Bytes()
+	if err != nil {
+		if err == redis.Nil {
+			return State{Status: "not_ready"}
+		}
+		return State{Status: "unknown"}
+	}
+	var st State
+	if err := json.Unmarshal(b, &st); err != nil {
+		return State{Status: "unknown"}
+	}
+	return st
+}
+
+func (r *redisStore) Store(s State) {
+	b, err := json.Marshal(s)
+	if err != nil {
+		return
+	}
+	_ = r.client.Set(r.ctx, r.key, b, 0).Err()
+}

--- a/internal/serverstate/redis_test.go
+++ b/internal/serverstate/redis_test.go
@@ -1,0 +1,78 @@
+package serverstate
+
+import (
+	"testing"
+
+	miniredis "github.com/alicebob/miniredis/v2"
+)
+
+func TestRedisStore(t *testing.T) {
+	mr, err := miniredis.Run()
+	if err != nil {
+		t.Fatalf("miniredis: %v", err)
+	}
+	defer mr.Close()
+
+	rs, err := NewRedisStore(mr.Addr())
+	if err != nil {
+		t.Fatalf("NewRedisStore: %v", err)
+	}
+
+	prev := active
+	UseStore(rs)
+	defer UseStore(prev)
+
+	if got := GetState(); got != "not_ready" {
+		t.Fatalf("initial state = %q; want %q", got, "not_ready")
+	}
+
+	SetState("ready")
+	if got := GetState(); got != "ready" {
+		t.Fatalf("state after SetState = %q; want %q", got, "ready")
+	}
+
+	StartDrain()
+	if got := GetState(); got != "draining" {
+		t.Fatalf("state after StartDrain = %q; want %q", got, "draining")
+	}
+	if !IsDraining() {
+		t.Fatalf("IsDraining = false; want true")
+	}
+
+	// Ensure a new store sees the persisted state.
+	rs2, err := NewRedisStore(mr.Addr())
+	if err != nil {
+		t.Fatalf("NewRedisStore: %v", err)
+	}
+	if st := rs2.Load(); st.Status != "draining" || !st.Draining {
+		t.Fatalf("persisted state = %#v; want {Status: 'draining', Draining: true}", st)
+	}
+}
+
+func TestParseRedisURL(t *testing.T) {
+	tests := []struct {
+		url    string
+		addrs  int
+		master string
+		db     int
+	}{
+		{"redis://:pass@localhost:6379/1", 1, "", 1},
+		{"redis://host1:6379,host2:6379/0", 2, "", 0},
+		{"redis-sentinel://localhost:26379/mymaster?db=2", 1, "mymaster", 2},
+	}
+	for _, tt := range tests {
+		opts, err := parseRedisURL(tt.url)
+		if err != nil {
+			t.Fatalf("parseRedisURL(%q): %v", tt.url, err)
+		}
+		if len(opts.Addrs) != tt.addrs {
+			t.Fatalf("%q addrs = %d; want %d", tt.url, len(opts.Addrs), tt.addrs)
+		}
+		if opts.MasterName != tt.master {
+			t.Fatalf("%q master = %q; want %q", tt.url, opts.MasterName, tt.master)
+		}
+		if opts.DB != tt.db {
+			t.Fatalf("%q db = %d; want %d", tt.url, opts.DB, tt.db)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- consolidate state store configuration into a single REDIS_ADDR option
- allow REDIS_ADDR to use cluster and sentinel Redis URLs
- document redis configuration for shared server state

## Testing
- `make lint`
- `make build`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68a96a74d044832c85af8cf03af62ea5