### PR TITLE
refactor: add llm plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ You may then choose to expose an LLM provider, an MCP server and/or a RAG system
 
 ```bash
 docker run --rm \
-  -e SERVER_URL="wss://${MY_SERVER_ADDR}/api/llm/connect" \
+  -e SERVER_URL="wss://${MY_SERVER_ADDR}/api/workers/connect" \
   -e CLIENT_KEY="${MY_CLIENT_KEY}" \
   -e COMPLETION_BASE_URL="http://host.docker.internal:11434/v1" \
   ghcr.io/gaspardpetit/nfrx-llm:main
@@ -68,7 +68,7 @@ docker run --rm \
 ##### Bare (Linux)
 
 ```bash
-SERVER_URL="wss://${MY_SERVER_ADDR}/api/llm/connect" \
+SERVER_URL="wss://${MY_SERVER_ADDR}/api/workers/connect" \
 CLIENT_KEY="${MY_CLIENT_KEY}" \
 COMPLETION_BASE_URL="http://127.0.0.1:11434/v1" \
 nfrx-llm   # or: go run ./cmd/nfrx-llm

--- a/internal/llmplugin/llmplugin.go
+++ b/internal/llmplugin/llmplugin.go
@@ -1,0 +1,103 @@
+package llmplugin
+
+import (
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/gaspardpetit/nfrx/api/generated"
+	"github.com/gaspardpetit/nfrx/internal/api"
+	"github.com/gaspardpetit/nfrx/internal/config"
+	ctrlsrv "github.com/gaspardpetit/nfrx/internal/ctrlsrv"
+	mcpbroker "github.com/gaspardpetit/nfrx/internal/mcpbroker"
+	"github.com/gaspardpetit/nfrx/internal/metrics"
+	"github.com/gaspardpetit/nfrx/internal/plugin"
+	"github.com/gaspardpetit/nfrx/internal/serverstate"
+)
+
+// Plugin implements the llm subsystem as a plugin.
+type Plugin struct {
+	cfg     config.ServerConfig
+	version string
+	sha     string
+	date    string
+
+	reg     *ctrlsrv.Registry
+	metrics *ctrlsrv.MetricsRegistry
+	sched   ctrlsrv.Scheduler
+	mcp     *mcpbroker.Registry
+}
+
+// New constructs a new LLM plugin.
+func New(cfg config.ServerConfig, version, sha, date string, mcp *mcpbroker.Registry) *Plugin {
+	reg := ctrlsrv.NewRegistry()
+	metricsReg := ctrlsrv.NewMetricsRegistry(version, sha, date)
+	sched := &ctrlsrv.LeastBusyScheduler{Reg: reg}
+	return &Plugin{cfg: cfg, version: version, sha: sha, date: date, reg: reg, metrics: metricsReg, sched: sched, mcp: mcp}
+}
+
+func (p *Plugin) ID() string { return "llm" }
+
+// RegisterRoutes wires the HTTP endpoints.
+func (p *Plugin) RegisterRoutes(r chi.Router) {
+	impl := &api.API{Reg: p.reg, Metrics: p.metrics, MCP: p.mcp, Sched: p.sched, Timeout: p.cfg.RequestTimeout, MaxParallelEmbeddings: p.cfg.MaxParallelEmbeddings}
+	wrapper := generated.ServerInterfaceWrapper{Handler: impl}
+
+	r.Get("/healthz", wrapper.GetHealthz)
+	r.Route("/api", func(apiGroup chi.Router) {
+		if p.cfg.APIKey != "" {
+			apiGroup.Use(api.APIKeyMiddleware(p.cfg.APIKey))
+		}
+		apiGroup.Route("/v1", func(v1 chi.Router) {
+			v1.Post("/chat/completions", wrapper.PostApiV1ChatCompletions)
+			v1.Post("/embeddings", wrapper.PostApiV1Embeddings)
+			v1.Get("/models", wrapper.GetApiV1Models)
+			v1.Get("/models/{id}", wrapper.GetApiV1ModelsId)
+		})
+		apiGroup.Get("/state", wrapper.GetApiState)
+		apiGroup.Get("/state/stream", wrapper.GetApiStateStream)
+	})
+	r.Route("/api/client", func(r chi.Router) {
+		r.Get("/openapi.json", api.OpenAPIHandler())
+		r.Get("/*", api.SwaggerHandler())
+	})
+
+	go func() {
+		ticker := time.NewTicker(ctrlsrv.HeartbeatInterval)
+		for range ticker.C {
+			p.reg.PruneExpired(ctrlsrv.HeartbeatExpiry)
+		}
+	}()
+}
+
+// RegisterWebSocket attaches the worker connect endpoint.
+func (p *Plugin) RegisterWebSocket(r chi.Router) {
+	r.Handle("/api/workers/connect", ctrlsrv.WSHandler(p.reg, p.metrics, p.cfg.ClientKey))
+}
+
+// Scheduler returns the plugin's scheduler.
+func (p *Plugin) Scheduler() ctrlsrv.Scheduler { return p.sched }
+
+// RegisterMetrics registers Prometheus collectors.
+func (p *Plugin) RegisterMetrics(reg *prometheus.Registry) {
+	metrics.Register(reg)
+	metrics.SetServerBuildInfo(p.version, p.sha, p.date)
+}
+
+// RegisterState registers state elements.
+func (p *Plugin) RegisterState(reg *serverstate.Registry) {
+	reg.Add(serverstate.Element{ID: "llm", Data: func() interface{} { return p.metrics.Snapshot() }})
+}
+
+// Registry exposes the worker registry for tests.
+func (p *Plugin) Registry() *ctrlsrv.Registry { return p.reg }
+
+// MetricsRegistry exposes metrics for tests.
+func (p *Plugin) MetricsRegistry() *ctrlsrv.MetricsRegistry { return p.metrics }
+
+// Sched exposes scheduler for tests.
+func (p *Plugin) Sched() ctrlsrv.Scheduler { return p.sched }
+
+var _ plugin.Plugin = (*Plugin)(nil)
+var _ plugin.WorkerProvider = (*Plugin)(nil)

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -3,24 +3,21 @@ package server
 import (
 	"fmt"
 	"net/http"
-	"time"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/cors"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 
-	"github.com/gaspardpetit/nfrx/api/generated"
 	"github.com/gaspardpetit/nfrx/internal/api"
 	"github.com/gaspardpetit/nfrx/internal/config"
-	ctrlsrv "github.com/gaspardpetit/nfrx/internal/ctrlsrv"
 	mcpbroker "github.com/gaspardpetit/nfrx/internal/mcpbroker"
 	"github.com/gaspardpetit/nfrx/internal/plugin"
 	"github.com/gaspardpetit/nfrx/internal/serverstate"
 )
 
 // New constructs the HTTP handler for the server.
