### PR TITLE
feat: expose embedding batch size

### DIFF
--- a/desktop/windows/Installer/worker.yaml
+++ b/desktop/windows/Installer/worker.yaml
@@ -3,4 +3,5 @@ server_url: ""
 client_key: ""
 completion_base_url: "http://127.0.0.1:11434/v1"
 max_concurrency: 1
+# embedding_batch_size: 0
 status_addr: "127.0.0.1:4555"

--- a/doc/env.md
+++ b/doc/env.md
@@ -50,6 +50,7 @@ The worker optionally reads settings from a YAML config file. Defaults:
 | `COMPLETION_BASE_URL` | `completion_base_url` | base URL of the completion API | `http://127.0.0.1:11434/v1` | `--completion-base-url` |
 | `COMPLETION_API_KEY` | — | API key for the completion API | unset | `--completion-api-key` |
 | `MAX_CONCURRENCY` | `max_concurrency` | maximum number of jobs processed concurrently | `2` | `--max-concurrency` |
+| `EMBEDDING_BATCH_SIZE` | `embedding_batch_size` | ideal number of inputs per embeddings call | `0` | `--embedding-batch-size` |
 | `CLIENT_ID` | — | client identifier (random if unset) | unset | `--client-id` |
 | `STATUS_ADDR` | `status_addr` | local status HTTP listen address | unset (disabled) | `--status-addr` |
 | `METRICS_PORT` | `metrics_addr` | Prometheus metrics listen address or port | unset (disabled) | `--metrics-port` |

--- a/doc/server-endpoints.md
+++ b/doc/server-endpoints.md
@@ -27,7 +27,7 @@ The JSON snapshot includes `server.state` which reports `ready`, `not_ready`, or
 
 | Verb & Endpoint | Parameters | Description | Auth |
 | --- | --- | --- | --- |
-| `GET /api/workers/connect` (WS) | Initial message `{ type: "register", client_key?: string, worker_id?: string, worker_name?: string, models?: [string], max_concurrency?: int }` | Worker connects to server. | Client key |
+| `GET /api/workers/connect` (WS) | Initial message `{ type: "register", client_key?: string, worker_id?: string, worker_name?: string, models?: [string], max_concurrency?: int, embedding_batch_size?: int }` | Worker connects to server. | Client key |
 
 ### Client Usage
 

--- a/examples/config/worker.yaml
+++ b/examples/config/worker.yaml
@@ -5,6 +5,7 @@ server_url: ws://localhost:8080/api/workers/connect
 completion_base_url: http://127.0.0.1:11434/v1
 # completion_api_key: ""      # API key for the completion API
 max_concurrency: 2
+# embedding_batch_size: 0     # ideal number of inputs per embeddings call
 # client_id: ""               # client identifier
 # client_name: ""             # worker display name
 # status_addr: ""             # local status HTTP listen address

