### PR TITLE
refactor: extract MCP client runner

### DIFF
--- a/cmd/nfrx-mcp/main.go
+++ b/cmd/nfrx-mcp/main.go
@@ -1,23 +1,17 @@
 package main
 
 import (
-	"bytes"
 	"context"
-	"encoding/json"
 	"errors"
 	"flag"
 	"fmt"
-	"io"
-	"net/http"
 	"os"
-	"strings"
-	"time"
+	"os/signal"
+	"syscall"
 
-	"github.com/coder/websocket"
 	"github.com/gaspardpetit/nfrx/internal/config"
 	"github.com/gaspardpetit/nfrx/internal/logx"
 	"github.com/gaspardpetit/nfrx/internal/mcp"
-	reconnect "github.com/gaspardpetit/nfrx/internal/reconnect"
 )
 
 var (
@@ -25,74 +19,6 @@ var (
 	buildSHA  = "unknown"
 	buildDate = "unknown"
 )
-
-func probeProvider(ctx context.Context, url string) error {
-	logx.Log.Debug().Str("url", url).Msg("probing mcp provider")
-	payload := map[string]any{
-		"jsonrpc": "2.0",
-		"id":      "1",
-		"method":  "tools/list",
-		"params":  map[string]any{},
-	}
-	body, err := json.Marshal(payload)
-	if err != nil {
-		return err
-	}
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
-	if err != nil {
-		return err
-	}
-	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("Accept", "application/json, text/event-stream")
-	resp, err := http.DefaultClient.Do(req)
-	if err != nil {
-		return err
-	}
-	defer func() { _ = resp.Body.Close() }()
-	logx.Log.Debug().Str("status", resp.Status).Msg("probe response")
-	if resp.StatusCode >= http.StatusBadRequest {
-		b, _ := io.ReadAll(resp.Body)
-		msg := strings.TrimSpace(string(b))
-		if msg != "" {
-			return fmt.Errorf("status %s: %s", resp.Status, msg)
-		}
-		return fmt.Errorf("status %s", resp.Status)
-	}
-	return nil
-}
-
-func monitorProvider(ctx context.Context, url string, shouldReconnect bool) {
-	attempt := 0
-	for {
-		logx.Log.Debug().Int("attempt", attempt).Str("url", url).Msg("checking mcp provider")
-		err := probeProvider(ctx, url)
-		if err != nil {
-			lvl := logx.Log.Warn()
-			if strings.Contains(err.Error(), "status 401") || strings.Contains(err.Error(), "status 403") {
-				lvl = logx.Log.Error()
-			}
-			lvl.Err(err).Msg("mcp provider unavailable; not_ready")
-			if !shouldReconnect {
-				return
-			}
-			delay := reconnect.Delay(attempt)
-			attempt++
-			select {
-			case <-ctx.Done():
-				return
-			case <-time.After(delay):
-			}
-			continue
-		}
-		logx.Log.Info().Msg("mcp provider ready")
-		attempt = 0
-		select {
-		case <-ctx.Done():
-			return
-		case <-time.After(20 * time.Second):
-		}
-	}
-}
 
 func main() {
 	showVersion := flag.Bool("version", false, "print version and exit")
@@ -110,81 +36,9 @@ func main() {
 	}
 	logx.Configure(cfg.LogLevel)
 
-	header := http.Header{}
-	reconnectFlag := cfg.Reconnect
-	metricsAddr := cfg.MetricsAddr
-	requestTimeout := cfg.RequestTimeout
-	wsURL := cfg.ServerURL
-	clientKey := cfg.ClientKey
-	clientID := cfg.ClientID
-	clientName := cfg.ClientName
-	providerURL := cfg.ProviderURL
-	authToken := cfg.AuthToken
-
-	if metricsAddr != "" {
-		if _, err := mcp.StartMetricsServer(context.Background(), metricsAddr); err != nil {
-			logx.Log.Fatal().Err(err).Msg("metrics server")
-		}
-		logx.Log.Info().Str("addr", metricsAddr).Msg("metrics server started")
-	}
-
-	attempt := 0
-	for {
-		ctx := context.Background()
-		conn, _, err := websocket.Dial(ctx, wsURL, &websocket.DialOptions{HTTPHeader: header})
-		if err != nil {
-			if !reconnectFlag {
-				logx.Log.Fatal().Err(err).Msg("dial broker")
-			}
-			delay := reconnect.Delay(attempt)
-			attempt++
-			logx.Log.Warn().Dur("backoff", delay).Err(err).Msg("dial broker failed; retrying")
-			time.Sleep(delay)
-			continue
-		}
-		reg := map[string]string{"id": clientID, "client_name": clientName}
-		if clientKey != "" {
-			reg["client_key"] = clientKey
-		}
-		b, _ := json.Marshal(reg)
-		if err := conn.Write(ctx, websocket.MessageText, b); err != nil {
-			_ = conn.Close(websocket.StatusInternalError, "closing")
-			logx.Log.Error().Err(err).Msg("register")
-			return
-		}
-		_, msg, err := conn.Read(ctx)
-		if err != nil {
-			_ = conn.Close(websocket.StatusInternalError, "closing")
-			logx.Log.Error().Err(err).Msg("register ack")
-			return
-		}
-		var ack struct {
-			ID string `json:"id"`
-		}
-		_ = json.Unmarshal(msg, &ack)
-		clientID = ack.ID
-		logx.Log.Info().Str("server", wsURL).Str("client_id", clientID).Str("client_name", clientName).Msg("connected to server")
-		attempt = 0
-
-		runCtx, cancel := context.WithCancel(ctx)
-		go monitorProvider(runCtx, providerURL, reconnectFlag)
-
-		relay := mcp.NewRelayClient(conn, providerURL, authToken, requestTimeout)
-		if err := relay.Run(runCtx); err != nil {
-			cancel()
-			_ = conn.Close(websocket.StatusInternalError, "closing")
-			if !reconnectFlag {
-				logx.Log.Error().Err(err).Msg("relay stopped")
-				return
-			}
-			delay := reconnect.Delay(attempt)
-			attempt++
-			logx.Log.Warn().Dur("backoff", delay).Err(err).Msg("relay stopped; reconnecting")
-			time.Sleep(delay)
-			continue
-		}
-		cancel()
-		_ = conn.Close(websocket.StatusNormalClosure, "closing")
-		return
+	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer cancel()
+	if err := mcp.Run(ctx, cfg); err != nil {
+		logx.Log.Fatal().Err(err).Msg("relay stopped")
 	}
 }

--- a/cmd/nfrx-mcp/main_test.go
+++ b/cmd/nfrx-mcp/main_test.go
@@ -6,6 +6,8 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+
+	"github.com/gaspardpetit/nfrx/internal/mcp"
 )
 
 func TestProbeProviderSetsAcceptHeader(t *testing.T) {
@@ -19,7 +21,7 @@ func TestProbeProviderSetsAcceptHeader(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	if err := probeProvider(context.Background(), srv.URL); err != nil {
+	if err := mcp.ProbeProvider(context.Background(), srv.URL); err != nil {
 		t.Fatalf("probeProvider returned error: %v", err)
 	}
 }
@@ -31,7 +33,7 @@ func TestProbeProviderReturnsBodyOnError(t *testing.T) {
 		_, _ = w.Write([]byte(msg))
 	}))
 	defer srv.Close()
-	err := probeProvider(context.Background(), srv.URL)
+	err := mcp.ProbeProvider(context.Background(), srv.URL)
 	if err == nil || !strings.Contains(err.Error(), msg) {
 		t.Fatalf("expected error containing %q got %v", msg, err)
 	}

--- a/internal/mcp/run.go
+++ b/internal/mcp/run.go
@@ -1,0 +1,188 @@
+package mcp
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/coder/websocket"
+
+	"github.com/gaspardpetit/nfrx/internal/config"
+	"github.com/gaspardpetit/nfrx/internal/logx"
+	reconnect "github.com/gaspardpetit/nfrx/internal/reconnect"
+)
+
+// Run starts the MCP relay client and blocks until the context is canceled or a
+// non-recoverable error occurs. It manages connection retries, provider
+// availability checks, and optional metrics.
+func Run(ctx context.Context, cfg config.MCPConfig) error {
+	if cfg.MetricsAddr != "" {
+		if _, err := StartMetricsServer(ctx, cfg.MetricsAddr); err != nil {
+			return err
+		}
+		logx.Log.Info().Str("addr", cfg.MetricsAddr).Msg("metrics server started")
+	}
+
+	attempt := 0
+	for {
+		conn, _, err := websocket.Dial(ctx, cfg.ServerURL, nil)
+		if err != nil {
+			if !cfg.Reconnect {
+				return err
+			}
+			delay := reconnect.Delay(attempt)
+			attempt++
+			logx.Log.Warn().Dur("backoff", delay).Err(err).Msg("dial broker failed; retrying")
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-time.After(delay):
+				continue
+			}
+		}
+
+		reg := map[string]string{"id": cfg.ClientID, "client_name": cfg.ClientName}
+		if cfg.ClientKey != "" {
+			reg["client_key"] = cfg.ClientKey
+		}
+		b, _ := json.Marshal(reg)
+		if err := conn.Write(ctx, websocket.MessageText, b); err != nil {
+			_ = conn.Close(websocket.StatusInternalError, "closing")
+			if !cfg.Reconnect {
+				return err
+			}
+			delay := reconnect.Delay(attempt)
+			attempt++
+			logx.Log.Warn().Dur("backoff", delay).Err(err).Msg("register failed; retrying")
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-time.After(delay):
+				continue
+			}
+		}
+
+		_, msg, err := conn.Read(ctx)
+		if err != nil {
+			_ = conn.Close(websocket.StatusInternalError, "closing")
+			if !cfg.Reconnect {
+				return err
+			}
+			delay := reconnect.Delay(attempt)
+			attempt++
+			logx.Log.Warn().Dur("backoff", delay).Err(err).Msg("register ack failed; retrying")
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-time.After(delay):
+				continue
+			}
+		}
+		var ack struct {
+			ID string `json:"id"`
+		}
+		_ = json.Unmarshal(msg, &ack)
+		cfg.ClientID = ack.ID
+		logx.Log.Info().Str("server", cfg.ServerURL).Str("client_id", cfg.ClientID).Str("client_name", cfg.ClientName).Msg("connected to server")
+		attempt = 0
+
+		runCtx, cancel := context.WithCancel(ctx)
+		go monitorProvider(runCtx, cfg.ProviderURL, cfg.Reconnect)
+
+		relay := NewRelayClient(conn, cfg.ProviderURL, cfg.AuthToken, cfg.RequestTimeout)
+		if err := relay.Run(runCtx); err != nil {
+			cancel()
+			_ = conn.Close(websocket.StatusInternalError, "closing")
+			if !cfg.Reconnect {
+				return err
+			}
+			delay := reconnect.Delay(attempt)
+			attempt++
+			logx.Log.Warn().Dur("backoff", delay).Err(err).Msg("relay stopped; reconnecting")
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-time.After(delay):
+				continue
+			}
+		}
+		cancel()
+		_ = conn.Close(websocket.StatusNormalClosure, "closing")
+		return nil
+	}
+}
+
+func monitorProvider(ctx context.Context, url string, shouldReconnect bool) {
+	attempt := 0
+	for {
+		logx.Log.Debug().Int("attempt", attempt).Str("url", url).Msg("checking mcp provider")
+		err := ProbeProvider(ctx, url)
+		if err != nil {
+			lvl := logx.Log.Warn()
+			if strings.Contains(err.Error(), "status 401") || strings.Contains(err.Error(), "status 403") {
+				lvl = logx.Log.Error()
+			}
+			lvl.Err(err).Msg("mcp provider unavailable; not_ready")
+			if !shouldReconnect {
+				return
+			}
+			delay := reconnect.Delay(attempt)
+			attempt++
+			select {
+			case <-ctx.Done():
+				return
+			case <-time.After(delay):
+			}
+			continue
+		}
+		logx.Log.Info().Msg("mcp provider ready")
+		attempt = 0
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(20 * time.Second):
+		}
+	}
+}
+
+// ProbeProvider checks if the MCP provider at the given URL responds to a basic
+// tools/list request.
+func ProbeProvider(ctx context.Context, url string) error {
+	logx.Log.Debug().Str("url", url).Msg("probing mcp provider")
+	payload := map[string]any{
+		"jsonrpc": "2.0",
+		"id":      "1",
+		"method":  "tools/list",
+		"params":  map[string]any{},
+	}
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json, text/event-stream")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	logx.Log.Debug().Str("status", resp.Status).Msg("probe response")
+	if resp.StatusCode >= http.StatusBadRequest {
+		b, _ := io.ReadAll(resp.Body)
+		msg := strings.TrimSpace(string(b))
+		if msg != "" {
+			return fmt.Errorf("status %s: %s", resp.Status, msg)
+		}
+		return fmt.Errorf("status %s", resp.Status)
+	}
+	return nil
+}


### PR DESCRIPTION
## Summary
- add reusable Run helper for MCP relay clients and move connection logic out of main
- simplify nfrx-mcp main to rely on shared runner

## Testing
- `make lint`
- `make build`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68ad24d94f3c832ca87ddb3c56edcf89