-func New(reg *ctrlsrv.Registry, metrics *ctrlsrv.MetricsRegistry, sched ctrlsrv.Scheduler, mcpReg *mcpbroker.Registry, cfg config.ServerConfig, stateReg *serverstate.Registry, plugins []plugin.Plugin) http.Handler {
+func New(mcpReg *mcpbroker.Registry, cfg config.ServerConfig, stateReg *serverstate.Registry, plugins []plugin.Plugin) http.Handler {
 	r := chi.NewRouter()
 	if len(cfg.AllowedOrigins) > 0 {
 		r.Use(cors.Handler(cors.Options{
@@ -36,51 +33,23 @@ func New(reg *ctrlsrv.Registry, metrics *ctrlsrv.MetricsRegistry, sched ctrlsrv.
 	if stateReg == nil {
 		stateReg = serverstate.NewRegistry()
 	}
-	preg, _ := prometheus.DefaultRegisterer.(*prometheus.Registry)
-	plugin.Load(plugin.Context{Router: r, Metrics: preg, State: stateReg}, plugins)
+	preg := prometheus.NewRegistry()
+	prometheus.DefaultRegisterer = preg
+	prometheus.DefaultGatherer = preg
+	pregistry := plugin.Load(plugin.Context{Router: r, Metrics: preg, State: stateReg}, plugins)
+	for _, wp := range pregistry.WorkerProviders() {
+		wp.RegisterWebSocket(r)
+	}
 
-	impl := &api.API{Reg: reg, Metrics: metrics, MCP: mcpReg, Sched: sched, Timeout: cfg.RequestTimeout, MaxParallelEmbeddings: cfg.MaxParallelEmbeddings}
-	wrapper := generated.ServerInterfaceWrapper{Handler: impl}
-
-	r.Route("/api/client", func(r chi.Router) {
-		r.Get("/openapi.json", api.OpenAPIHandler())
-		r.Get("/*", api.SwaggerHandler())
-	})
-
-	r.Group(func(public chi.Router) {
-		public.Get("/healthz", wrapper.GetHealthz)
-		public.Get("/state", StateHandler())
-	})
-
-	r.Route("/api", func(apiGroup chi.Router) {
-		if cfg.APIKey != "" {
-			apiGroup.Use(api.APIKeyMiddleware(cfg.APIKey))
-		}
-		apiGroup.Route("/v1", func(v1 chi.Router) {
-			v1.Post("/chat/completions", wrapper.PostApiV1ChatCompletions)
-			v1.Post("/embeddings", wrapper.PostApiV1Embeddings)
-			v1.Get("/models", wrapper.GetApiV1Models)
-			v1.Get("/models/{id}", wrapper.GetApiV1ModelsId)
-		})
-		apiGroup.Get("/state", wrapper.GetApiState)
-		apiGroup.Get("/state/stream", wrapper.GetApiStateStream)
-	})
+	r.Get("/state", StateHandler())
 	if mcpReg != nil {
 		r.Post("/api/mcp/id/{id}", mcpReg.HTTPHandler())
 		r.Handle("/api/mcp/connect", mcpReg.WSHandler(cfg.ClientKey))
 	}
-	r.Handle("/api/workers/connect", ctrlsrv.WSHandler(reg, metrics, cfg.ClientKey))
 
 	if cfg.MetricsAddr == fmt.Sprintf(":%d", cfg.Port) {
-		r.Handle("/metrics", promhttp.Handler())
+		r.Handle("/metrics", promhttp.HandlerFor(preg, promhttp.HandlerOpts{}))
 	}
-
-	go func() {
-		ticker := time.NewTicker(ctrlsrv.HeartbeatInterval)
-		for range ticker.C {
-			reg.PruneExpired(ctrlsrv.HeartbeatExpiry)
-		}
-	}()
 
 	return r
 }

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -8,19 +8,18 @@ import (
 	"time"
 
 	"github.com/gaspardpetit/nfrx/internal/config"
-	ctrlsrv "github.com/gaspardpetit/nfrx/internal/ctrlsrv"
+	llmplugin "github.com/gaspardpetit/nfrx/internal/llmplugin"
 	mcpbroker "github.com/gaspardpetit/nfrx/internal/mcpbroker"
 	"github.com/gaspardpetit/nfrx/internal/plugin"
 	"github.com/gaspardpetit/nfrx/internal/serverstate"
 )
 
 func TestMetricsEndpointDefaultPort(t *testing.T) {
-	reg := ctrlsrv.NewRegistry()
-	metricsReg := ctrlsrv.NewMetricsRegistry("test", "", "")
-	sched := &ctrlsrv.LeastBusyScheduler{Reg: reg}
 	cfg := config.ServerConfig{Port: 8080, MetricsAddr: ":8080", RequestTimeout: time.Second}
+	mcpReg := mcpbroker.NewRegistry(time.Second)
 	stateReg := serverstate.NewRegistry()
-	h := New(reg, metricsReg, sched, mcpbroker.NewRegistry(time.Second), cfg, stateReg, []plugin.Plugin{})
+	llm := llmplugin.New(cfg, "test", "", "", mcpReg)
+	h := New(mcpReg, cfg, stateReg, []plugin.Plugin{llm})
 	ts := httptest.NewServer(h)
 	defer ts.Close()
 
@@ -34,12 +33,11 @@ func TestMetricsEndpointDefaultPort(t *testing.T) {
 }
 
 func TestMetricsEndpointSeparatePort(t *testing.T) {
-	reg := ctrlsrv.NewRegistry()
-	metricsReg := ctrlsrv.NewMetricsRegistry("test", "", "")
-	sched := &ctrlsrv.LeastBusyScheduler{Reg: reg}
 	cfg := config.ServerConfig{Port: 8080, MetricsAddr: ":9090", RequestTimeout: time.Second}
+	mcpReg := mcpbroker.NewRegistry(time.Second)
 	stateReg := serverstate.NewRegistry()
-	h := New(reg, metricsReg, sched, mcpbroker.NewRegistry(time.Second), cfg, stateReg, []plugin.Plugin{})
+	llm := llmplugin.New(cfg, "test", "", "", mcpReg)
+	h := New(mcpReg, cfg, stateReg, []plugin.Plugin{llm})
 	ts := httptest.NewServer(h)
 	defer ts.Close()
 
@@ -53,12 +51,11 @@ func TestMetricsEndpointSeparatePort(t *testing.T) {
 }
 
 func TestStatePage(t *testing.T) {
-	reg := ctrlsrv.NewRegistry()
-	metricsReg := ctrlsrv.NewMetricsRegistry("test", "", "")
-	sched := &ctrlsrv.LeastBusyScheduler{Reg: reg}
 	cfg := config.ServerConfig{Port: 8080, RequestTimeout: time.Second}
+	mcpReg := mcpbroker.NewRegistry(time.Second)
 	stateReg := serverstate.NewRegistry()
-	h := New(reg, metricsReg, sched, mcpbroker.NewRegistry(time.Second), cfg, stateReg, []plugin.Plugin{})
+	llm := llmplugin.New(cfg, "test", "", "", mcpReg)
+	h := New(mcpReg, cfg, stateReg, []plugin.Plugin{llm})
 	ts := httptest.NewServer(h)
 	defer ts.Close()
 
@@ -76,12 +73,11 @@ func TestStatePage(t *testing.T) {
 }
 
 func TestCORSAllowedOrigins(t *testing.T) {
-	reg := ctrlsrv.NewRegistry()
-	metricsReg := ctrlsrv.NewMetricsRegistry("test", "", "")
-	sched := &ctrlsrv.LeastBusyScheduler{Reg: reg}
 	cfg := config.ServerConfig{Port: 8080, RequestTimeout: time.Second, AllowedOrigins: []string{"https://example.com"}}
+	mcpReg := mcpbroker.NewRegistry(time.Second)
 	stateReg := serverstate.NewRegistry()
-	h := New(reg, metricsReg, sched, mcpbroker.NewRegistry(time.Second), cfg, stateReg, []plugin.Plugin{})
+	llm := llmplugin.New(cfg, "test", "", "", mcpReg)
+	h := New(mcpReg, cfg, stateReg, []plugin.Plugin{llm})
 	ts := httptest.NewServer(h)
 	defer ts.Close()
 

--- a/test/e2e_api_key_test.go
+++ b/test/e2e_api_key_test.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	"github.com/gaspardpetit/nfrx/internal/config"
-	ctrlsrv "github.com/gaspardpetit/nfrx/internal/ctrlsrv"
+	llmplugin "github.com/gaspardpetit/nfrx/internal/llmplugin"
 	mcpbroker "github.com/gaspardpetit/nfrx/internal/mcpbroker"
 	"github.com/gaspardpetit/nfrx/internal/plugin"
 	"github.com/gaspardpetit/nfrx/internal/server"
@@ -15,12 +15,11 @@ import (
 )
 
 func TestAPIKeyEnforcement(t *testing.T) {
-	reg := ctrlsrv.NewRegistry()
-	sched := &ctrlsrv.LeastBusyScheduler{Reg: reg}
 	cfg := config.ServerConfig{APIKey: "test123", RequestTimeout: 5 * time.Second}
-	metricsReg := ctrlsrv.NewMetricsRegistry("test", "", "")
+	mcpReg := mcpbroker.NewRegistry(cfg.RequestTimeout)
 	stateReg := serverstate.NewRegistry()
-	handler := server.New(reg, metricsReg, sched, mcpbroker.NewRegistry(cfg.RequestTimeout), cfg, stateReg, []plugin.Plugin{})
+	llm := llmplugin.New(cfg, "test", "", "", mcpReg)
+	handler := server.New(mcpReg, cfg, stateReg, []plugin.Plugin{llm})
 	srv := httptest.NewServer(handler)
 	defer srv.Close()
 

--- a/test/e2e_embeddings_proxy_test.go
+++ b/test/e2e_embeddings_proxy_test.go
@@ -13,7 +13,7 @@ import (
 	"time"
 
 	"github.com/gaspardpetit/nfrx/internal/config"
-	ctrlsrv "github.com/gaspardpetit/nfrx/internal/ctrlsrv"
+	llmplugin "github.com/gaspardpetit/nfrx/internal/llmplugin"
 	mcpbroker "github.com/gaspardpetit/nfrx/internal/mcpbroker"
 	"github.com/gaspardpetit/nfrx/internal/plugin"
 	"github.com/gaspardpetit/nfrx/internal/server"
@@ -22,12 +22,11 @@ import (
 )
 
 func TestE2EEmbeddingsProxy(t *testing.T) {
-	reg := ctrlsrv.NewRegistry()
-	sched := &ctrlsrv.LeastBusyScheduler{Reg: reg}
 	cfg := config.ServerConfig{ClientKey: "secret", APIKey: "apikey", RequestTimeout: 5 * time.Second}
-	metricsReg := ctrlsrv.NewMetricsRegistry("test", "", "")
+	mcpReg := mcpbroker.NewRegistry(cfg.RequestTimeout)
 	stateReg := serverstate.NewRegistry()
-	handler := server.New(reg, metricsReg, sched, mcpbroker.NewRegistry(cfg.RequestTimeout), cfg, stateReg, []plugin.Plugin{})
+	llm := llmplugin.New(cfg, "test", "", "", mcpReg)
+	handler := server.New(mcpReg, cfg, stateReg, []plugin.Plugin{llm})
 	srv := httptest.NewServer(handler)
 	defer srv.Close()
 

--- a/test/e2e_model_update_test.go
+++ b/test/e2e_model_update_test.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/gaspardpetit/nfrx/internal/config"
 	ctrl "github.com/gaspardpetit/nfrx/internal/ctrl"
-	ctrlsrv "github.com/gaspardpetit/nfrx/internal/ctrlsrv"
+	llmplugin "github.com/gaspardpetit/nfrx/internal/llmplugin"
 	mcpbroker "github.com/gaspardpetit/nfrx/internal/mcpbroker"
 	"github.com/gaspardpetit/nfrx/internal/plugin"
 	"github.com/gaspardpetit/nfrx/internal/server"
@@ -21,12 +21,11 @@ import (
 )
 
 func TestWorkerModelRefresh(t *testing.T) {
-	reg := ctrlsrv.NewRegistry()
-	sched := &ctrlsrv.LeastBusyScheduler{Reg: reg}
 	cfg := config.ServerConfig{RequestTimeout: 5 * time.Second}
-	metricsReg := ctrlsrv.NewMetricsRegistry("test", "", "")
+	mcpReg := mcpbroker.NewRegistry(cfg.RequestTimeout)
 	stateReg := serverstate.NewRegistry()
-	handler := server.New(reg, metricsReg, sched, mcpbroker.NewRegistry(cfg.RequestTimeout), cfg, stateReg, []plugin.Plugin{})
+	llm := llmplugin.New(cfg, "test", "", "", mcpReg)
+	handler := server.New(mcpReg, cfg, stateReg, []plugin.Plugin{llm})
 	srv := httptest.NewServer(handler)
 	defer srv.Close()
 

--- a/test/e2e_models_api_test.go
+++ b/test/e2e_models_api_test.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/gaspardpetit/nfrx/internal/config"
 	ctrl "github.com/gaspardpetit/nfrx/internal/ctrl"
-	ctrlsrv "github.com/gaspardpetit/nfrx/internal/ctrlsrv"
+	llmplugin "github.com/gaspardpetit/nfrx/internal/llmplugin"
 	mcpbroker "github.com/gaspardpetit/nfrx/internal/mcpbroker"
 	"github.com/gaspardpetit/nfrx/internal/plugin"
 	"github.com/gaspardpetit/nfrx/internal/server"
@@ -21,12 +21,11 @@ import (
 )
 
 func TestModelsAPI(t *testing.T) {
-	reg := ctrlsrv.NewRegistry()
-	sched := &ctrlsrv.LeastBusyScheduler{Reg: reg}
 	cfg := config.ServerConfig{RequestTimeout: 5 * time.Second}
-	metricsReg := ctrlsrv.NewMetricsRegistry("test", "", "")
+	mcpReg := mcpbroker.NewRegistry(cfg.RequestTimeout)
 	stateReg := serverstate.NewRegistry()
-	handler := server.New(reg, metricsReg, sched, mcpbroker.NewRegistry(cfg.RequestTimeout), cfg, stateReg, []plugin.Plugin{})
+	llm := llmplugin.New(cfg, "test", "", "", mcpReg)
+	handler := server.New(mcpReg, cfg, stateReg, []plugin.Plugin{llm})
 	srv := httptest.NewServer(handler)
 	defer srv.Close()
 


### PR DESCRIPTION
## Summary
- add llmplugin implementing Plugin and WorkerProvider interfaces
- load llm plugin in main and server, routing endpoints and websockets through plugin registry
- refresh docs to use /api/workers/connect

## Testing
- `make lint`
- `make build`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68ac728774f0832c9e99cfc71c8b560c