### PR TITLE
feat: pluginize MCP relay

### DIFF
--- a/cmd/nfrx/main.go
+++ b/cmd/nfrx/main.go
@@ -18,7 +18,7 @@ import (
 	"github.com/gaspardpetit/nfrx/internal/config"
 	llmplugin "github.com/gaspardpetit/nfrx/internal/llmplugin"
 	"github.com/gaspardpetit/nfrx/internal/logx"
-	mcpbroker "github.com/gaspardpetit/nfrx/internal/mcpbroker"
+	mcpplugin "github.com/gaspardpetit/nfrx/internal/mcpplugin"
 	"github.com/gaspardpetit/nfrx/internal/plugin"
 	"github.com/gaspardpetit/nfrx/internal/server"
 	"github.com/gaspardpetit/nfrx/internal/serverstate"
@@ -68,11 +68,11 @@ func main() {
 		logx.Log.Info().Str("addr", cfg.RedisAddr).Msg("using redis state store")
 	}
 
-	mcpReg := mcpbroker.NewRegistry(cfg.RequestTimeout)
+	mcp := mcpplugin.New(cfg)
 	stateReg := serverstate.NewRegistry()
-	llm := llmplugin.New(cfg, version, buildSHA, buildDate, mcpReg)
-	plugins := []plugin.Plugin{llm}
-	handler := server.New(mcpReg, cfg, stateReg, plugins)
+	llm := llmplugin.New(cfg, version, buildSHA, buildDate, mcp.Registry())
+	plugins := []plugin.Plugin{mcp, llm}
+	handler := server.New(cfg, stateReg, plugins)
 	srv := &http.Server{Addr: fmt.Sprintf(":%d", cfg.Port), Handler: handler}
 	var metricsSrv *http.Server
 	if cfg.MetricsAddr != fmt.Sprintf(":%d", cfg.Port) {

--- a/internal/mcpplugin/mcpplugin.go
+++ b/internal/mcpplugin/mcpplugin.go
@@ -1,0 +1,48 @@
+package mcpplugin
+
+import (
+	"github.com/go-chi/chi/v5"
+	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/gaspardpetit/nfrx/internal/config"
+	mcpbroker "github.com/gaspardpetit/nfrx/internal/mcpbroker"
+	"github.com/gaspardpetit/nfrx/internal/plugin"
+	"github.com/gaspardpetit/nfrx/internal/serverstate"
+)
+
+// Plugin implements the MCP relay as a plugin.
+type Plugin struct {
+	cfg    config.ServerConfig
+	broker *mcpbroker.Registry
+}
+
+// New constructs a new MCP plugin.
+func New(cfg config.ServerConfig) *Plugin {
+	reg := mcpbroker.NewRegistry(cfg.RequestTimeout)
+	return &Plugin{cfg: cfg, broker: reg}
+}
+
+func (p *Plugin) ID() string { return "mcp" }
+
+// RegisterRoutes registers HTTP routes; MCP uses relay endpoints only.
+func (p *Plugin) RegisterRoutes(r chi.Router) {}
+
+// RegisterMetrics registers Prometheus collectors; MCP has none currently.
+func (p *Plugin) RegisterMetrics(reg *prometheus.Registry) {}
+
+// RegisterState registers MCP state elements.
+func (p *Plugin) RegisterState(reg *serverstate.Registry) {
+	reg.Add(serverstate.Element{ID: "mcp", Data: func() interface{} { return p.broker.Snapshot() }})
+}
+
+// RegisterRelayEndpoints wires MCP relay HTTP/WS endpoints.
+func (p *Plugin) RegisterRelayEndpoints(r chi.Router) {
+	r.Handle("/api/mcp/connect", p.broker.WSHandler(p.cfg.ClientKey))
+	r.Post("/api/mcp/id/{id}", p.broker.HTTPHandler())
+}
+
+// Registry exposes the underlying broker for tests.
+func (p *Plugin) Registry() *mcpbroker.Registry { return p.broker }
+
+var _ plugin.Plugin = (*Plugin)(nil)
+var _ plugin.RelayProvider = (*Plugin)(nil)

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -9,17 +9,17 @@ import (
 
 	"github.com/gaspardpetit/nfrx/internal/config"
 	llmplugin "github.com/gaspardpetit/nfrx/internal/llmplugin"
-	mcpbroker "github.com/gaspardpetit/nfrx/internal/mcpbroker"
+	mcpplugin "github.com/gaspardpetit/nfrx/internal/mcpplugin"
 	"github.com/gaspardpetit/nfrx/internal/plugin"
 	"github.com/gaspardpetit/nfrx/internal/serverstate"
 )
 
 func TestMetricsEndpointDefaultPort(t *testing.T) {
 	cfg := config.ServerConfig{Port: 8080, MetricsAddr: ":8080", RequestTimeout: time.Second}
-	mcpReg := mcpbroker.NewRegistry(time.Second)
+	mcp := mcpplugin.New(cfg)
 	stateReg := serverstate.NewRegistry()
-	llm := llmplugin.New(cfg, "test", "", "", mcpReg)
-	h := New(mcpReg, cfg, stateReg, []plugin.Plugin{llm})
+	llm := llmplugin.New(cfg, "test", "", "", mcp.Registry())
+	h := New(cfg, stateReg, []plugin.Plugin{mcp, llm})
 	ts := httptest.NewServer(h)
 	defer ts.Close()
 
@@ -34,10 +34,10 @@ func TestMetricsEndpointDefaultPort(t *testing.T) {
 
 func TestMetricsEndpointSeparatePort(t *testing.T) {
 	cfg := config.ServerConfig{Port: 8080, MetricsAddr: ":9090", RequestTimeout: time.Second}
-	mcpReg := mcpbroker.NewRegistry(time.Second)
+	mcp := mcpplugin.New(cfg)
 	stateReg := serverstate.NewRegistry()
-	llm := llmplugin.New(cfg, "test", "", "", mcpReg)
-	h := New(mcpReg, cfg, stateReg, []plugin.Plugin{llm})
+	llm := llmplugin.New(cfg, "test", "", "", mcp.Registry())
+	h := New(cfg, stateReg, []plugin.Plugin{mcp, llm})
 	ts := httptest.NewServer(h)
 	defer ts.Close()
 
@@ -52,10 +52,10 @@ func TestMetricsEndpointSeparatePort(t *testing.T) {
 
 func TestStatePage(t *testing.T) {
 	cfg := config.ServerConfig{Port: 8080, RequestTimeout: time.Second}
-	mcpReg := mcpbroker.NewRegistry(time.Second)
+	mcp := mcpplugin.New(cfg)
 	stateReg := serverstate.NewRegistry()
-	llm := llmplugin.New(cfg, "test", "", "", mcpReg)
-	h := New(mcpReg, cfg, stateReg, []plugin.Plugin{llm})
+	llm := llmplugin.New(cfg, "test", "", "", mcp.Registry())
+	h := New(cfg, stateReg, []plugin.Plugin{mcp, llm})
 	ts := httptest.NewServer(h)
 	defer ts.Close()
 
@@ -74,10 +74,10 @@ func TestStatePage(t *testing.T) {
 
 func TestCORSAllowedOrigins(t *testing.T) {
 	cfg := config.ServerConfig{Port: 8080, RequestTimeout: time.Second, AllowedOrigins: []string{"https://example.com"}}
-	mcpReg := mcpbroker.NewRegistry(time.Second)
+	mcp := mcpplugin.New(cfg)
 	stateReg := serverstate.NewRegistry()
-	llm := llmplugin.New(cfg, "test", "", "", mcpReg)
-	h := New(mcpReg, cfg, stateReg, []plugin.Plugin{llm})
+	llm := llmplugin.New(cfg, "test", "", "", mcp.Registry())
+	h := New(cfg, stateReg, []plugin.Plugin{mcp, llm})
 	ts := httptest.NewServer(h)
 	defer ts.Close()
 

--- a/test/e2e_api_key_test.go
+++ b/test/e2e_api_key_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/gaspardpetit/nfrx/internal/config"
 	llmplugin "github.com/gaspardpetit/nfrx/internal/llmplugin"
-	mcpbroker "github.com/gaspardpetit/nfrx/internal/mcpbroker"
+	mcpplugin "github.com/gaspardpetit/nfrx/internal/mcpplugin"
 	"github.com/gaspardpetit/nfrx/internal/plugin"
 	"github.com/gaspardpetit/nfrx/internal/server"
 	"github.com/gaspardpetit/nfrx/internal/serverstate"
@@ -16,10 +16,10 @@ import (
 
 func TestAPIKeyEnforcement(t *testing.T) {
 	cfg := config.ServerConfig{APIKey: "test123", RequestTimeout: 5 * time.Second}
-	mcpReg := mcpbroker.NewRegistry(cfg.RequestTimeout)
+	mcp := mcpplugin.New(cfg)
 	stateReg := serverstate.NewRegistry()
-	llm := llmplugin.New(cfg, "test", "", "", mcpReg)
-	handler := server.New(mcpReg, cfg, stateReg, []plugin.Plugin{llm})
+	llm := llmplugin.New(cfg, "test", "", "", mcp.Registry())
+	handler := server.New(cfg, stateReg, []plugin.Plugin{mcp, llm})
 	srv := httptest.NewServer(handler)
 	defer srv.Close()
 

--- a/test/e2e_auth_test.go
+++ b/test/e2e_auth_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/gaspardpetit/nfrx/internal/config"
 	ctrl "github.com/gaspardpetit/nfrx/internal/ctrl"
 	llmplugin "github.com/gaspardpetit/nfrx/internal/llmplugin"
-	mcpbroker "github.com/gaspardpetit/nfrx/internal/mcpbroker"
+	mcpplugin "github.com/gaspardpetit/nfrx/internal/mcpplugin"
 	"github.com/gaspardpetit/nfrx/internal/plugin"
 	"github.com/gaspardpetit/nfrx/internal/server"
 	"github.com/gaspardpetit/nfrx/internal/serverstate"
@@ -22,10 +22,10 @@ import (
 
 func TestWorkerAuth(t *testing.T) {
 	cfg := config.ServerConfig{ClientKey: "secret", RequestTimeout: 5 * time.Second}
-	mcpReg := mcpbroker.NewRegistry(cfg.RequestTimeout)
+	mcp := mcpplugin.New(cfg)
 	stateReg := serverstate.NewRegistry()
-	llm := llmplugin.New(cfg, "test", "", "", mcpReg)
-	handler := server.New(mcpReg, cfg, stateReg, []plugin.Plugin{llm})
+	llm := llmplugin.New(cfg, "test", "", "", mcp.Registry())
+	handler := server.New(cfg, stateReg, []plugin.Plugin{mcp, llm})
 	srv := httptest.NewServer(handler)
 	defer srv.Close()
 
@@ -86,10 +86,10 @@ func TestWorkerAuth(t *testing.T) {
 
 func TestWorkerClientKeyUnexpected(t *testing.T) {
 	cfg := config.ServerConfig{RequestTimeout: 5 * time.Second}
-	mcpReg := mcpbroker.NewRegistry(cfg.RequestTimeout)
+	mcp := mcpplugin.New(cfg)
 	stateReg := serverstate.NewRegistry()
-	llm := llmplugin.New(cfg, "test", "", "", mcpReg)
-	handler := server.New(mcpReg, cfg, stateReg, []plugin.Plugin{llm})
+	llm := llmplugin.New(cfg, "test", "", "", mcp.Registry())
+	handler := server.New(cfg, stateReg, []plugin.Plugin{mcp, llm})
 	srv := httptest.NewServer(handler)
 	defer srv.Close()
 
@@ -112,10 +112,10 @@ func TestWorkerClientKeyUnexpected(t *testing.T) {
 
 func TestMCPAuth(t *testing.T) {
 	cfg := config.ServerConfig{ClientKey: "secret", RequestTimeout: 5 * time.Second}
-	mcpReg := mcpbroker.NewRegistry(cfg.RequestTimeout)
+	mcp := mcpplugin.New(cfg)
 	stateReg := serverstate.NewRegistry()
-	llm := llmplugin.New(cfg, "test", "", "", mcpReg)
-	handler := server.New(mcpReg, cfg, stateReg, []plugin.Plugin{llm})
+	llm := llmplugin.New(cfg, "test", "", "", mcp.Registry())
+	handler := server.New(cfg, stateReg, []plugin.Plugin{mcp, llm})
 	srv := httptest.NewServer(handler)
 	defer srv.Close()
 
@@ -154,9 +154,10 @@ func TestMCPAuth(t *testing.T) {
 
 	// unexpected key when server has none
 	cfg = config.ServerConfig{RequestTimeout: 5 * time.Second}
+	mcpReg := mcpplugin.New(cfg)
 	stateReg = serverstate.NewRegistry()
-	llm = llmplugin.New(cfg, "test", "", "", mcpReg)
-	handler = server.New(mcpReg, cfg, stateReg, []plugin.Plugin{llm})
+	llm = llmplugin.New(cfg, "test", "", "", mcpReg.Registry())
+	handler = server.New(cfg, stateReg, []plugin.Plugin{mcpReg, llm})
 	srv2 := httptest.NewServer(handler)
 	defer srv2.Close()
 	wsURL2 := strings.Replace(srv2.URL, "http", "ws", 1) + "/api/mcp/connect"

--- a/test/e2e_chat_completions_proxy_test.go
+++ b/test/e2e_chat_completions_proxy_test.go
@@ -14,7 +14,7 @@ import (
 
 	"github.com/gaspardpetit/nfrx/internal/config"
 	llmplugin "github.com/gaspardpetit/nfrx/internal/llmplugin"
-	mcpbroker "github.com/gaspardpetit/nfrx/internal/mcpbroker"
+	mcpplugin "github.com/gaspardpetit/nfrx/internal/mcpplugin"
 	"github.com/gaspardpetit/nfrx/internal/plugin"
 	"github.com/gaspardpetit/nfrx/internal/server"
 	"github.com/gaspardpetit/nfrx/internal/serverstate"
@@ -24,10 +24,10 @@ import (
 
 func TestE2EChatCompletionsProxy(t *testing.T) {
 	cfg := config.ServerConfig{ClientKey: "secret", APIKey: "apikey", RequestTimeout: 5 * time.Second}
-	mcpReg := mcpbroker.NewRegistry(cfg.RequestTimeout)
+	mcp := mcpplugin.New(cfg)
 	stateReg := serverstate.NewRegistry()
-	llm := llmplugin.New(cfg, "test", "", "", mcpReg)
-	handler := server.New(mcpReg, cfg, stateReg, []plugin.Plugin{llm})
+	llm := llmplugin.New(cfg, "test", "", "", mcp.Registry())
+	handler := server.New(cfg, stateReg, []plugin.Plugin{mcp, llm})
 	srv := httptest.NewServer(handler)
 	defer srv.Close()
 

--- a/test/e2e_embeddings_proxy_test.go
+++ b/test/e2e_embeddings_proxy_test.go
@@ -14,7 +14,7 @@ import (
 
 	"github.com/gaspardpetit/nfrx/internal/config"
 	llmplugin "github.com/gaspardpetit/nfrx/internal/llmplugin"
-	mcpbroker "github.com/gaspardpetit/nfrx/internal/mcpbroker"
+	mcpplugin "github.com/gaspardpetit/nfrx/internal/mcpplugin"
 	"github.com/gaspardpetit/nfrx/internal/plugin"
 	"github.com/gaspardpetit/nfrx/internal/server"
 	"github.com/gaspardpetit/nfrx/internal/serverstate"
@@ -23,10 +23,10 @@ import (
 
 func TestE2EEmbeddingsProxy(t *testing.T) {
 	cfg := config.ServerConfig{ClientKey: "secret", APIKey: "apikey", RequestTimeout: 5 * time.Second}
-	mcpReg := mcpbroker.NewRegistry(cfg.RequestTimeout)
+	mcp := mcpplugin.New(cfg)
 	stateReg := serverstate.NewRegistry()
-	llm := llmplugin.New(cfg, "test", "", "", mcpReg)
-	handler := server.New(mcpReg, cfg, stateReg, []plugin.Plugin{llm})
+	llm := llmplugin.New(cfg, "test", "", "", mcp.Registry())
+	handler := server.New(cfg, stateReg, []plugin.Plugin{mcp, llm})
 	srv := httptest.NewServer(handler)
 	defer srv.Close()
 

--- a/test/e2e_model_update_test.go
+++ b/test/e2e_model_update_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/gaspardpetit/nfrx/internal/config"
 	ctrl "github.com/gaspardpetit/nfrx/internal/ctrl"
 	llmplugin "github.com/gaspardpetit/nfrx/internal/llmplugin"
-	mcpbroker "github.com/gaspardpetit/nfrx/internal/mcpbroker"
+	mcpplugin "github.com/gaspardpetit/nfrx/internal/mcpplugin"
 	"github.com/gaspardpetit/nfrx/internal/plugin"
 	"github.com/gaspardpetit/nfrx/internal/server"
 	"github.com/gaspardpetit/nfrx/internal/serverstate"
@@ -22,10 +22,10 @@ import (
 
 func TestWorkerModelRefresh(t *testing.T) {
 	cfg := config.ServerConfig{RequestTimeout: 5 * time.Second}
-	mcpReg := mcpbroker.NewRegistry(cfg.RequestTimeout)
+	mcp := mcpplugin.New(cfg)
 	stateReg := serverstate.NewRegistry()
-	llm := llmplugin.New(cfg, "test", "", "", mcpReg)
-	handler := server.New(mcpReg, cfg, stateReg, []plugin.Plugin{llm})
+	llm := llmplugin.New(cfg, "test", "", "", mcp.Registry())
+	handler := server.New(cfg, stateReg, []plugin.Plugin{mcp, llm})
 	srv := httptest.NewServer(handler)
 	defer srv.Close()
 

--- a/test/e2e_models_api_test.go
+++ b/test/e2e_models_api_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/gaspardpetit/nfrx/internal/config"
 	ctrl "github.com/gaspardpetit/nfrx/internal/ctrl"
 	llmplugin "github.com/gaspardpetit/nfrx/internal/llmplugin"
-	mcpbroker "github.com/gaspardpetit/nfrx/internal/mcpbroker"
+	mcpplugin "github.com/gaspardpetit/nfrx/internal/mcpplugin"
 	"github.com/gaspardpetit/nfrx/internal/plugin"
 	"github.com/gaspardpetit/nfrx/internal/server"
 	"github.com/gaspardpetit/nfrx/internal/serverstate"
@@ -22,10 +22,10 @@ import (
 
 func TestModelsAPI(t *testing.T) {
 	cfg := config.ServerConfig{RequestTimeout: 5 * time.Second}
-	mcpReg := mcpbroker.NewRegistry(cfg.RequestTimeout)
+	mcp := mcpplugin.New(cfg)
 	stateReg := serverstate.NewRegistry()
-	llm := llmplugin.New(cfg, "test", "", "", mcpReg)
-	handler := server.New(mcpReg, cfg, stateReg, []plugin.Plugin{llm})
+	llm := llmplugin.New(cfg, "test", "", "", mcp.Registry())
+	handler := server.New(cfg, stateReg, []plugin.Plugin{mcp, llm})
 	srv := httptest.NewServer(handler)
 	defer srv.Close()
 

--- a/test/e2e_prune_test.go
+++ b/test/e2e_prune_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/gaspardpetit/nfrx/internal/config"
 	ctrl "github.com/gaspardpetit/nfrx/internal/ctrl"
 	llmplugin "github.com/gaspardpetit/nfrx/internal/llmplugin"
-	mcpbroker "github.com/gaspardpetit/nfrx/internal/mcpbroker"
+	mcpplugin "github.com/gaspardpetit/nfrx/internal/mcpplugin"
 	"github.com/gaspardpetit/nfrx/internal/plugin"
 	"github.com/gaspardpetit/nfrx/internal/server"
 	"github.com/gaspardpetit/nfrx/internal/serverstate"
@@ -21,10 +21,10 @@ import (
 
 func TestHeartbeatPrune(t *testing.T) {
 	cfg := config.ServerConfig{ClientKey: "secret", RequestTimeout: 5 * time.Second}
-	mcpReg := mcpbroker.NewRegistry(cfg.RequestTimeout)
+	mcp := mcpplugin.New(cfg)
 	stateReg := serverstate.NewRegistry()
-	llm := llmplugin.New(cfg, "test", "", "", mcpReg)
-	handler := server.New(mcpReg, cfg, stateReg, []plugin.Plugin{llm})
+	llm := llmplugin.New(cfg, "test", "", "", mcp.Registry())
+	handler := server.New(cfg, stateReg, []plugin.Plugin{mcp, llm})
 	srv := httptest.NewServer(handler)
 	defer srv.Close()
 


### PR DESCRIPTION
## Summary
- add MCP plugin implementing relay endpoints
- wire relay providers into server setup
- update server startup and tests for MCP plugin

## Testing
- `make lint`
- `make build`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68ac76afb788832c875375d1e6feefb8