### PR TITLE
chore: update build and packaging for module split

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,9 +53,9 @@ jobs:
           EXT=""
           if [ "$GOOS" = "windows" ]; then EXT=".exe"; fi
           mkdir -p dist
-          go build -ldflags "$LDFLAGS" -o dist/nfrx${EXT} ./cmd/nfrx
-          go build -ldflags "$LDFLAGS" -o dist/nfrx-llm${EXT} ./cmd/nfrx-llm
-          go build -ldflags "$LDFLAGS" -o dist/nfrx-mcp${EXT} ./cmd/nfrx-mcp
+          go build -ldflags "$LDFLAGS" -o dist/nfrx${EXT} ./server/cmd/nfrx
+          go build -ldflags "$LDFLAGS" -o dist/nfrx-llm${EXT} ./modules/llm/agent/cmd/nfrx-llm
+          go build -ldflags "$LDFLAGS" -o dist/nfrx-mcp${EXT} ./modules/mcp/agent/cmd/nfrx-mcp
       - name: Package
         id: pkg
         shell: bash

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -52,9 +52,9 @@ jobs:
           EXT=""
           [ "$GOOS" = "windows" ] && EXT=".exe"
           mkdir -p dist
-          go build -trimpath -ldflags "$LDFLAGS" -o "dist/nfrx${EXT}" ./cmd/nfrx
-          go build -trimpath -ldflags "$LDFLAGS" -o "dist/nfrx-llm${EXT}" ./cmd/nfrx-llm
-          go build -trimpath -ldflags "$LDFLAGS" -o "dist/nfrx-mcp${EXT}" ./cmd/nfrx-mcp
+          go build -trimpath -ldflags "$LDFLAGS" -o "dist/nfrx${EXT}" ./server/cmd/nfrx
+          go build -trimpath -ldflags "$LDFLAGS" -o "dist/nfrx-llm${EXT}" ./modules/llm/agent/cmd/nfrx-llm
+          go build -trimpath -ldflags "$LDFLAGS" -o "dist/nfrx-mcp${EXT}" ./modules/mcp/agent/cmd/nfrx-mcp
       
       - name: Package
         id: pkg

--- a/README.md
+++ b/README.md
@@ -340,8 +340,12 @@ The Windows service runs `nfrx-llm` with the `--reconnect` flag and shuts down i
 
 ```bash
 wget https://github.com/gaspardpetit/nfrx/releases/download/v1.3.0/nfrx_1.3.0-1_amd64.deb
-sudo dpkg -i nfrx_1.3.0-1_amd64.deb
+wget https://github.com/gaspardpetit/nfrx/releases/download/v1.3.0/nfrx-llm_1.3.0-1_amd64.deb
+wget https://github.com/gaspardpetit/nfrx/releases/download/v1.3.0/nfrx-mcp_1.3.0-1_amd64.deb
+sudo dpkg -i nfrx_1.3.0-1_amd64.deb nfrx-llm_1.3.0-1_amd64.deb nfrx-mcp_1.3.0-1_amd64.deb
 sudo systemctl status nfrx
+sudo systemctl status nfrx-llm
+sudo systemctl status nfrx-mcp
 ```
 
 ## Build
@@ -354,8 +358,9 @@ make build
 
 On Windows:
 ```
-go build -o .\bin\nfrx.exe .\cmd\nfrx
-go build -o .\bin\nfrx-llm.exe .\cmd\nfrx-llm
+go build -o .\bin\nfrx.exe .\server\cmd\nfrx
+go build -o .\bin\nfrx-llm.exe .\modules\llm\agent\cmd\nfrx-llm
+go build -o .\bin\nfrx-mcp.exe .\modules\mcp\agent\cmd\nfrx-mcp
 ```
 
 ### Version

--- a/debian/control
+++ b/debian/control
@@ -18,3 +18,9 @@ Architecture: any
 Depends: ${misc:Depends}, adduser
 Description: nfrx worker component (daemon)
  The worker for nfrx.
+
+Package: nfrx-mcp
+Architecture: any
+Depends: ${misc:Depends}, adduser
+Description: nfrx mcp bridge component (daemon)
+ The mcp bridge for nfrx.

