### PR TITLE
docs: add plugin templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,12 @@ A typical deployment looks like this:
 - **`nfrx-llm`** runs on private machines (e.g., a Mac Studio or personal GPU workstation) alongside an LLM service.
   When a worker connects, its available models are registered with the server and become accessible via the public API.
 
+## Developing Plugins
+
+nfrx exposes a small plugin interface so new modules can register routes,
+metrics and state. Skeleton implementations for worker-based and relay-based
+plugins live under [templates/](templates/).
+
 ## macOS Menu Bar App
 
 An early-stage macOS menu bar companion lives under `desktop/macos/nfrx/`. It polls `http://127.0.0.1:4555/status` every two seconds to display live worker status and can manage a per-user LaunchAgent to start or stop a local `nfrx-llm` and toggle launching at login. A simple preferences window lets you edit worker connection settings which are written to `~/Library/Application Support/nfrx/worker.yaml`, and the menu offers quick links to open the config and logs folders, view live logs, copy diagnostics to the Desktop, and check for updates via Sparkle.

--- a/templates/README.md
+++ b/templates/README.md
@@ -1,0 +1,10 @@
+# Plugin Templates
+
+These packages provide skeleton implementations of the plugin interfaces used
+by nfrx.  Copy and adapt them when authoring new modules:
+
+- `workerplugin`: starting point for load-balanced worker providers.
+- `relayplugin`: starting point for per-client relay providers.
+
+Each template compiles on its own and documents the methods that need to be
+filled out.

--- a/templates/relayplugin/README.md
+++ b/templates/relayplugin/README.md
@@ -1,0 +1,15 @@
+# Relay Plugin Template
+
+This package is a minimal scaffold for plugins that proxy requests to private
+per-client services (similar to the MCP relay).
+
+Steps to adapt:
+
+1. Change `ID()` to a unique identifier.
+2. Register HTTP routes in `RegisterRoutes`.
+3. Add Prometheus collectors via `RegisterMetrics`.
+4. Publish state elements in `RegisterState`.
+5. Expose per-client relay endpoints from `RegisterRelayEndpoints`.
+
+The server will automatically detect the `RelayProvider` capability when the
+plugin is loaded.

--- a/templates/relayplugin/relayplugin.go
+++ b/templates/relayplugin/relayplugin.go
@@ -1,0 +1,37 @@
+package relayplugin
+
+import (
+	"github.com/go-chi/chi/v5"
+	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/gaspardpetit/nfrx/internal/serverstate"
+)
+
+// Plugin is a minimal example implementing plugin.Plugin and plugin.RelayProvider.
+type Plugin struct{}
+
+// New returns a new instance of the plugin.
+func New() *Plugin { return &Plugin{} }
+
+// ID returns the plugin identifier.
+func (p *Plugin) ID() string { return "relay-template" }
+
+// RegisterRoutes installs HTTP routes served by this plugin.
+func (p *Plugin) RegisterRoutes(r chi.Router) {
+	// r.Post("/api/relay", p.handleRequest)
+}
+
+// RegisterMetrics adds Prometheus collectors.
+func (p *Plugin) RegisterMetrics(reg *prometheus.Registry) {
+	// reg.MustRegister(myCollector)
+}
+
+// RegisterState exposes values under /state.
+func (p *Plugin) RegisterState(reg *serverstate.Registry) {
+	// reg.Add("relay", serverstate.StringValue("ok"))
+}
+
+// RegisterRelayEndpoints attaches relay-specific routes.
+func (p *Plugin) RegisterRelayEndpoints(r chi.Router) {
+	// r.HandleFunc("/api/relay/connect", p.handleRelay)
+}

--- a/templates/workerplugin/README.md
+++ b/templates/workerplugin/README.md
@@ -1,0 +1,14 @@
+# Worker Plugin Template
+
+This package provides a starting point for plugins that expose load-balanced
+workers.  Copy the directory and implement your own logic:
+
+1. Update `ID()` with a unique identifier.
+2. Register any HTTP routes in `RegisterRoutes`.
+3. Add Prometheus collectors via `RegisterMetrics`.
+4. Publish state elements in `RegisterState`.
+5. Attach a worker WebSocket endpoint in `RegisterWebSocket`.
+6. Provide a scheduler that dispatches tasks in `Scheduler`.
+
+The server will automatically detect the `WorkerProvider` capability when the
+plugin is loaded.

--- a/templates/workerplugin/workerplugin.go
+++ b/templates/workerplugin/workerplugin.go
@@ -1,0 +1,44 @@
+package workerplugin
+
+import (
+	"github.com/go-chi/chi/v5"
+	"github.com/prometheus/client_golang/prometheus"
+
+	ctrlsrv "github.com/gaspardpetit/nfrx/internal/ctrlsrv"
+	"github.com/gaspardpetit/nfrx/internal/serverstate"
+)
+
+// Plugin is a minimal example implementing plugin.Plugin and plugin.WorkerProvider.
+type Plugin struct{}
+
+// New returns a new instance of the plugin.
+func New() *Plugin { return &Plugin{} }
+
+// ID returns the plugin identifier.
+func (p *Plugin) ID() string { return "worker-template" }
+
+// RegisterRoutes installs HTTP routes served by this plugin.
+func (p *Plugin) RegisterRoutes(r chi.Router) {
+	// r.Post("/api/example", p.handleRequest)
+}
+
+// RegisterMetrics adds Prometheus collectors.
+func (p *Plugin) RegisterMetrics(reg *prometheus.Registry) {
+	// reg.MustRegister(myCollector)
+}
+
+// RegisterState exposes values under /state.
+func (p *Plugin) RegisterState(reg *serverstate.Registry) {
+	// reg.Add("example", serverstate.StringValue("ok"))
+}
+
+// RegisterWebSocket registers the worker connect endpoint.
+func (p *Plugin) RegisterWebSocket(r chi.Router) {
+	// r.Get("/api/example/connect", p.handleConnect)
+}
+
+// Scheduler returns the dispatch scheduler for this plugin.
+func (p *Plugin) Scheduler() ctrlsrv.Scheduler {
+	// return myScheduler
+	return nil
+}


### PR DESCRIPTION
## Summary
- add skeleton workerplugin and relayplugin packages under templates/
- document plugin templates and expose section in README

## Testing
- `make lint`
- `make build`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68ad20f782b4832ca70bd31f1738f731