### PR TITLE
server: add plugin config toggles

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ PORT=${MY_SERVER_PORT} CLIENT_KEY="${MY_CLIENT_KEY}" API_KEY="${MY_API_KEY}" \
 
 You may then choose to expose an LLM provider, an MCP server and/or a RAG system from private hardware behind a NAT/Firewall.
 
+Set `PLUGINS` to control which modules load (`llm` and/or `mcp`; defaults to both). For example, `PLUGINS=llm` disables the MCP relay.
+
 ### Expose a local LLM worker (Ollama shown)
 
 ##### Docker

--- a/doc/env.md
+++ b/doc/env.md
@@ -28,11 +28,14 @@ The server optionally reads settings from a YAML config file. Defaults:
 | `ALLOWED_ORIGINS` | — | comma separated list of allowed CORS origins | unset (deny all) | `--allowed-origins` |
 | `REDIS_ADDR` | `redis_addr` | Redis connection URL for server state (e.g. `redis://:pass@host:6379/0`, `redis-sentinel://host:26379/mymaster`) | unset | `--redis-addr` |
 | `MAX_PARALLEL_EMBEDDINGS` | `max_parallel_embeddings` | maximum number of workers to split embeddings across | `8` | `--max-parallel-embeddings` |
+| `PLUGINS` | `plugins` | comma separated list of plugins to enable (`llm`, `mcp`) | `llm,mcp` | `--plugins` |
 | `BROKER_MAX_REQ_BYTES` | — | maximum MCP request size in bytes | `10485760` | — |
 | `BROKER_MAX_RESP_BYTES` | — | maximum MCP response size in bytes | `10485760` | — |
 | `BROKER_WS_HEARTBEAT_MS` | — | MCP WebSocket heartbeat interval in milliseconds | `15000` | — |
 | `BROKER_WS_DEAD_AFTER_MS` | — | MCP WebSocket idle timeout in milliseconds | `45000` | — |
 | `BROKER_MAX_CONCURRENCY_PER_CLIENT` | — | maximum concurrent MCP sessions per client | `16` | — |
+
+Plugin-specific options can be supplied in YAML under `plugin_options.<plugin>.<key>` and are passed directly to that plugin.
 
 ## nfrx-llm
 

--- a/doc/server-endpoints.md
+++ b/doc/server-endpoints.md
@@ -23,6 +23,8 @@ The JSON snapshot includes `server.state` which reports `ready`, `not_ready`, or
 
 ## Inference API
 
+These endpoints are present when the `llm` plugin is enabled.
+
 ### Worker Registration
 
 | Verb & Endpoint | Parameters | Description | Auth |
@@ -39,6 +41,8 @@ The JSON snapshot includes `server.state` which reports `ready`, `not_ready`, or
 | `GET /api/v1/models/{id}` | Path `{id}` | Get model details. | API key |
 
 ## MCP API
+
+These endpoints are present when the `mcp` plugin is enabled.
 
 ### MCP Registration
 

--- a/internal/llmplugin/llmplugin.go
+++ b/internal/llmplugin/llmplugin.go
@@ -27,14 +27,15 @@ type Plugin struct {
 	metrics *ctrlsrv.MetricsRegistry
 	sched   ctrlsrv.Scheduler
 	mcp     *mcpbroker.Registry
+	opts    map[string]string
 }
 
 // New constructs a new LLM plugin.
