### PR TITLE
feat: add plugin scaffolding

### DIFF
--- a/cmd/nfrx/main.go
+++ b/cmd/nfrx/main.go
@@ -21,6 +21,7 @@ import (
 	"github.com/gaspardpetit/nfrx/internal/logx"
 	mcpbroker "github.com/gaspardpetit/nfrx/internal/mcpbroker"
 	"github.com/gaspardpetit/nfrx/internal/metrics"
+	"github.com/gaspardpetit/nfrx/internal/plugin"
 	"github.com/gaspardpetit/nfrx/internal/server"
 	"github.com/gaspardpetit/nfrx/internal/serverstate"
 )
@@ -75,7 +76,9 @@ func main() {
 	metrics.SetServerBuildInfo(version, buildSHA, buildDate)
 	sched := &ctrlsrv.LeastBusyScheduler{Reg: reg}
 	mcpReg := mcpbroker.NewRegistry(cfg.RequestTimeout)
-	handler := server.New(reg, metricsReg, sched, mcpReg, cfg)
+	stateReg := serverstate.NewRegistry()
+	plugins := []plugin.Plugin{}
+	handler := server.New(reg, metricsReg, sched, mcpReg, cfg, stateReg, plugins)
 	srv := &http.Server{Addr: fmt.Sprintf(":%d", cfg.Port), Handler: handler}
 	var metricsSrv *http.Server
 	if cfg.MetricsAddr != fmt.Sprintf(":%d", cfg.Port) {

--- a/internal/plugin/plugin.go
+++ b/internal/plugin/plugin.go
@@ -1,0 +1,69 @@
+package plugin
+
+import (
+	"github.com/go-chi/chi/v5"
+	"github.com/prometheus/client_golang/prometheus"
+
+	ctrlsrv "github.com/gaspardpetit/nfrx/internal/ctrlsrv"
+	"github.com/gaspardpetit/nfrx/internal/serverstate"
+)
+
+// Plugin is implemented by all plugins.
+type Plugin interface {
+	ID() string
+	RegisterRoutes(r chi.Router)
+	RegisterMetrics(reg *prometheus.Registry)
+	RegisterState(reg *serverstate.Registry)
+}
+
+// WorkerProvider is implemented by plugins that handle load-balanced workers.
+type WorkerProvider interface {
+	RegisterWebSocket(r chi.Router)
+	Scheduler() ctrlsrv.Scheduler
+}
+
+// RelayProvider is implemented by plugins that manage client relays.
+type RelayProvider interface {
+	RegisterRelayEndpoints(r chi.Router)
+}
+
+// Context groups common facilities passed to plugins.
+type Context struct {
+	Router  chi.Router
+	Metrics *prometheus.Registry
+	State   *serverstate.Registry
+}
+
+// Registry holds loaded plugins and their optional capabilities.
+type Registry struct {
+	plugins []Plugin
+	workers []WorkerProvider
+	relays  []RelayProvider
+}
+
+// Load initializes plugins and returns a Registry describing their capabilities.
+func Load(ctx Context, plugins []Plugin) *Registry {
+	reg := &Registry{}
+	for _, p := range plugins {
+		p.RegisterRoutes(ctx.Router)
+		p.RegisterMetrics(ctx.Metrics)
+		p.RegisterState(ctx.State)
+		reg.plugins = append(reg.plugins, p)
+		if wp, ok := p.(WorkerProvider); ok {
+			reg.workers = append(reg.workers, wp)
+		}
+		if rp, ok := p.(RelayProvider); ok {
+			reg.relays = append(reg.relays, rp)
+		}
+	}
+	return reg
+}
+
+// Plugins returns all loaded plugins.
+func (r *Registry) Plugins() []Plugin { return r.plugins }
+
+// WorkerProviders returns plugins that implement WorkerProvider.
+func (r *Registry) WorkerProviders() []WorkerProvider { return r.workers }
+
+// RelayProviders returns plugins that implement RelayProvider.
+func (r *Registry) RelayProviders() []RelayProvider { return r.relays }

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -10,6 +10,8 @@ import (
 	"github.com/gaspardpetit/nfrx/internal/config"
 	ctrlsrv "github.com/gaspardpetit/nfrx/internal/ctrlsrv"
 	mcpbroker "github.com/gaspardpetit/nfrx/internal/mcpbroker"
+	"github.com/gaspardpetit/nfrx/internal/plugin"
+	"github.com/gaspardpetit/nfrx/internal/serverstate"
 )
 
 func TestMetricsEndpointDefaultPort(t *testing.T) {
@@ -17,7 +19,8 @@ func TestMetricsEndpointDefaultPort(t *testing.T) {
 	metricsReg := ctrlsrv.NewMetricsRegistry("test", "", "")
 	sched := &ctrlsrv.LeastBusyScheduler{Reg: reg}
 	cfg := config.ServerConfig{Port: 8080, MetricsAddr: ":8080", RequestTimeout: time.Second}
-	h := New(reg, metricsReg, sched, mcpbroker.NewRegistry(time.Second), cfg)
+	stateReg := serverstate.NewRegistry()
+	h := New(reg, metricsReg, sched, mcpbroker.NewRegistry(time.Second), cfg, stateReg, []plugin.Plugin{})
 	ts := httptest.NewServer(h)
 	defer ts.Close()
 
@@ -35,7 +38,8 @@ func TestMetricsEndpointSeparatePort(t *testing.T) {
 	metricsReg := ctrlsrv.NewMetricsRegistry("test", "", "")
 	sched := &ctrlsrv.LeastBusyScheduler{Reg: reg}
 	cfg := config.ServerConfig{Port: 8080, MetricsAddr: ":9090", RequestTimeout: time.Second}
-	h := New(reg, metricsReg, sched, mcpbroker.NewRegistry(time.Second), cfg)
+	stateReg := serverstate.NewRegistry()
+	h := New(reg, metricsReg, sched, mcpbroker.NewRegistry(time.Second), cfg, stateReg, []plugin.Plugin{})
 	ts := httptest.NewServer(h)
 	defer ts.Close()
 
@@ -53,7 +57,8 @@ func TestStatePage(t *testing.T) {
 	metricsReg := ctrlsrv.NewMetricsRegistry("test", "", "")
 	sched := &ctrlsrv.LeastBusyScheduler{Reg: reg}
 	cfg := config.ServerConfig{Port: 8080, RequestTimeout: time.Second}
-	h := New(reg, metricsReg, sched, mcpbroker.NewRegistry(time.Second), cfg)
+	stateReg := serverstate.NewRegistry()
+	h := New(reg, metricsReg, sched, mcpbroker.NewRegistry(time.Second), cfg, stateReg, []plugin.Plugin{})
 	ts := httptest.NewServer(h)
 	defer ts.Close()
 
@@ -75,7 +80,8 @@ func TestCORSAllowedOrigins(t *testing.T) {
 	metricsReg := ctrlsrv.NewMetricsRegistry("test", "", "")
 	sched := &ctrlsrv.LeastBusyScheduler{Reg: reg}
 	cfg := config.ServerConfig{Port: 8080, RequestTimeout: time.Second, AllowedOrigins: []string{"https://example.com"}}
-	h := New(reg, metricsReg, sched, mcpbroker.NewRegistry(time.Second), cfg)
+	stateReg := serverstate.NewRegistry()
+	h := New(reg, metricsReg, sched, mcpbroker.NewRegistry(time.Second), cfg, stateReg, []plugin.Plugin{})
 	ts := httptest.NewServer(h)
 	defer ts.Close()
 

--- a/internal/serverstate/registry.go
+++ b/internal/serverstate/registry.go
@@ -1,0 +1,39 @@
+package serverstate
+
+import "sync"
+
+// Element represents a plugin-contributed state element.
+type Element struct {
+	ID   string
+	Data func() interface{}
+	HTML func() string
+}
+
+// Registry collects state elements provided by plugins.
+type Registry struct {
+	mu      sync.RWMutex
+	entries map[string]Element
+}
+
+// NewRegistry returns a new empty Registry.
+func NewRegistry() *Registry {
+	return &Registry{entries: make(map[string]Element)}
+}
+
+// Add registers a new state element.
+func (r *Registry) Add(e Element) {
+	r.mu.Lock()
+	r.entries[e.ID] = e
+	r.mu.Unlock()
+}
+
+// Elements returns all registered state elements.
+func (r *Registry) Elements() []Element {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	res := make([]Element, 0, len(r.entries))
+	for _, e := range r.entries {
+		res = append(res, e)
+	}
+	return res
+}

--- a/test/e2e_api_key_test.go
+++ b/test/e2e_api_key_test.go
@@ -9,7 +9,9 @@ import (
 	"github.com/gaspardpetit/nfrx/internal/config"
 	ctrlsrv "github.com/gaspardpetit/nfrx/internal/ctrlsrv"
 	mcpbroker "github.com/gaspardpetit/nfrx/internal/mcpbroker"
+	"github.com/gaspardpetit/nfrx/internal/plugin"
 	"github.com/gaspardpetit/nfrx/internal/server"
+	"github.com/gaspardpetit/nfrx/internal/serverstate"
 )
 
 func TestAPIKeyEnforcement(t *testing.T) {
@@ -17,7 +19,8 @@ func TestAPIKeyEnforcement(t *testing.T) {
 	sched := &ctrlsrv.LeastBusyScheduler{Reg: reg}
 	cfg := config.ServerConfig{APIKey: "test123", RequestTimeout: 5 * time.Second}
 	metricsReg := ctrlsrv.NewMetricsRegistry("test", "", "")
-	handler := server.New(reg, metricsReg, sched, mcpbroker.NewRegistry(cfg.RequestTimeout), cfg)
+	stateReg := serverstate.NewRegistry()
+	handler := server.New(reg, metricsReg, sched, mcpbroker.NewRegistry(cfg.RequestTimeout), cfg, stateReg, []plugin.Plugin{})
 	srv := httptest.NewServer(handler)
 	defer srv.Close()
 

--- a/test/e2e_auth_test.go
+++ b/test/e2e_auth_test.go
@@ -15,7 +15,9 @@ import (
 	ctrl "github.com/gaspardpetit/nfrx/internal/ctrl"
 	ctrlsrv "github.com/gaspardpetit/nfrx/internal/ctrlsrv"
 	mcpbroker "github.com/gaspardpetit/nfrx/internal/mcpbroker"
+	"github.com/gaspardpetit/nfrx/internal/plugin"
 	"github.com/gaspardpetit/nfrx/internal/server"
+	"github.com/gaspardpetit/nfrx/internal/serverstate"
 )
 
 func TestWorkerAuth(t *testing.T) {
@@ -23,7 +25,8 @@ func TestWorkerAuth(t *testing.T) {
 	sched := &ctrlsrv.LeastBusyScheduler{Reg: reg}
 	cfg := config.ServerConfig{ClientKey: "secret", RequestTimeout: 5 * time.Second}
 	metricsReg := ctrlsrv.NewMetricsRegistry("test", "", "")
-	handler := server.New(reg, metricsReg, sched, mcpbroker.NewRegistry(cfg.RequestTimeout), cfg)
+	stateReg := serverstate.NewRegistry()
+	handler := server.New(reg, metricsReg, sched, mcpbroker.NewRegistry(cfg.RequestTimeout), cfg, stateReg, []plugin.Plugin{})
 	srv := httptest.NewServer(handler)
 	defer srv.Close()
 
@@ -87,7 +90,8 @@ func TestWorkerClientKeyUnexpected(t *testing.T) {
 	sched := &ctrlsrv.LeastBusyScheduler{Reg: reg}
 	cfg := config.ServerConfig{RequestTimeout: 5 * time.Second}
 	metricsReg := ctrlsrv.NewMetricsRegistry("test", "", "")
-	handler := server.New(reg, metricsReg, sched, mcpbroker.NewRegistry(cfg.RequestTimeout), cfg)
+	stateReg := serverstate.NewRegistry()
+	handler := server.New(reg, metricsReg, sched, mcpbroker.NewRegistry(cfg.RequestTimeout), cfg, stateReg, []plugin.Plugin{})
 	srv := httptest.NewServer(handler)
 	defer srv.Close()
 
@@ -114,7 +118,8 @@ func TestMCPAuth(t *testing.T) {
 	cfg := config.ServerConfig{ClientKey: "secret", RequestTimeout: 5 * time.Second}
 	metricsReg := ctrlsrv.NewMetricsRegistry("test", "", "")
 	mcpReg := mcpbroker.NewRegistry(cfg.RequestTimeout)
-	handler := server.New(reg, metricsReg, sched, mcpReg, cfg)
+	stateReg := serverstate.NewRegistry()
+	handler := server.New(reg, metricsReg, sched, mcpReg, cfg, stateReg, []plugin.Plugin{})
 	srv := httptest.NewServer(handler)
 	defer srv.Close()
 
@@ -153,7 +158,8 @@ func TestMCPAuth(t *testing.T) {
 
 	// unexpected key when server has none
 	cfg = config.ServerConfig{RequestTimeout: 5 * time.Second}
-	handler = server.New(reg, metricsReg, sched, mcpReg, cfg)
+	stateReg = serverstate.NewRegistry()
+	handler = server.New(reg, metricsReg, sched, mcpReg, cfg, stateReg, []plugin.Plugin{})
 	srv2 := httptest.NewServer(handler)
 	defer srv2.Close()
 	wsURL2 := strings.Replace(srv2.URL, "http", "ws", 1) + "/api/mcp/connect"

--- a/test/e2e_chat_completions_proxy_test.go
+++ b/test/e2e_chat_completions_proxy_test.go
@@ -15,7 +15,9 @@ import (
 	"github.com/gaspardpetit/nfrx/internal/config"
 	ctrlsrv "github.com/gaspardpetit/nfrx/internal/ctrlsrv"
 	mcpbroker "github.com/gaspardpetit/nfrx/internal/mcpbroker"
+	"github.com/gaspardpetit/nfrx/internal/plugin"
 	"github.com/gaspardpetit/nfrx/internal/server"
+	"github.com/gaspardpetit/nfrx/internal/serverstate"
 	"github.com/gaspardpetit/nfrx/internal/worker"
 	"sync/atomic"
 )
@@ -25,7 +27,8 @@ func TestE2EChatCompletionsProxy(t *testing.T) {
 	sched := &ctrlsrv.LeastBusyScheduler{Reg: reg}
 	cfg := config.ServerConfig{ClientKey: "secret", APIKey: "apikey", RequestTimeout: 5 * time.Second}
 	metricsReg := ctrlsrv.NewMetricsRegistry("test", "", "")
-	handler := server.New(reg, metricsReg, sched, mcpbroker.NewRegistry(cfg.RequestTimeout), cfg)
+	stateReg := serverstate.NewRegistry()
+	handler := server.New(reg, metricsReg, sched, mcpbroker.NewRegistry(cfg.RequestTimeout), cfg, stateReg, []plugin.Plugin{})
 	srv := httptest.NewServer(handler)
 	defer srv.Close()
 

--- a/test/e2e_embeddings_proxy_test.go
+++ b/test/e2e_embeddings_proxy_test.go
@@ -15,7 +15,9 @@ import (
 	"github.com/gaspardpetit/nfrx/internal/config"
 	ctrlsrv "github.com/gaspardpetit/nfrx/internal/ctrlsrv"
 	mcpbroker "github.com/gaspardpetit/nfrx/internal/mcpbroker"
+	"github.com/gaspardpetit/nfrx/internal/plugin"
 	"github.com/gaspardpetit/nfrx/internal/server"
+	"github.com/gaspardpetit/nfrx/internal/serverstate"
 	"github.com/gaspardpetit/nfrx/internal/worker"
 )
 
@@ -24,7 +26,8 @@ func TestE2EEmbeddingsProxy(t *testing.T) {
 	sched := &ctrlsrv.LeastBusyScheduler{Reg: reg}
 	cfg := config.ServerConfig{ClientKey: "secret", APIKey: "apikey", RequestTimeout: 5 * time.Second}
 	metricsReg := ctrlsrv.NewMetricsRegistry("test", "", "")
-	handler := server.New(reg, metricsReg, sched, mcpbroker.NewRegistry(cfg.RequestTimeout), cfg)
+	stateReg := serverstate.NewRegistry()
+	handler := server.New(reg, metricsReg, sched, mcpbroker.NewRegistry(cfg.RequestTimeout), cfg, stateReg, []plugin.Plugin{})
 	srv := httptest.NewServer(handler)
 	defer srv.Close()
 

--- a/test/e2e_model_update_test.go
+++ b/test/e2e_model_update_test.go
@@ -15,7 +15,9 @@ import (
 	ctrl "github.com/gaspardpetit/nfrx/internal/ctrl"
 	ctrlsrv "github.com/gaspardpetit/nfrx/internal/ctrlsrv"
 	mcpbroker "github.com/gaspardpetit/nfrx/internal/mcpbroker"
+	"github.com/gaspardpetit/nfrx/internal/plugin"
 	"github.com/gaspardpetit/nfrx/internal/server"
+	"github.com/gaspardpetit/nfrx/internal/serverstate"
 )
 
 func TestWorkerModelRefresh(t *testing.T) {
@@ -23,7 +25,8 @@ func TestWorkerModelRefresh(t *testing.T) {
 	sched := &ctrlsrv.LeastBusyScheduler{Reg: reg}
 	cfg := config.ServerConfig{RequestTimeout: 5 * time.Second}
 	metricsReg := ctrlsrv.NewMetricsRegistry("test", "", "")
-	handler := server.New(reg, metricsReg, sched, mcpbroker.NewRegistry(cfg.RequestTimeout), cfg)
+	stateReg := serverstate.NewRegistry()
+	handler := server.New(reg, metricsReg, sched, mcpbroker.NewRegistry(cfg.RequestTimeout), cfg, stateReg, []plugin.Plugin{})
 	srv := httptest.NewServer(handler)
 	defer srv.Close()
 

--- a/test/e2e_models_api_test.go
+++ b/test/e2e_models_api_test.go
@@ -15,7 +15,9 @@ import (
 	ctrl "github.com/gaspardpetit/nfrx/internal/ctrl"
 	ctrlsrv "github.com/gaspardpetit/nfrx/internal/ctrlsrv"
 	mcpbroker "github.com/gaspardpetit/nfrx/internal/mcpbroker"
+	"github.com/gaspardpetit/nfrx/internal/plugin"
 	"github.com/gaspardpetit/nfrx/internal/server"
+	"github.com/gaspardpetit/nfrx/internal/serverstate"
 )
 
 func TestModelsAPI(t *testing.T) {
@@ -23,7 +25,8 @@ func TestModelsAPI(t *testing.T) {
 	sched := &ctrlsrv.LeastBusyScheduler{Reg: reg}
 	cfg := config.ServerConfig{RequestTimeout: 5 * time.Second}
 	metricsReg := ctrlsrv.NewMetricsRegistry("test", "", "")
-	handler := server.New(reg, metricsReg, sched, mcpbroker.NewRegistry(cfg.RequestTimeout), cfg)
+	stateReg := serverstate.NewRegistry()
+	handler := server.New(reg, metricsReg, sched, mcpbroker.NewRegistry(cfg.RequestTimeout), cfg, stateReg, []plugin.Plugin{})
 	srv := httptest.NewServer(handler)
 	defer srv.Close()
 

--- a/test/e2e_prune_test.go
+++ b/test/e2e_prune_test.go
@@ -14,7 +14,9 @@ import (
 	ctrl "github.com/gaspardpetit/nfrx/internal/ctrl"
 	ctrlsrv "github.com/gaspardpetit/nfrx/internal/ctrlsrv"
 	mcpbroker "github.com/gaspardpetit/nfrx/internal/mcpbroker"
+	"github.com/gaspardpetit/nfrx/internal/plugin"
 	"github.com/gaspardpetit/nfrx/internal/server"
+	"github.com/gaspardpetit/nfrx/internal/serverstate"
 )
 
 func TestHeartbeatPrune(t *testing.T) {
@@ -22,7 +24,8 @@ func TestHeartbeatPrune(t *testing.T) {
 	sched := &ctrlsrv.LeastBusyScheduler{Reg: reg}
 	cfg := config.ServerConfig{ClientKey: "secret", RequestTimeout: 5 * time.Second}
 	metricsReg := ctrlsrv.NewMetricsRegistry("test", "", "")
-	handler := server.New(reg, metricsReg, sched, mcpbroker.NewRegistry(cfg.RequestTimeout), cfg)
+	stateReg := serverstate.NewRegistry()
+	handler := server.New(reg, metricsReg, sched, mcpbroker.NewRegistry(cfg.RequestTimeout), cfg, stateReg, []plugin.Plugin{})
 	srv := httptest.NewServer(handler)
 	defer srv.Close()
 


### PR DESCRIPTION
## Summary
- add plugin interfaces, context, and registry for optional capabilities
- introduce server state registry for plugin-contributed elements
- wire plugin loading into server startup with empty plugin list

## Testing
- `make lint`
- `make build`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68ac6b502ac0832ca4d91acd36c4ac07