--- a/debian/examples/mcp.env
+++ b/debian/examples/mcp.env
@@ -1,0 +1,6 @@
+# Example environment file for nfrx-mcp
+# Uncomment and set values as needed.
+# SERVER_URL=ws://localhost:8080/api/mcp/connect
+# CLIENT_KEY=secret
+# PROVIDER_URL=http://127.0.0.1:7777/
+# CLIENT_NAME=MyMCPClient

--- a/debian/nfrx-mcp.install
+++ b/debian/nfrx-mcp.install
@@ -1,0 +1,3 @@
+build/bin/nfrx-mcp usr/bin/
+debian/nfrx-mcp.service usr/lib/systemd/system/
+debian/examples/mcp.env etc/nfrx/mcp.env

--- a/debian/nfrx-mcp.lintian-overrides
+++ b/debian/nfrx-mcp.lintian-overrides
@@ -1,0 +1,1 @@
+nfrx-mcp binary: statically-linked-binary

--- a/debian/nfrx-mcp.postinst
+++ b/debian/nfrx-mcp.postinst
@@ -1,0 +1,13 @@
+#!/bin/sh
+set -e
+case "$1" in
+  configure)
+    if ! getent group nfrx >/dev/null; then
+      addgroup --system nfrx
+    fi
+    if ! id -u nfrx >/dev/null 2>&1; then
+      adduser --system --ingroup nfrx --no-create-home --home /nonexistent --shell /usr/sbin/nologin nfrx
+    fi
+    ;;
+esac
+#DEBHELPER#

--- a/debian/nfrx-mcp.service
+++ b/debian/nfrx-mcp.service
@@ -1,0 +1,27 @@
+[Unit]
+Description=nfrx mcp bridge
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+User=nfrx
+Group=nfrx
+EnvironmentFile=-/etc/nfrx/mcp.env
+ExecStart=/usr/bin/nfrx-mcp $MCP_FLAGS
+Restart=on-failure
+RestartSec=3s
+AmbientCapabilities=
+NoNewPrivileges=true
+ProtectSystem=full
+ProtectHome=true
+PrivateTmp=true
+CapabilityBoundingSet=
+StateDirectory=nfrx
+RuntimeDirectory=nfrx
+ProtectKernelLogs=true
+ProtectKernelModules=true
+ProtectControlGroups=true
+LockPersonality=true
+
+[Install]
+WantedBy=multi-user.target

--- a/debian/rules
+++ b/debian/rules
@@ -40,10 +40,12 @@ GO_LDFLAGS := $(GO_STRIP_FLAGS) \
 	dh $@ --buildsystem=golang
 
 override_dh_auto_build:
-	# Build server
-	GOBIN=$(CURDIR)/build/bin go build -ldflags "$(GO_LDFLAGS)" -o build/bin/nfrx ./server/cmd/nfrx
-	# Build worker
-	GOBIN=$(CURDIR)/build/bin go build -ldflags "$(GO_LDFLAGS)" -o build/bin/nfrx-llm ./modules/llm/agent/cmd/nfrx-llm
+        # Build server
+        GOBIN=$(CURDIR)/build/bin go build -ldflags "$(GO_LDFLAGS)" -o build/bin/nfrx ./server/cmd/nfrx
+        # Build worker
+        GOBIN=$(CURDIR)/build/bin go build -ldflags "$(GO_LDFLAGS)" -o build/bin/nfrx-llm ./modules/llm/agent/cmd/nfrx-llm
+        # Build mcp bridge
+        GOBIN=$(CURDIR)/build/bin go build -ldflags "$(GO_LDFLAGS)" -o build/bin/nfrx-mcp ./modules/mcp/agent/cmd/nfrx-mcp
 
 override_dh_auto_install:
 	# Installation handled via .install files


### PR DESCRIPTION
## Summary
- build binaries from new module locations in snapshot and release workflows
- add Debian packaging for `nfrx-mcp`
- document Debian packages and Windows build paths in README

## Testing
- `make lint`
- `make build`
- `make test` *(fails: some packages have no tests but run completes? actually test succeeded; will mention.*)
- `dpkg-buildpackage -b -us -uc -aamd64` *(fails: cannot open debian/changelog)*

------
https://chatgpt.com/codex/tasks/task_e_68af0ffb0adc832c95da7be6b484575a