-func New(cfg config.ServerConfig, version, sha, date string, mcp *mcpbroker.Registry) *Plugin {
+func New(cfg config.ServerConfig, version, sha, date string, mcp *mcpbroker.Registry, opts map[string]string) *Plugin {
 	reg := ctrlsrv.NewRegistry()
 	metricsReg := ctrlsrv.NewMetricsRegistry(version, sha, date)
 	sched := &ctrlsrv.LeastBusyScheduler{Reg: reg}
-	return &Plugin{cfg: cfg, version: version, sha: sha, date: date, reg: reg, metrics: metricsReg, sched: sched, mcp: mcp}
+	return &Plugin{cfg: cfg, version: version, sha: sha, date: date, reg: reg, metrics: metricsReg, sched: sched, mcp: mcp, opts: opts}
 }
 
 func (p *Plugin) ID() string { return "llm" }

--- a/internal/mcpplugin/mcpplugin.go
+++ b/internal/mcpplugin/mcpplugin.go
@@ -14,12 +14,13 @@ import (
 type Plugin struct {
 	cfg    config.ServerConfig
 	broker *mcpbroker.Registry
+	opts   map[string]string
 }
 
 // New constructs a new MCP plugin.
-func New(cfg config.ServerConfig) *Plugin {
+func New(cfg config.ServerConfig, opts map[string]string) *Plugin {
 	reg := mcpbroker.NewRegistry(cfg.RequestTimeout)
-	return &Plugin{cfg: cfg, broker: reg}
+	return &Plugin{cfg: cfg, broker: reg, opts: opts}
 }
 
 func (p *Plugin) ID() string { return "mcp" }

--- a/test/e2e_api_key_test.go
+++ b/test/e2e_api_key_test.go
@@ -16,9 +16,9 @@ import (
 
 func TestAPIKeyEnforcement(t *testing.T) {
 	cfg := config.ServerConfig{APIKey: "test123", RequestTimeout: 5 * time.Second}
-	mcp := mcpplugin.New(cfg)
+	mcp := mcpplugin.New(cfg, nil)
 	stateReg := serverstate.NewRegistry()
-	llm := llmplugin.New(cfg, "test", "", "", mcp.Registry())
+	llm := llmplugin.New(cfg, "test", "", "", mcp.Registry(), nil)
 	handler := server.New(cfg, stateReg, []plugin.Plugin{mcp, llm})
 	srv := httptest.NewServer(handler)
 	defer srv.Close()

--- a/test/e2e_auth_test.go
+++ b/test/e2e_auth_test.go
@@ -22,9 +22,9 @@ import (
 
 func TestWorkerAuth(t *testing.T) {
 	cfg := config.ServerConfig{ClientKey: "secret", RequestTimeout: 5 * time.Second}
-	mcp := mcpplugin.New(cfg)
+	mcp := mcpplugin.New(cfg, nil)
 	stateReg := serverstate.NewRegistry()
-	llm := llmplugin.New(cfg, "test", "", "", mcp.Registry())
+	llm := llmplugin.New(cfg, "test", "", "", mcp.Registry(), nil)
 	handler := server.New(cfg, stateReg, []plugin.Plugin{mcp, llm})
 	srv := httptest.NewServer(handler)
 	defer srv.Close()
@@ -86,9 +86,9 @@ func TestWorkerAuth(t *testing.T) {
 
 func TestWorkerClientKeyUnexpected(t *testing.T) {
 	cfg := config.ServerConfig{RequestTimeout: 5 * time.Second}
-	mcp := mcpplugin.New(cfg)
+	mcp := mcpplugin.New(cfg, nil)
 	stateReg := serverstate.NewRegistry()
-	llm := llmplugin.New(cfg, "test", "", "", mcp.Registry())
+	llm := llmplugin.New(cfg, "test", "", "", mcp.Registry(), nil)
 	handler := server.New(cfg, stateReg, []plugin.Plugin{mcp, llm})
 	srv := httptest.NewServer(handler)
 	defer srv.Close()
@@ -112,9 +112,9 @@ func TestWorkerClientKeyUnexpected(t *testing.T) {
 
 func TestMCPAuth(t *testing.T) {
 	cfg := config.ServerConfig{ClientKey: "secret", RequestTimeout: 5 * time.Second}
-	mcp := mcpplugin.New(cfg)
+	mcp := mcpplugin.New(cfg, nil)
 	stateReg := serverstate.NewRegistry()
-	llm := llmplugin.New(cfg, "test", "", "", mcp.Registry())
+	llm := llmplugin.New(cfg, "test", "", "", mcp.Registry(), nil)
 	handler := server.New(cfg, stateReg, []plugin.Plugin{mcp, llm})
 	srv := httptest.NewServer(handler)
 	defer srv.Close()
@@ -154,9 +154,9 @@ func TestMCPAuth(t *testing.T) {
 
 	// unexpected key when server has none
 	cfg = config.ServerConfig{RequestTimeout: 5 * time.Second}
-	mcpReg := mcpplugin.New(cfg)
+	mcpReg := mcpplugin.New(cfg, nil)
 	stateReg = serverstate.NewRegistry()
-	llm = llmplugin.New(cfg, "test", "", "", mcpReg.Registry())
+	llm = llmplugin.New(cfg, "test", "", "", mcpReg.Registry(), nil)
 	handler = server.New(cfg, stateReg, []plugin.Plugin{mcpReg, llm})
 	srv2 := httptest.NewServer(handler)
 	defer srv2.Close()

--- a/test/e2e_chat_completions_proxy_test.go
+++ b/test/e2e_chat_completions_proxy_test.go
@@ -24,9 +24,9 @@ import (
 
 func TestE2EChatCompletionsProxy(t *testing.T) {
 	cfg := config.ServerConfig{ClientKey: "secret", APIKey: "apikey", RequestTimeout: 5 * time.Second}
-	mcp := mcpplugin.New(cfg)
+	mcp := mcpplugin.New(cfg, nil)
 	stateReg := serverstate.NewRegistry()
-	llm := llmplugin.New(cfg, "test", "", "", mcp.Registry())
+	llm := llmplugin.New(cfg, "test", "", "", mcp.Registry(), nil)
 	handler := server.New(cfg, stateReg, []plugin.Plugin{mcp, llm})
 	srv := httptest.NewServer(handler)
 	defer srv.Close()

--- a/test/e2e_embeddings_proxy_test.go
+++ b/test/e2e_embeddings_proxy_test.go
@@ -23,9 +23,9 @@ import (
 
 func TestE2EEmbeddingsProxy(t *testing.T) {
 	cfg := config.ServerConfig{ClientKey: "secret", APIKey: "apikey", RequestTimeout: 5 * time.Second}
-	mcp := mcpplugin.New(cfg)
+	mcp := mcpplugin.New(cfg, nil)
 	stateReg := serverstate.NewRegistry()
-	llm := llmplugin.New(cfg, "test", "", "", mcp.Registry())
+	llm := llmplugin.New(cfg, "test", "", "", mcp.Registry(), nil)
 	handler := server.New(cfg, stateReg, []plugin.Plugin{mcp, llm})
 	srv := httptest.NewServer(handler)
 	defer srv.Close()

--- a/test/e2e_model_update_test.go
+++ b/test/e2e_model_update_test.go
@@ -22,9 +22,9 @@ import (
 
 func TestWorkerModelRefresh(t *testing.T) {
 	cfg := config.ServerConfig{RequestTimeout: 5 * time.Second}
-	mcp := mcpplugin.New(cfg)
+	mcp := mcpplugin.New(cfg, nil)
 	stateReg := serverstate.NewRegistry()
-	llm := llmplugin.New(cfg, "test", "", "", mcp.Registry())
+	llm := llmplugin.New(cfg, "test", "", "", mcp.Registry(), nil)
 	handler := server.New(cfg, stateReg, []plugin.Plugin{mcp, llm})
 	srv := httptest.NewServer(handler)
 	defer srv.Close()

--- a/test/e2e_models_api_test.go
+++ b/test/e2e_models_api_test.go
@@ -22,9 +22,9 @@ import (
 
 func TestModelsAPI(t *testing.T) {
 	cfg := config.ServerConfig{RequestTimeout: 5 * time.Second}
-	mcp := mcpplugin.New(cfg)
+	mcp := mcpplugin.New(cfg, nil)
 	stateReg := serverstate.NewRegistry()
-	llm := llmplugin.New(cfg, "test", "", "", mcp.Registry())
+	llm := llmplugin.New(cfg, "test", "", "", mcp.Registry(), nil)
 	handler := server.New(cfg, stateReg, []plugin.Plugin{mcp, llm})
 	srv := httptest.NewServer(handler)
 	defer srv.Close()

--- a/test/e2e_prune_test.go
+++ b/test/e2e_prune_test.go
@@ -21,9 +21,9 @@ import (
 
 func TestHeartbeatPrune(t *testing.T) {
 	cfg := config.ServerConfig{ClientKey: "secret", RequestTimeout: 5 * time.Second}
-	mcp := mcpplugin.New(cfg)
+	mcp := mcpplugin.New(cfg, nil)
 	stateReg := serverstate.NewRegistry()
-	llm := llmplugin.New(cfg, "test", "", "", mcp.Registry())
+	llm := llmplugin.New(cfg, "test", "", "", mcp.Registry(), nil)
 	handler := server.New(cfg, stateReg, []plugin.Plugin{mcp, llm})
 	srv := httptest.NewServer(handler)
 	defer srv.Close()


### PR DESCRIPTION
## Summary
- allow enabling or disabling plugins via new `PLUGINS` config key
- wire server startup to load only selected plugins and pass plugin-specific options
- document plugin configuration and clarify that inference and MCP endpoints depend on their plugins

## Testing
- `make lint`
- `make build`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68ac7d0f1750832c8cfbf54170213184