### PR TITLE
feat: parallelize embedding dispatch

### DIFF
--- a/README.md
+++ b/README.md
@@ -611,7 +611,7 @@ For manual end-to-end verification on a clean VM, see [desktop/windows/ACCEPTANC
 | Feature | Supported | Notes |
 | --- | --- | --- |
 | OpenAI-compatible `POST /api/v1/chat/completions` | ✅ | Proxied to workers without payload mutation |
-| OpenAI-compatible `POST /api/v1/embeddings` | ✅ | Requests with large input arrays are split across workers respecting each worker's ideal embedding batch size |
+| OpenAI-compatible `POST /api/v1/embeddings` | ✅ | Requests with large input arrays are split and processed in parallel across workers respecting each worker's ideal embedding batch size |
 | Multiple worker registration | ✅ | Workers can join/leave dynamically; models registered on connect |
 | Model-based routing (least-busy) | ✅ | `LeastBusyScheduler` selects worker by current load |
 | Model alias fallback | ✅ | Falls back to base model when exact quantization not available |

--- a/doc/env.md
+++ b/doc/env.md
@@ -27,6 +27,7 @@ The server optionally reads settings from a YAML config file. Defaults:
 | `DRAIN_TIMEOUT` | — | time to wait for in-flight requests on shutdown | `5m` | `--drain-timeout` |
 | `ALLOWED_ORIGINS` | — | comma separated list of allowed CORS origins | unset (deny all) | `--allowed-origins` |
 | `REDIS_ADDR` | `redis_addr` | Redis connection URL for server state (e.g. `redis://:pass@host:6379/0`, `redis-sentinel://host:26379/mymaster`) | unset | `--redis-addr` |
+| `MAX_PARALLEL_EMBEDDINGS` | `max_parallel_embeddings` | maximum number of workers to split embeddings across | `8` | `--max-parallel-embeddings` |
 | `BROKER_MAX_REQ_BYTES` | — | maximum MCP request size in bytes | `10485760` | — |
 | `BROKER_MAX_RESP_BYTES` | — | maximum MCP response size in bytes | `10485760` | — |
 | `BROKER_WS_HEARTBEAT_MS` | — | MCP WebSocket heartbeat interval in milliseconds | `15000` | — |

--- a/examples/config/server.yaml
+++ b/examples/config/server.yaml
@@ -6,5 +6,6 @@ metrics_addr: ":8080"        # Prometheus metrics listen address
 # client_key: ""             # shared key clients must present when registering
 request_timeout: 120s         # request timeout without worker activity
 drain_timeout: 5m             # wait time for in-flight requests on shutdown
+# max_parallel_embeddings: 8  # maximum number of workers to split embeddings across
 # allowed_origins: []         # comma separated list of allowed CORS origins
 # redis_addr: redis://127.0.0.1:6379/0  # redis connection URL for server state

--- a/internal/api/impl.go
+++ b/internal/api/impl.go
@@ -15,12 +15,13 @@ type HealthChecker interface {
 }
 
 type API struct {
-	Reg     *ctrl.Registry
-	Metrics *ctrl.MetricsRegistry
-	MCP     *mcp.Registry
-	Sched   ctrl.Scheduler
-	Timeout time.Duration
-	Health  HealthChecker
+	Reg                   *ctrl.Registry
+	Metrics               *ctrl.MetricsRegistry
+	MCP                   *mcp.Registry
+	Sched                 ctrl.Scheduler
+	Timeout               time.Duration
+	MaxParallelEmbeddings int
+	Health                HealthChecker
 }
 
 var _ generated.ServerInterface = (*API)(nil)
@@ -42,7 +43,7 @@ func (a *API) PostApiV1ChatCompletions(w http.ResponseWriter, r *http.Request) {
 }
 
 func (a *API) PostApiV1Embeddings(w http.ResponseWriter, r *http.Request) {
-	EmbeddingsHandler(a.Reg, a.Sched, a.Metrics, a.Timeout)(w, r)
+	EmbeddingsHandler(a.Reg, a.Sched, a.Metrics, a.Timeout, a.MaxParallelEmbeddings)(w, r)
 }
 
 func (a *API) GetApiV1Models(w http.ResponseWriter, r *http.Request) {

--- a/internal/config/server.go
+++ b/internal/config/server.go
@@ -13,16 +13,17 @@ import (
 
 // ServerConfig holds configuration for the infero server.
 type ServerConfig struct {
-	Port           int
-	MetricsAddr    string
-	APIKey         string
-	ClientKey      string
-	RequestTimeout time.Duration
-	DrainTimeout   time.Duration
-	AllowedOrigins []string
-	ConfigFile     string
-	LogLevel       string
-	RedisAddr      string
+	Port                  int
+	MetricsAddr           string
+	APIKey                string
+	ClientKey             string
+	RequestTimeout        time.Duration
+	DrainTimeout          time.Duration
+	AllowedOrigins        []string
+	ConfigFile            string
+	LogLevel              string
+	RedisAddr             string
+	MaxParallelEmbeddings int
 }
 
 // BindFlags populates the struct with defaults from environment variables and
@@ -45,6 +46,11 @@ func (c *ServerConfig) BindFlags() {
 	c.APIKey = getEnv("API_KEY", "")
 	c.ClientKey = getEnv("CLIENT_KEY", "")
 	c.RedisAddr = getEnv("REDIS_ADDR", "")
+	if v, err := strconv.Atoi(getEnv("MAX_PARALLEL_EMBEDDINGS", "8")); err == nil {
+		c.MaxParallelEmbeddings = v
+	} else {
+		c.MaxParallelEmbeddings = 8
+	}
 	if v, err := strconv.ParseFloat(getEnv("REQUEST_TIMEOUT", "120"), 64); err == nil {
 		c.RequestTimeout = time.Duration(v * float64(time.Second))
 	} else {
@@ -64,6 +70,7 @@ func (c *ServerConfig) BindFlags() {
 	flag.StringVar(&c.APIKey, "api-key", c.APIKey, "client API key required for HTTP requests; leave empty to disable auth")
 	flag.StringVar(&c.ClientKey, "client-key", c.ClientKey, "shared key clients must present when registering")
 	flag.StringVar(&c.RedisAddr, "redis-addr", c.RedisAddr, "redis connection URL for server state")
+	flag.IntVar(&c.MaxParallelEmbeddings, "max-parallel-embeddings", c.MaxParallelEmbeddings, "maximum number of workers to split embeddings across")
 	flag.Func("request-timeout", "request timeout in seconds without worker activity", func(v string) error {
 		f, err := strconv.ParseFloat(v, 64)
 		if err != nil {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -30,7 +30,7 @@ func New(reg *ctrl.Registry, metrics *ctrl.MetricsRegistry, sched ctrl.Scheduler
 		r.Use(m)
 	}
 
-	impl := &api.API{Reg: reg, Metrics: metrics, MCP: mcpReg, Sched: sched, Timeout: cfg.RequestTimeout}
+	impl := &api.API{Reg: reg, Metrics: metrics, MCP: mcpReg, Sched: sched, Timeout: cfg.RequestTimeout, MaxParallelEmbeddings: cfg.MaxParallelEmbeddings}
 	wrapper := generated.ServerInterfaceWrapper{Handler: impl}
 
 	r.Route("/api/client", func(r chi.Router) {


### PR DESCRIPTION
## Summary
- parallelize embedding batches across workers with single-slot concurrency and retry support
- add MAX_PARALLEL_EMBEDDINGS config to limit per-request worker usage
- document new embedding parallelism and configuration

## Testing
- `golangci-lint run` *(fails: command not found)*
- `go build ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68a9f23e2814832cb2c53d45118b2e48