### PR TITLE
Decouple server from module-specific LLM and MCP logic

### DIFF
--- a/modules/common/spi/spi.go
+++ b/modules/common/spi/spi.go
@@ -90,3 +90,7 @@ type MCPState struct {
 	Clients  []MCPClientSnapshot  `json:"clients"`
 	Sessions []MCPSessionSnapshot `json:"sessions"`
 }
+
+type MCPStateProvider interface {
+	Snapshot() MCPState
+}

--- a/server/internal/api/impl.go
+++ b/server/internal/api/impl.go
@@ -6,7 +6,7 @@ import (
 	"time"
 
 	"github.com/gaspardpetit/nfrx/api/generated"
-	mcpbroker "github.com/gaspardpetit/nfrx/modules/mcp/ext/mcpbroker"
+	"github.com/gaspardpetit/nfrx/modules/common/spi"
 	ctrlsrv "github.com/gaspardpetit/nfrx/server/internal/ctrlsrv"
 )
 
@@ -17,7 +17,7 @@ type HealthChecker interface {
 type API struct {
 	Reg                   *ctrlsrv.Registry
 	Metrics               *ctrlsrv.MetricsRegistry
-	MCP                   *mcpbroker.Registry
+	MCP                   spi.MCPStateProvider
 	Sched                 ctrlsrv.Scheduler
 	Timeout               time.Duration
 	MaxParallelEmbeddings int

--- a/server/internal/api/state.go
+++ b/server/internal/api/state.go
@@ -6,14 +6,14 @@ import (
 	"time"
 
 	"github.com/gaspardpetit/nfrx/modules/common/logx"
-	mcpbroker "github.com/gaspardpetit/nfrx/modules/mcp/ext/mcpbroker"
+	"github.com/gaspardpetit/nfrx/modules/common/spi"
 	ctrlsrv "github.com/gaspardpetit/nfrx/server/internal/ctrlsrv"
 )
 
 // StateHandler serves state snapshots and streams.
 type StateHandler struct {
 	Metrics *ctrlsrv.MetricsRegistry
-	MCP     *mcpbroker.Registry
+	MCP     spi.MCPStateProvider
 }
 
 // GetState returns a JSON snapshot of metrics.

--- a/server/test/e2e_api_key_test.go
+++ b/server/test/e2e_api_key_test.go
@@ -19,7 +19,7 @@ func TestAPIKeyEnforcement(t *testing.T) {
 	cfg := config.ServerConfig{APIKey: "test123", RequestTimeout: 5 * time.Second}
 	mcpPlugin := mcp.New(adapters.ServerState{}, mcp.Options{RequestTimeout: cfg.RequestTimeout}, nil)
 	stateReg := serverstate.NewRegistry()
-	llmPlugin := llm.New(cfg, "test", "", "", mcpPlugin.Registry(), nil)
+	llmPlugin := llm.New(cfg, "test", "", "", mcpPlugin.Registry(), openAIMount(cfg), nil)
 	handler := server.New(cfg, stateReg, []plugin.Plugin{mcpPlugin, llmPlugin})
 	srv := httptest.NewServer(handler)
 	defer srv.Close()

--- a/server/test/e2e_auth_test.go
+++ b/server/test/e2e_auth_test.go
@@ -25,7 +25,7 @@ func TestWorkerAuth(t *testing.T) {
 	cfg := config.ServerConfig{ClientKey: "secret", RequestTimeout: 5 * time.Second}
 	mcpPlugin := mcp.New(adapters.ServerState{}, mcp.Options{RequestTimeout: cfg.RequestTimeout}, nil)
 	stateReg := serverstate.NewRegistry()
-	llmPlugin := llm.New(cfg, "test", "", "", mcpPlugin.Registry(), nil)
+	llmPlugin := llm.New(cfg, "test", "", "", mcpPlugin.Registry(), openAIMount(cfg), nil)
 	handler := server.New(cfg, stateReg, []plugin.Plugin{mcpPlugin, llmPlugin})
 	srv := httptest.NewServer(handler)
 	defer srv.Close()
@@ -89,7 +89,7 @@ func TestWorkerClientKeyUnexpected(t *testing.T) {
 	cfg := config.ServerConfig{RequestTimeout: 5 * time.Second}
 	mcpPlugin := mcp.New(adapters.ServerState{}, mcp.Options{RequestTimeout: cfg.RequestTimeout}, nil)
 	stateReg := serverstate.NewRegistry()
-	llmPlugin := llm.New(cfg, "test", "", "", mcpPlugin.Registry(), nil)
+	llmPlugin := llm.New(cfg, "test", "", "", mcpPlugin.Registry(), openAIMount(cfg), nil)
 	handler := server.New(cfg, stateReg, []plugin.Plugin{mcpPlugin, llmPlugin})
 	srv := httptest.NewServer(handler)
 	defer srv.Close()
@@ -115,7 +115,7 @@ func TestMCPAuth(t *testing.T) {
 	cfg := config.ServerConfig{ClientKey: "secret", RequestTimeout: 5 * time.Second}
 	mcpPlugin := mcp.New(adapters.ServerState{}, mcp.Options{RequestTimeout: cfg.RequestTimeout}, nil)
 	stateReg := serverstate.NewRegistry()
-	llmPlugin := llm.New(cfg, "test", "", "", mcpPlugin.Registry(), nil)
+	llmPlugin := llm.New(cfg, "test", "", "", mcpPlugin.Registry(), openAIMount(cfg), nil)
 	handler := server.New(cfg, stateReg, []plugin.Plugin{mcpPlugin, llmPlugin})
 	srv := httptest.NewServer(handler)
 	defer srv.Close()
@@ -157,7 +157,7 @@ func TestMCPAuth(t *testing.T) {
 	cfg = config.ServerConfig{RequestTimeout: 5 * time.Second}
 	mcpReg := mcp.New(adapters.ServerState{}, mcp.Options{RequestTimeout: cfg.RequestTimeout}, nil)
 	stateReg = serverstate.NewRegistry()
-	llmPlugin = llm.New(cfg, "test", "", "", mcpReg.Registry(), nil)
+	llmPlugin = llm.New(cfg, "test", "", "", mcpReg.Registry(), openAIMount(cfg), nil)
 	handler = server.New(cfg, stateReg, []plugin.Plugin{mcpReg, llmPlugin})
 	srv2 := httptest.NewServer(handler)
 	defer srv2.Close()

--- a/server/test/e2e_chat_completions_proxy_test.go
+++ b/server/test/e2e_chat_completions_proxy_test.go
@@ -28,7 +28,7 @@ func TestE2EChatCompletionsProxy(t *testing.T) {
 	cfg := config.ServerConfig{ClientKey: "secret", APIKey: "apikey", RequestTimeout: 5 * time.Second}
 	mcpPlugin := mcp.New(adapters.ServerState{}, mcp.Options{RequestTimeout: cfg.RequestTimeout}, nil)
 	stateReg := serverstate.NewRegistry()
-	llmPlugin := llm.New(cfg, "test", "", "", mcpPlugin.Registry(), nil)
+	llmPlugin := llm.New(cfg, "test", "", "", mcpPlugin.Registry(), openAIMount(cfg), nil)
 	handler := server.New(cfg, stateReg, []plugin.Plugin{mcpPlugin, llmPlugin})
 	srv := httptest.NewServer(handler)
 	defer srv.Close()

--- a/server/test/e2e_embeddings_proxy_test.go
+++ b/server/test/e2e_embeddings_proxy_test.go
@@ -26,7 +26,7 @@ func TestE2EEmbeddingsProxy(t *testing.T) {
 	cfg := config.ServerConfig{ClientKey: "secret", APIKey: "apikey", RequestTimeout: 5 * time.Second}
 	mcpPlugin := mcp.New(adapters.ServerState{}, mcp.Options{RequestTimeout: cfg.RequestTimeout}, nil)
 	stateReg := serverstate.NewRegistry()
-	llmPlugin := llm.New(cfg, "test", "", "", mcpPlugin.Registry(), nil)
+	llmPlugin := llm.New(cfg, "test", "", "", mcpPlugin.Registry(), openAIMount(cfg), nil)
 	handler := server.New(cfg, stateReg, []plugin.Plugin{mcpPlugin, llmPlugin})
 	srv := httptest.NewServer(handler)
 	defer srv.Close()

--- a/server/test/e2e_model_update_test.go
+++ b/server/test/e2e_model_update_test.go
@@ -25,7 +25,7 @@ func TestWorkerModelRefresh(t *testing.T) {
 	cfg := config.ServerConfig{RequestTimeout: 5 * time.Second}
 	mcpPlugin := mcp.New(adapters.ServerState{}, mcp.Options{RequestTimeout: cfg.RequestTimeout}, nil)
 	stateReg := serverstate.NewRegistry()
-	llmPlugin := llm.New(cfg, "test", "", "", mcpPlugin.Registry(), nil)
+	llmPlugin := llm.New(cfg, "test", "", "", mcpPlugin.Registry(), openAIMount(cfg), nil)
 	handler := server.New(cfg, stateReg, []plugin.Plugin{mcpPlugin, llmPlugin})
 	srv := httptest.NewServer(handler)
 	defer srv.Close()

--- a/server/test/e2e_models_api_test.go
+++ b/server/test/e2e_models_api_test.go
@@ -25,7 +25,7 @@ func TestModelsAPI(t *testing.T) {
 	cfg := config.ServerConfig{RequestTimeout: 5 * time.Second}
 	mcpPlugin := mcp.New(adapters.ServerState{}, mcp.Options{RequestTimeout: cfg.RequestTimeout}, nil)
 	stateReg := serverstate.NewRegistry()
-	llmPlugin := llm.New(cfg, "test", "", "", mcpPlugin.Registry(), nil)
+	llmPlugin := llm.New(cfg, "test", "", "", mcpPlugin.Registry(), openAIMount(cfg), nil)
 	handler := server.New(cfg, stateReg, []plugin.Plugin{mcpPlugin, llmPlugin})
 	srv := httptest.NewServer(handler)
 	defer srv.Close()

--- a/server/test/e2e_prune_test.go
+++ b/server/test/e2e_prune_test.go
@@ -24,7 +24,7 @@ func TestHeartbeatPrune(t *testing.T) {
 	cfg := config.ServerConfig{ClientKey: "secret", RequestTimeout: 5 * time.Second}
 	mcpPlugin := mcp.New(adapters.ServerState{}, mcp.Options{RequestTimeout: cfg.RequestTimeout}, nil)
 	stateReg := serverstate.NewRegistry()
-	llmPlugin := llm.New(cfg, "test", "", "", mcpPlugin.Registry(), nil)
+	llmPlugin := llm.New(cfg, "test", "", "", mcpPlugin.Registry(), openAIMount(cfg), nil)
 	handler := server.New(cfg, stateReg, []plugin.Plugin{mcpPlugin, llmPlugin})
 	srv := httptest.NewServer(handler)
 	defer srv.Close()

--- a/server/test/util.go
+++ b/server/test/util.go
@@ -1,0 +1,15 @@
+package test
+
+import (
+	"github.com/gaspardpetit/nfrx/modules/common/spi"
+	openai "github.com/gaspardpetit/nfrx/modules/llm/ext/openai"
+	"github.com/gaspardpetit/nfrx/server/internal/config"
+	llm "github.com/gaspardpetit/nfrx/server/internal/llm"
+	"github.com/go-chi/chi/v5"
+)
+
+func openAIMount(cfg config.ServerConfig) llm.APIMount {
+	return func(v1 chi.Router, reg spi.WorkerRegistry, sched spi.Scheduler, metrics spi.Metrics) {
+		openai.Mount(v1, reg, sched, metrics, openai.Options{RequestTimeout: cfg.RequestTimeout, MaxParallelEmbeddings: cfg.MaxParallelEmbeddings})
+	}
+}


### PR DESCRIPTION
## Summary
- Introduce `MCPStateProvider` SPI interface and update server API/state handlers to rely on it instead of the concrete MCP broker
- Refactor LLM plugin to accept a generic `APIMount` callback, removing direct OpenAI imports
- Inject OpenAI routes from `main` and add test helper to mount them in e2e tests

## Testing
- `make lint`
- `make build`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68af1a55b1d0832c9c86f6b9e7b301c3