--- a/internal/api/chat_completions_test.go
+++ b/internal/api/chat_completions_test.go
@@ -24,7 +24,7 @@ func TestChatCompletionsHeaders(t *testing.T) {
 	wk := &ctrl.Worker{ID: "w1", Models: map[string]bool{"m": true}, MaxConcurrency: 1, Send: make(chan interface{}, 1), Jobs: make(map[string]chan interface{})}
 	reg.Add(wk)
 	metricsReg := ctrl.NewMetricsRegistry("", "", "")
-	metricsReg.UpsertWorker("w1", "w1", "", "", "", 1, []string{"m"})
+	metricsReg.UpsertWorker("w1", "w1", "", "", "", 1, 0, []string{"m"})
 	metricsReg.SetWorkerStatus("w1", ctrl.StatusConnected)
 	h := ChatCompletionsHandler(reg, sched, metricsReg, time.Second)
 

--- a/internal/api/state_test.go
+++ b/internal/api/state_test.go
@@ -15,7 +15,7 @@ import (
 
 func TestGetState(t *testing.T) {
 	metricsReg := ctrl.NewMetricsRegistry("v", "sha", "date")
-	metricsReg.UpsertWorker("w1", "w1", "1", "a", "d", 1, []string{"m"})
+	metricsReg.UpsertWorker("w1", "w1", "1", "a", "d", 1, 0, []string{"m"})
 	metricsReg.SetWorkerStatus("w1", ctrl.StatusConnected)
 	metricsReg.RecordJobStart("w1")
 	metricsReg.RecordJobEnd("w1", "m", 50*time.Millisecond, 5, 7, true, "")

--- a/internal/config/worker.go
+++ b/internal/config/worker.go
@@ -15,22 +15,23 @@ import (
 
 // WorkerConfig holds configuration for the worker agent.
 type WorkerConfig struct {
-	ServerURL         string
-	ClientKey         string
-	CompletionBaseURL string
-	CompletionAPIKey  string
-	MaxConcurrency    int
-	ClientID          string
-	ClientName        string
-	StatusAddr        string
-	MetricsAddr       string
-	DrainTimeout      time.Duration
-	ModelPollInterval time.Duration
-	ConfigFile        string
-	LogDir            string
-	Reconnect         bool
-	RequestTimeout    time.Duration
-	LogLevel          string
+	ServerURL          string
+	ClientKey          string
+	CompletionBaseURL  string
+	CompletionAPIKey   string
+	MaxConcurrency     int
+	EmbeddingBatchSize int
+	ClientID           string
+	ClientName         string
+	StatusAddr         string
+	MetricsAddr        string
+	DrainTimeout       time.Duration
+	ModelPollInterval  time.Duration
+	ConfigFile         string
+	LogDir             string
+	Reconnect          bool
+	RequestTimeout     time.Duration
+	LogLevel           string
 }
 
 func (c *WorkerConfig) BindFlags() {
@@ -49,6 +50,10 @@ func (c *WorkerConfig) BindFlags() {
 		c.MaxConcurrency = v
 	} else {
 		c.MaxConcurrency = 2
+	}
+	eb := getEnv("EMBEDDING_BATCH_SIZE", "0")
+	if v, err := strconv.Atoi(eb); err == nil {
+		c.EmbeddingBatchSize = v
 	}
 	c.ClientID = getEnv("CLIENT_ID", "")
 	c.StatusAddr = getEnv("STATUS_ADDR", "")
@@ -87,6 +92,7 @@ func (c *WorkerConfig) BindFlags() {
 	flag.StringVar(&c.CompletionBaseURL, "completion-base-url", c.CompletionBaseURL, "base URL of the completion API (e.g. http://127.0.0.1:11434/v1)")
 	flag.StringVar(&c.CompletionAPIKey, "completion-api-key", c.CompletionAPIKey, "API key for the completion API; leave empty for no auth")
 	flag.IntVar(&c.MaxConcurrency, "max-concurrency", c.MaxConcurrency, "maximum number of jobs processed concurrently")
+	flag.IntVar(&c.EmbeddingBatchSize, "embedding-batch-size", c.EmbeddingBatchSize, "ideal embedding batch size for embeddings")
 	flag.StringVar(&c.ClientID, "client-id", c.ClientID, "client identifier; randomly generated if omitted")
 	flag.StringVar(&c.ClientName, "client-name", c.ClientName, "client display name shown in logs and status")
 	flag.StringVar(&c.StatusAddr, "status-addr", c.StatusAddr, "local status HTTP listen address (enables /status; e.g. 127.0.0.1:4555)")

--- a/internal/ctrl/messages.go
+++ b/internal/ctrl/messages.go
@@ -3,23 +3,25 @@ package ctrl
 import "encoding/json"
 
 type RegisterMessage struct {
-	Type           string   `json:"type"`
-	WorkerID       string   `json:"worker_id"`
-	WorkerName     string   `json:"worker_name,omitempty"`
-	ClientKey      string   `json:"client_key"`
-	Token          string   `json:"token,omitempty"`
-	Models         []string `json:"models"`
-	MaxConcurrency int      `json:"max_concurrency"`
-	Version        string   `json:"version,omitempty"`
-	BuildSHA       string   `json:"build_sha,omitempty"`
-	BuildDate      string   `json:"build_date,omitempty"`
+	Type               string   `json:"type"`
+	WorkerID           string   `json:"worker_id"`
+	WorkerName         string   `json:"worker_name,omitempty"`
+	ClientKey          string   `json:"client_key"`
+	Token              string   `json:"token,omitempty"`
+	Models             []string `json:"models"`
+	MaxConcurrency     int      `json:"max_concurrency"`
+	EmbeddingBatchSize int      `json:"embedding_batch_size"`
+	Version            string   `json:"version,omitempty"`
+	BuildSHA           string   `json:"build_sha,omitempty"`
+	BuildDate          string   `json:"build_date,omitempty"`
 }
 
 type StatusUpdateMessage struct {
-	Type           string   `json:"type"`
-	MaxConcurrency int      `json:"max_concurrency"`
-	Models         []string `json:"models,omitempty"`
-	Status         string   `json:"status,omitempty"`
+	Type               string   `json:"type"`
+	MaxConcurrency     int      `json:"max_concurrency"`
+	EmbeddingBatchSize int      `json:"embedding_batch_size"`
+	Models             []string `json:"models,omitempty"`
+	Status             string   `json:"status,omitempty"`
 }
 
 type HeartbeatMessage struct {

--- a/internal/ctrl/metrics_test.go
+++ b/internal/ctrl/metrics_test.go
@@ -20,7 +20,7 @@ func TestSnapshotEmpty(t *testing.T) {
 
 func TestWorkerLifecycle(t *testing.T) {
 	reg := NewMetricsRegistry("v", "sha", "date")
-	reg.UpsertWorker("w1", "w1", "1.0", "a", "today", 1, []string{"llama3:8b"})
+	reg.UpsertWorker("w1", "w1", "1.0", "a", "today", 1, 0, []string{"llama3:8b"})
 	reg.SetWorkerStatus("w1", StatusConnected)
 	reg.RecordHeartbeat("w1")
 	reg.RecordJobStart("w1")
@@ -44,7 +44,7 @@ func TestWorkerLifecycle(t *testing.T) {
 
 func TestErrorPaths(t *testing.T) {
 	reg := NewMetricsRegistry("v", "sha", "date")
-	reg.UpsertWorker("w1", "w1", "1.0", "a", "today", 1, nil)
+	reg.UpsertWorker("w1", "w1", "1.0", "a", "today", 1, 0, nil)
 	reg.RecordJobStart("w1")
 	reg.RecordJobEnd("w1", "m", 0, 0, 0, false, "boom")
 
@@ -60,9 +60,9 @@ func TestErrorPaths(t *testing.T) {
 
 func TestWorkersSummaryAndModels(t *testing.T) {
 	reg := NewMetricsRegistry("v", "sha", "date")
-	reg.UpsertWorker("a", "a", "1", "", "", 1, []string{"m1", "m2"})
+	reg.UpsertWorker("a", "a", "1", "", "", 1, 0, []string{"m1", "m2"})
 	reg.SetWorkerStatus("a", StatusConnected)
-	reg.UpsertWorker("b", "b", "1", "", "", 1, []string{"m2"})
+	reg.UpsertWorker("b", "b", "1", "", "", 1, 0, []string{"m2"})
 	reg.SetWorkerStatus("b", StatusIdle)
 
 	snap := reg.Snapshot()
@@ -76,7 +76,7 @@ func TestWorkersSummaryAndModels(t *testing.T) {
 
 func TestRemoveWorker(t *testing.T) {
 	reg := NewMetricsRegistry("v", "sha", "date")
-	reg.UpsertWorker("w1", "w1", "1", "", "", 1, nil)
+	reg.UpsertWorker("w1", "w1", "1", "", "", 1, 0, nil)
 	reg.RemoveWorker("w1")
 	snap := reg.Snapshot()
 	if len(snap.Workers) != 0 {
@@ -86,9 +86,9 @@ func TestRemoveWorker(t *testing.T) {
 
 func TestWorkersSortedByAge(t *testing.T) {
 	reg := NewMetricsRegistry("v", "sha", "date")
-	reg.UpsertWorker("old", "old", "1", "", "", 1, nil)
+	reg.UpsertWorker("old", "old", "1", "", "", 1, 0, nil)
 	time.Sleep(10 * time.Millisecond)
-	reg.UpsertWorker("new", "new", "1", "", "", 1, nil)
+	reg.UpsertWorker("new", "new", "1", "", "", 1, 0, nil)
 	snap := reg.Snapshot()
 	if len(snap.Workers) != 2 || snap.Workers[0].ID != "old" {
 		t.Fatalf("expected deterministic sort by age, got %+v", snap.Workers)
@@ -97,7 +97,7 @@ func TestWorkersSortedByAge(t *testing.T) {
 
 func TestRegistryRace(t *testing.T) {
 	reg := NewMetricsRegistry("v", "sha", "date")
-	reg.UpsertWorker("w", "w", "1", "", "", 1, []string{"m"})
+	reg.UpsertWorker("w", "w", "1", "", "", 1, 0, []string{"m"})
 	var wg sync.WaitGroup
 	for i := 0; i < 10; i++ {
 		wg.Add(1)

--- a/internal/ctrl/models_test.go
+++ b/internal/ctrl/models_test.go
@@ -7,8 +7,8 @@ import (
 
 func TestAggregatedModels(t *testing.T) {
 	reg := NewRegistry()
-	reg.Add(&Worker{ID: "w1", Name: "Alpha", Models: map[string]bool{"llama3:8b": true, "mistral:7b": true}, MaxConcurrency: 1})
-	reg.Add(&Worker{ID: "w2", Name: "Beta", Models: map[string]bool{"llama3:8b": true, "qwen2.5:14b": true}, MaxConcurrency: 1})
+	reg.Add(&Worker{ID: "w1", Name: "Alpha", Models: map[string]bool{"llama3:8b": true, "mistral:7b": true}, MaxConcurrency: 1, EmbeddingBatchSize: 0})
+	reg.Add(&Worker{ID: "w2", Name: "Beta", Models: map[string]bool{"llama3:8b": true, "qwen2.5:14b": true}, MaxConcurrency: 1, EmbeddingBatchSize: 0})
 
 	list := reg.AggregatedModels()
 	if len(list) != 3 {

--- a/internal/ctrl/registry.go
+++ b/internal/ctrl/registry.go
@@ -13,15 +13,16 @@ const (
 )
 
 type Worker struct {
-	ID             string
-	Name           string
-	Models         map[string]bool
-	MaxConcurrency int
-	InFlight       int
-	LastHeartbeat  time.Time
-	Send           chan interface{}
-	Jobs           map[string]chan interface{}
-	mu             sync.Mutex
+	ID                 string
+	Name               string
+	Models             map[string]bool
+	MaxConcurrency     int
+	EmbeddingBatchSize int
+	InFlight           int
+	LastHeartbeat      time.Time
+	Send               chan interface{}
+	Jobs               map[string]chan interface{}
+	mu                 sync.Mutex
 }
 
 type Registry struct {

--- a/internal/ctrl/registry_test.go
+++ b/internal/ctrl/registry_test.go
@@ -7,7 +7,7 @@ import (
 
 func TestRegistry(t *testing.T) {
 	reg := NewRegistry()
-	w := &Worker{ID: "w1", Models: map[string]bool{"m": true}, MaxConcurrency: 1}
+	w := &Worker{ID: "w1", Models: map[string]bool{"m": true}, MaxConcurrency: 1, EmbeddingBatchSize: 0}
 	reg.Add(w)
 	if len(reg.WorkersForModel("m")) != 1 {
 		t.Fatalf("expected worker for model")
@@ -24,7 +24,7 @@ func TestRegistry(t *testing.T) {
 
 func TestRegistryPruneExpired(t *testing.T) {
 	reg := NewRegistry()
-	w := &Worker{ID: "w1", Models: map[string]bool{"m": true}, MaxConcurrency: 1, LastHeartbeat: time.Now().Add(-HeartbeatExpiry - time.Second), Send: make(chan interface{}), Jobs: make(map[string]chan interface{})}
+	w := &Worker{ID: "w1", Models: map[string]bool{"m": true}, MaxConcurrency: 1, EmbeddingBatchSize: 0, LastHeartbeat: time.Now().Add(-HeartbeatExpiry - time.Second), Send: make(chan interface{}), Jobs: make(map[string]chan interface{})}
 	jobCh := make(chan interface{})
 	w.Jobs["j1"] = jobCh
 	reg.Add(w)
@@ -42,7 +42,7 @@ func TestRegistryPruneExpired(t *testing.T) {
 
 func TestRegistryWorkersForAlias(t *testing.T) {
 	reg := NewRegistry()
-	w := &Worker{ID: "w1", Models: map[string]bool{"llama2:7b-fp16": true}, MaxConcurrency: 1}
+	w := &Worker{ID: "w1", Models: map[string]bool{"llama2:7b-fp16": true}, MaxConcurrency: 1, EmbeddingBatchSize: 0}
 	reg.Add(w)
 	ws := reg.WorkersForAlias("llama2:7b-q4_0")
 	if len(ws) != 1 || ws[0].ID != "w1" {

--- a/internal/ctrl/scheduler_test.go
+++ b/internal/ctrl/scheduler_test.go
@@ -4,8 +4,8 @@ import "testing"
 
 func TestLeastBusyScheduler(t *testing.T) {
 	reg := NewRegistry()
-	w1 := &Worker{ID: "w1", Models: map[string]bool{"m": true}, InFlight: 1, MaxConcurrency: 2}
-	w2 := &Worker{ID: "w2", Models: map[string]bool{"m": true}, InFlight: 0, MaxConcurrency: 1}
+	w1 := &Worker{ID: "w1", Models: map[string]bool{"m": true}, InFlight: 1, MaxConcurrency: 2, EmbeddingBatchSize: 0}
+	w2 := &Worker{ID: "w2", Models: map[string]bool{"m": true}, InFlight: 0, MaxConcurrency: 1, EmbeddingBatchSize: 0}
 	reg.Add(w1)
 	reg.Add(w2)
 	sched := &LeastBusyScheduler{Reg: reg}
@@ -20,8 +20,8 @@ func TestLeastBusyScheduler(t *testing.T) {
 
 func TestLeastBusySchedulerExactMatchWins(t *testing.T) {
 	reg := NewRegistry()
-	exact := &Worker{ID: "exact", Models: map[string]bool{"llama2:7b-q4_0": true}, InFlight: 10, MaxConcurrency: 20}
-	alias := &Worker{ID: "alias", Models: map[string]bool{"llama2:7b-fp16": true}, InFlight: 0, MaxConcurrency: 1}
+	exact := &Worker{ID: "exact", Models: map[string]bool{"llama2:7b-q4_0": true}, InFlight: 10, MaxConcurrency: 20, EmbeddingBatchSize: 0}
+	alias := &Worker{ID: "alias", Models: map[string]bool{"llama2:7b-fp16": true}, InFlight: 0, MaxConcurrency: 1, EmbeddingBatchSize: 0}
 	reg.Add(exact)
 	reg.Add(alias)
 	sched := &LeastBusyScheduler{Reg: reg}
@@ -36,7 +36,7 @@ func TestLeastBusySchedulerExactMatchWins(t *testing.T) {
 
 func TestLeastBusySchedulerAliasFallback(t *testing.T) {
 	reg := NewRegistry()
-	alias := &Worker{ID: "alias", Models: map[string]bool{"llama2:7b-fp16": true}, MaxConcurrency: 1}
+	alias := &Worker{ID: "alias", Models: map[string]bool{"llama2:7b-fp16": true}, MaxConcurrency: 1, EmbeddingBatchSize: 0}
 	reg.Add(alias)
 	sched := &LeastBusyScheduler{Reg: reg}
 	w, err := sched.PickWorker("llama2:7b-q4_0")
@@ -50,7 +50,7 @@ func TestLeastBusySchedulerAliasFallback(t *testing.T) {
 
 func TestLeastBusySchedulerNoAliasCandidates(t *testing.T) {
 	reg := NewRegistry()
-	reg.Add(&Worker{ID: "w1", Models: map[string]bool{"mistral:7b-q4_0": true}, MaxConcurrency: 1})
+	reg.Add(&Worker{ID: "w1", Models: map[string]bool{"mistral:7b-q4_0": true}, MaxConcurrency: 1, EmbeddingBatchSize: 0})
 	sched := &LeastBusyScheduler{Reg: reg}
 	if _, err := sched.PickWorker("llama2:7b-q4_0"); err == nil {
 		t.Fatalf("expected error")
@@ -59,7 +59,7 @@ func TestLeastBusySchedulerNoAliasCandidates(t *testing.T) {
 
 func TestLeastBusySchedulerNoDashAlias(t *testing.T) {
 	reg := NewRegistry()
-	w := &Worker{ID: "w1", Models: map[string]bool{"mistral:7b-fp16": true}, MaxConcurrency: 1}
+	w := &Worker{ID: "w1", Models: map[string]bool{"mistral:7b-fp16": true}, MaxConcurrency: 1, EmbeddingBatchSize: 0}
 	reg.Add(w)
 	sched := &LeastBusyScheduler{Reg: reg}
 	wkr, err := sched.PickWorker("mistral:7b")
@@ -73,8 +73,8 @@ func TestLeastBusySchedulerNoDashAlias(t *testing.T) {
 
 func TestLeastBusySchedulerAliasLeastBusy(t *testing.T) {
 	reg := NewRegistry()
-	w1 := &Worker{ID: "w1", Models: map[string]bool{"llama2:7b-q4_0": true}, InFlight: 2, MaxConcurrency: 3}
-	w2 := &Worker{ID: "w2", Models: map[string]bool{"llama2:7b-fp16": true}, InFlight: 1, MaxConcurrency: 3}
+	w1 := &Worker{ID: "w1", Models: map[string]bool{"llama2:7b-q4_0": true}, InFlight: 2, MaxConcurrency: 3, EmbeddingBatchSize: 0}
+	w2 := &Worker{ID: "w2", Models: map[string]bool{"llama2:7b-fp16": true}, InFlight: 1, MaxConcurrency: 3, EmbeddingBatchSize: 0}
 	reg.Add(w1)
 	reg.Add(w2)
 	sched := &LeastBusyScheduler{Reg: reg}

--- a/internal/ctrl/ws_workername_test.go
+++ b/internal/ctrl/ws_workername_test.go
@@ -26,7 +26,7 @@ func TestRegisterStoresWorkerName(t *testing.T) {
 	defer func() {
 		_ = conn.Close(websocket.StatusNormalClosure, "")
 	}()
-	rm := RegisterMessage{Type: "register", WorkerID: "w1abcdef", WorkerName: "Alpha", Models: []string{"m"}, MaxConcurrency: 1}
+	rm := RegisterMessage{Type: "register", WorkerID: "w1abcdef", WorkerName: "Alpha", Models: []string{"m"}, MaxConcurrency: 1, EmbeddingBatchSize: 0}
 	b, _ := json.Marshal(rm)
 	if err := conn.Write(ctx, websocket.MessageText, b); err != nil {
 		t.Fatalf("write: %v", err)
@@ -61,7 +61,7 @@ func TestRegisterFallbackName(t *testing.T) {
 	defer func() {
 		_ = conn.Close(websocket.StatusNormalClosure, "")
 	}()
-	rm := RegisterMessage{Type: "register", WorkerID: "w123456789", Models: []string{"m"}, MaxConcurrency: 1}
+	rm := RegisterMessage{Type: "register", WorkerID: "w123456789", Models: []string{"m"}, MaxConcurrency: 1, EmbeddingBatchSize: 0}
 	b, _ := json.Marshal(rm)
 	if err := conn.Write(ctx, websocket.MessageText, b); err != nil {
 		t.Fatalf("write: %v", err)

--- a/internal/server/state.html
+++ b/internal/server/state.html
@@ -132,6 +132,7 @@ function render() {
       <div class="name"><span class="status-dot" style="background:${status}"></span>${w.name || w.id}</div>
       <div>${w.status}</div>
       <div>inflight: ${w.inflight}</div>
+      <div>embed batch: ${w.embedding_batch_size}</div>
       <div>tokens in/out: ${w.tokens_in_total}/${w.tokens_out_total}</div>
       <div>total tokens: ${w.tokens_total}</div>
       <div>avg rate: ${w.avg_tokens_per_second.toFixed(2)} tok/s</div>

--- a/internal/worker/drain_integration_test.go
+++ b/internal/worker/drain_integration_test.go
@@ -54,7 +54,7 @@ func TestDrainAndTerminate(t *testing.T) {
 	statusAddr := ln.Addr().String()
 	_ = ln.Close()
 
-	cfg := config.WorkerConfig{ServerURL: wsURL, CompletionBaseURL: ollama.URL + "/v1", MaxConcurrency: 1, StatusAddr: statusAddr, ConfigFile: filepath.Join(t.TempDir(), "worker.yaml")}
+	cfg := config.WorkerConfig{ServerURL: wsURL, CompletionBaseURL: ollama.URL + "/v1", MaxConcurrency: 1, EmbeddingBatchSize: 0, StatusAddr: statusAddr, ConfigFile: filepath.Join(t.TempDir(), "worker.yaml")}
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	errCh := make(chan error, 1)
@@ -151,7 +151,7 @@ func TestDrainTerminatesWhenIdle(t *testing.T) {
 	defer srv.Close()
 	wsURL := "ws://" + srv.Listener.Addr().String()
 
-	cfg := config.WorkerConfig{ServerURL: wsURL, CompletionBaseURL: ollama.URL + "/v1", MaxConcurrency: 1}
+	cfg := config.WorkerConfig{ServerURL: wsURL, CompletionBaseURL: ollama.URL + "/v1", MaxConcurrency: 1, EmbeddingBatchSize: 0}
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	errCh := make(chan error, 1)

--- a/internal/worker/health_test.go
+++ b/internal/worker/health_test.go
@@ -29,7 +29,7 @@ func (f fakeHealthClient) Health(ctx context.Context) ([]string, error) {
 
 func TestProbeBackendUpdatesState(t *testing.T) {
 	resetState()
-	cfg := config.WorkerConfig{ClientID: "w1", ClientName: "n", MaxConcurrency: 1}
+	cfg := config.WorkerConfig{ClientID: "w1", ClientName: "n", MaxConcurrency: 1, EmbeddingBatchSize: 0}
 	if err := probeBackend(context.Background(), fakeHealthClient{models: []string{"m1"}}, cfg, nil); err != nil {
 		t.Fatalf("probe healthy: %v", err)
 	}
@@ -55,9 +55,9 @@ func TestProbeBackendUpdatesState(t *testing.T) {
 
 func TestProbeBackendSendsUpdates(t *testing.T) {
 	resetState()
-	SetWorkerInfo("w1", "n", 1, []string{"m1"})
+	SetWorkerInfo("w1", "n", 1, 0, []string{"m1"})
 	SetConnectedToBackend(true)
-	cfg := config.WorkerConfig{ClientID: "w1", ClientName: "n", MaxConcurrency: 1}
+	cfg := config.WorkerConfig{ClientID: "w1", ClientName: "n", MaxConcurrency: 1, EmbeddingBatchSize: 0}
 
 	// We now use the status update channel, and probeOllama only emits when something changes.
 	ch := make(chan ctrl.StatusUpdateMessage, 1)
@@ -117,7 +117,7 @@ func TestHealthProbeIntegration(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	cfgFile := filepath.Join(t.TempDir(), "worker.yaml")
-	cfg := config.WorkerConfig{ClientID: "w1", ClientName: "n", MaxConcurrency: 1}
+	cfg := config.WorkerConfig{ClientID: "w1", ClientName: "n", MaxConcurrency: 1, EmbeddingBatchSize: 0}
 	addr, err := StartStatusServer(ctx, "127.0.0.1:0", cfgFile, time.Second, cancel)
 	if err != nil {
 		t.Fatalf("start status server: %v", err)

--- a/internal/worker/http_proxy_test.go
+++ b/internal/worker/http_proxy_test.go
@@ -45,7 +45,7 @@ func TestHandleHTTPProxyAuthAndStream(t *testing.T) {
 	}))
 	defer ollama.Close()
 
-	cfg := config.WorkerConfig{CompletionBaseURL: ollama.URL + "/v1", CompletionAPIKey: "secret-123"}
+	cfg := config.WorkerConfig{CompletionBaseURL: ollama.URL + "/v1", CompletionAPIKey: "secret-123", EmbeddingBatchSize: 0}
 	sendCh := make(chan []byte, 16)
 	cancels := make(map[string]context.CancelFunc)
 	var mu sync.Mutex

--- a/internal/worker/metrics.go
+++ b/internal/worker/metrics.go
@@ -28,6 +28,10 @@ var (
 		Name: "infero_worker_max_concurrency",
 		Help: "Maximum number of concurrent jobs",
 	})
+	embeddingBatchSizeGauge = prometheus.NewGauge(prometheus.GaugeOpts{
+		Name: "infero_worker_embedding_batch_size",
+		Help: "Ideal embedding batch size",
+	})
 	jobsStartedCounter = prometheus.NewCounter(prometheus.CounterOpts{
 		Name: "infero_worker_jobs_started_total",
 		Help: "Total number of jobs started",
@@ -56,6 +60,7 @@ func StartMetricsServer(ctx context.Context, addr string) (string, error) {
 		connectedToBackendGauge,
 		currentJobsGauge,
 		maxConcurrencyGauge,
+		embeddingBatchSizeGauge,
 		jobsStartedCounter,
 		jobsSucceededCounter,
 		jobsFailedCounter,
@@ -106,6 +111,10 @@ func setCurrentJobs(n int) {
 
 func setMaxConcurrency(n int) {
 	maxConcurrencyGauge.Set(float64(n))
+}
+
+func setEmbeddingBatchSize(n int) {
+	embeddingBatchSizeGauge.Set(float64(n))
 }
 
 // JobStarted increments the started jobs counter.

--- a/internal/worker/metrics_test.go
+++ b/internal/worker/metrics_test.go
@@ -11,7 +11,7 @@ import (
 
 func TestMetricsServer(t *testing.T) {
 	resetState()
-	SetWorkerInfo("id1", "worker", 2, nil)
+	SetWorkerInfo("id1", "worker", 2, 0, nil)
 	SetConnectedToServer(true)
 	SetConnectedToBackend(true)
 	ctx, cancel := context.WithCancel(context.Background())

--- a/internal/worker/status.go
+++ b/internal/worker/status.go
@@ -12,6 +12,7 @@ type State struct {
 	ConnectedToBackend bool      `json:"connected_to_backend"`
 	CurrentJobs        int       `json:"current_jobs"`
 	MaxConcurrency     int       `json:"max_concurrency"`
+	EmbeddingBatchSize int       `json:"embedding_batch_size"`
 	Models             []string  `json:"models"`
 	LastError          string    `json:"last_error"`
 	LastHeartbeat      time.Time `json:"last_heartbeat"`
@@ -54,15 +55,17 @@ func GetVersionInfo() VersionInfo {
 	return buildInfo
 }
 
-func SetWorkerInfo(id, name string, maxConc int, models []string) {
+func SetWorkerInfo(id, name string, maxConc, embedBatch int, models []string) {
 	stateMu.Lock()
 	stateData.WorkerID = id
 	stateData.WorkerName = name
 	stateData.MaxConcurrency = maxConc
+	stateData.EmbeddingBatchSize = embedBatch
 	stateData.Models = append([]string(nil), models...)
 	cur := stateData.CurrentJobs
 	stateMu.Unlock()
 	setMaxConcurrency(maxConc)
+	setEmbeddingBatchSize(embedBatch)
 	setCurrentJobs(cur)
 }
 

--- a/internal/worker/status_http_test.go
+++ b/internal/worker/status_http_test.go
@@ -14,7 +14,7 @@ import (
 func TestStatusHTTP(t *testing.T) {
 	resetState()
 	SetBuildInfo("v1", "sha1", "2024-01-01")
-	SetWorkerInfo("id1", "worker", 2, []string{"m1"})
+	SetWorkerInfo("id1", "worker", 2, 0, []string{"m1"})
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	cfgFile := filepath.Join(t.TempDir(), "worker.yaml")

--- a/test/e2e_auth_test.go
+++ b/test/e2e_auth_test.go
@@ -34,7 +34,7 @@ func TestWorkerAuth(t *testing.T) {
 	if err != nil {
 		t.Fatalf("dial bad: %v", err)
 	}
-	regBad := ctrl.RegisterMessage{Type: "register", WorkerID: "wbad", ClientKey: "nope", Models: []string{"m"}, MaxConcurrency: 1}
+	regBad := ctrl.RegisterMessage{Type: "register", WorkerID: "wbad", ClientKey: "nope", Models: []string{"m"}, MaxConcurrency: 1, EmbeddingBatchSize: 0}
 	b, _ := json.Marshal(regBad)
 	if err := connBad.Write(ctx, websocket.MessageText, b); err != nil {
 		t.Fatalf("write bad: %v", err)
@@ -58,7 +58,7 @@ func TestWorkerAuth(t *testing.T) {
 	defer func() {
 		_ = conn.Close(websocket.StatusNormalClosure, "")
 	}()
-	regMsg := ctrl.RegisterMessage{Type: "register", WorkerID: "w1", ClientKey: "secret", Models: []string{"m"}, MaxConcurrency: 1}
+	regMsg := ctrl.RegisterMessage{Type: "register", WorkerID: "w1", ClientKey: "secret", Models: []string{"m"}, MaxConcurrency: 1, EmbeddingBatchSize: 0}
 	b, _ = json.Marshal(regMsg)
 	if err := conn.Write(ctx, websocket.MessageText, b); err != nil {
 		t.Fatalf("write: %v", err)
@@ -96,7 +96,7 @@ func TestWorkerClientKeyUnexpected(t *testing.T) {
 	if err != nil {
 		t.Fatalf("dial: %v", err)
 	}
-	regMsg := ctrl.RegisterMessage{Type: "register", WorkerID: "w1", ClientKey: "secret", Models: []string{"m"}, MaxConcurrency: 1}
+	regMsg := ctrl.RegisterMessage{Type: "register", WorkerID: "w1", ClientKey: "secret", Models: []string{"m"}, MaxConcurrency: 1, EmbeddingBatchSize: 0}
 	b, _ := json.Marshal(regMsg)
 	if err := conn.Write(ctx, websocket.MessageText, b); err != nil {
 		t.Fatalf("write: %v", err)

--- a/test/e2e_chat_completions_proxy_test.go
+++ b/test/e2e_chat_completions_proxy_test.go
@@ -65,7 +65,7 @@ func TestE2EChatCompletionsProxy(t *testing.T) {
 	defer cancel()
 	wsURL := strings.Replace(srv.URL, "http", "ws", 1) + "/api/workers/connect"
 	go func() {
-		_ = worker.Run(ctx, config.WorkerConfig{ServerURL: wsURL, ClientKey: "secret", CompletionBaseURL: ollama.URL + "/v1", CompletionAPIKey: "secret-123", ClientID: "w1", ClientName: "w1", MaxConcurrency: 2})
+		_ = worker.Run(ctx, config.WorkerConfig{ServerURL: wsURL, ClientKey: "secret", CompletionBaseURL: ollama.URL + "/v1", CompletionAPIKey: "secret-123", ClientID: "w1", ClientName: "w1", MaxConcurrency: 2, EmbeddingBatchSize: 0})
 	}()
 
 	// wait for worker registration

--- a/test/e2e_embeddings_proxy_test.go
+++ b/test/e2e_embeddings_proxy_test.go
@@ -52,7 +52,7 @@ func TestE2EEmbeddingsProxy(t *testing.T) {
 	defer cancel()
 	wsURL := strings.Replace(srv.URL, "http", "ws", 1) + "/api/workers/connect"
 	go func() {
-		_ = worker.Run(ctx, config.WorkerConfig{ServerURL: wsURL, ClientKey: "secret", CompletionBaseURL: ollama.URL + "/v1", CompletionAPIKey: "secret-123", ClientID: "w1", ClientName: "w1", MaxConcurrency: 2})
+		_ = worker.Run(ctx, config.WorkerConfig{ServerURL: wsURL, ClientKey: "secret", CompletionBaseURL: ollama.URL + "/v1", CompletionAPIKey: "secret-123", ClientID: "w1", ClientName: "w1", MaxConcurrency: 2, EmbeddingBatchSize: 0})
 	}()
 
 	for i := 0; i < 20; i++ {

--- a/test/e2e_model_update_test.go
+++ b/test/e2e_model_update_test.go
@@ -34,7 +34,7 @@ func TestWorkerModelRefresh(t *testing.T) {
 	}
 	defer func() { _ = conn.Close(websocket.StatusNormalClosure, "") }()
 
-	rm := ctrl.RegisterMessage{Type: "register", WorkerID: "w1", WorkerName: "Alpha", Models: []string{"m1"}, MaxConcurrency: 1}
+	rm := ctrl.RegisterMessage{Type: "register", WorkerID: "w1", WorkerName: "Alpha", Models: []string{"m1"}, MaxConcurrency: 1, EmbeddingBatchSize: 0}
 	b, _ := json.Marshal(rm)
 	if err := conn.Write(ctx, websocket.MessageText, b); err != nil {
 		t.Fatalf("write register: %v", err)
@@ -71,7 +71,7 @@ func TestWorkerModelRefresh(t *testing.T) {
 		t.Fatalf("models not updated")
 	}
 
-	sm := ctrl.StatusUpdateMessage{Type: "status_update", MaxConcurrency: 1, Models: []string{"m1"}, Status: "idle"}
+	sm := ctrl.StatusUpdateMessage{Type: "status_update", MaxConcurrency: 1, EmbeddingBatchSize: 0, Models: []string{"m1"}, Status: "idle"}
 	b, _ = json.Marshal(sm)
 	if err := conn.Write(ctx, websocket.MessageText, b); err != nil {
 		t.Fatalf("write status: %v", err)
@@ -79,7 +79,7 @@ func TestWorkerModelRefresh(t *testing.T) {
 
 	waitForModels(1, "m1")
 
-	sm = ctrl.StatusUpdateMessage{Type: "status_update", MaxConcurrency: 1, Models: []string{"m1", "m2"}, Status: "idle"}
+	sm = ctrl.StatusUpdateMessage{Type: "status_update", MaxConcurrency: 1, EmbeddingBatchSize: 0, Models: []string{"m1", "m2"}, Status: "idle"}
 	b, _ = json.Marshal(sm)
 	if err := conn.Write(ctx, websocket.MessageText, b); err != nil {
 		t.Fatalf("write update: %v", err)
@@ -87,7 +87,7 @@ func TestWorkerModelRefresh(t *testing.T) {
 
 	waitForModels(2, "m2")
 
-	sm = ctrl.StatusUpdateMessage{Type: "status_update", MaxConcurrency: 1, Models: []string{"m2"}, Status: "idle"}
+	sm = ctrl.StatusUpdateMessage{Type: "status_update", MaxConcurrency: 1, EmbeddingBatchSize: 0, Models: []string{"m2"}, Status: "idle"}
 	b, _ = json.Marshal(sm)
 	if err := conn.Write(ctx, websocket.MessageText, b); err != nil {
 		t.Fatalf("write update2: %v", err)

--- a/test/e2e_models_api_test.go
+++ b/test/e2e_models_api_test.go
@@ -34,7 +34,7 @@ func TestModelsAPI(t *testing.T) {
 	if err != nil {
 		t.Fatalf("dial alpha: %v", err)
 	}
-	rmA := ctrl.RegisterMessage{Type: "register", WorkerID: "wA", WorkerName: "Alpha", Models: []string{"llama3:8b", "mistral:7b"}, MaxConcurrency: 1}
+	rmA := ctrl.RegisterMessage{Type: "register", WorkerID: "wA", WorkerName: "Alpha", Models: []string{"llama3:8b", "mistral:7b"}, MaxConcurrency: 1, EmbeddingBatchSize: 0}
 	b, _ := json.Marshal(rmA)
 	if err := connA.Write(ctx, websocket.MessageText, b); err != nil {
 		t.Fatalf("write alpha: %v", err)
@@ -45,7 +45,7 @@ func TestModelsAPI(t *testing.T) {
 	if err != nil {
 		t.Fatalf("dial beta: %v", err)
 	}
-	rmB := ctrl.RegisterMessage{Type: "register", WorkerID: "wB", WorkerName: "Beta", Models: []string{"llama3:8b", "qwen2.5:14b"}, MaxConcurrency: 1}
+	rmB := ctrl.RegisterMessage{Type: "register", WorkerID: "wB", WorkerName: "Beta", Models: []string{"llama3:8b", "qwen2.5:14b"}, MaxConcurrency: 1, EmbeddingBatchSize: 0}
 	b, _ = json.Marshal(rmB)
 	if err := connB.Write(ctx, websocket.MessageText, b); err != nil {
 		t.Fatalf("write beta: %v", err)

--- a/test/e2e_prune_test.go
+++ b/test/e2e_prune_test.go
@@ -32,7 +32,7 @@ func TestHeartbeatPrune(t *testing.T) {
 		t.Fatalf("dial: %v", err)
 	}
 	defer func() { _ = conn.Close(websocket.StatusNormalClosure, "") }()
-	regMsg := ctrl.RegisterMessage{Type: "register", WorkerID: "w1", ClientKey: "secret", Models: []string{"m"}, MaxConcurrency: 1}
+	regMsg := ctrl.RegisterMessage{Type: "register", WorkerID: "w1", ClientKey: "secret", Models: []string{"m"}, MaxConcurrency: 1, EmbeddingBatchSize: 0}
 	b, _ := json.Marshal(regMsg)
 	if err := conn.Write(ctx, websocket.MessageText, b); err != nil {
 		t.Fatalf("write: %v", err)


### PR DESCRIPTION
## Summary
- allow infero-llm to set an ideal embedding batch size via flag, env var and config
- send embedding batch size to the server and surface it in worker metrics and state APIs
- show embedding batch size on `/state` dashboard and document new parameter

## Testing
- `make lint`
- `make build`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68a9e17d7cf0832c9d9b590cbd115e3f