### PR TITLE
Add protocol handshake fields for worker registration

### DIFF
--- a/nfrx-plugins-llm/internal/llmagent/worker.go
+++ b/nfrx-plugins-llm/internal/llmagent/worker.go
@@ -111,6 +111,8 @@ func connectAndServe(ctx context.Context, cancelAll context.CancelFunc, cfg conf
 		Version:            vi.Version,
 		BuildSHA:           vi.BuildSHA,
 		BuildDate:          vi.BuildDate,
+		ProtocolVersion:    ctrl.ProtocolVersion,
+		Capabilities:       []string{"llm"},
 	}
 	b, _ := json.Marshal(regMsg)
 	if err := ws.Write(connCtx, websocket.MessageText, b); err != nil {

--- a/nfrx-sdk/ctrl/messages.go
+++ b/nfrx-sdk/ctrl/messages.go
@@ -2,6 +2,8 @@ package ctrl
 
 import "encoding/json"
 
+const ProtocolVersion = "1"
+
 type RegisterMessage struct {
 	Type               string   `json:"type"`
 	WorkerID           string   `json:"worker_id"`
@@ -14,6 +16,8 @@ type RegisterMessage struct {
 	Version            string   `json:"version,omitempty"`
 	BuildSHA           string   `json:"build_sha,omitempty"`
 	BuildDate          string   `json:"build_date,omitempty"`
+	ProtocolVersion    string   `json:"protocol_version,omitempty"`
+	Capabilities       []string `json:"capabilities,omitempty"`
 }
 
 type StatusUpdateMessage struct {

--- a/nfrx-server/go.mod
+++ b/nfrx-server/go.mod
@@ -4,8 +4,6 @@ go 1.24.3
 
 replace github.com/gaspardpetit/nfrx-sdk => ../nfrx-sdk
 
-replace github.com/gaspardpetit/nfrx-plugins-mcp => ../nfrx-plugins-mcp
-
 require (
 	github.com/alicebob/miniredis/v2 v2.35.0
 	github.com/coder/websocket v1.8.13

--- a/nfrx-server/internal/ctrlsrv/registry.go
+++ b/nfrx-server/internal/ctrlsrv/registry.go
@@ -17,12 +17,14 @@ type Worker struct {
 	ID                 string
 	Name               string
 	Models             map[string]bool
+	Capabilities       map[string]bool
 	MaxConcurrency     int
 	EmbeddingBatchSize int
 	InFlight           int
 	LastHeartbeat      time.Time
 	Send               chan interface{}
 	Jobs               map[string]chan interface{}
+	ProtocolVersion    string
 	mu                 sync.Mutex
 }
 

--- a/nfrx-server/internal/ctrlsrv/ws.go
+++ b/nfrx-server/internal/ctrlsrv/ws.go
@@ -72,15 +72,20 @@ func WSHandler(reg *Registry, metrics *MetricsRegistry, clientKey string) http.H
 			ID:                 rm.WorkerID,
 			Name:               name,
 			Models:             map[string]bool{},
+			Capabilities:       map[string]bool{},
 			MaxConcurrency:     rm.MaxConcurrency,
 			EmbeddingBatchSize: rm.EmbeddingBatchSize,
 			InFlight:           0,
 			LastHeartbeat:      time.Now(),
 			Send:               make(chan interface{}, 32),
 			Jobs:               make(map[string]chan interface{}),
+			ProtocolVersion:    rm.ProtocolVersion,
 		}
 		for _, m := range rm.Models {
 			wk.Models[m] = true
+		}
+		for _, ccap := range rm.Capabilities {
+			wk.Capabilities[ccap] = true
 		}
 		reg.Add(wk)
 		metrics.UpsertWorker(wk.ID, wk.Name, rm.Version, rm.BuildSHA, rm.BuildDate, rm.MaxConcurrency, rm.EmbeddingBatchSize, rm.Models)


### PR DESCRIPTION
## Summary
- add protocol version constant and capability list to control-plane RegisterMessage
- send capabilities and protocol version from LLM agent
- record worker capabilities and protocol version on server and drop unused plugin replace

## Testing
- `make lint`
- `make build`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68add42c90bc832cb925244a37ccfae9