### PR TITLE
feat: mount plugins under surface prefixes

### DIFF
--- a/api/generated/server.gen.go
+++ b/api/generated/server.gen.go
@@ -19,9 +19,6 @@ type ServerInterface interface {
 	// Stream server state
 	// (GET /api/state/stream)
 	GetApiStateStream(w http.ResponseWriter, r *http.Request)
-	// Worker connect (WebSocket)
-	// (GET /api/workers/connect)
-	GetApiWorkersConnect(w http.ResponseWriter, r *http.Request)
 	// Health check
 	// (GET /healthz)
 	GetHealthz(w http.ResponseWriter, r *http.Request)
@@ -40,12 +37,6 @@ func (_ Unimplemented) GetApiState(w http.ResponseWriter, r *http.Request) {
 // Stream server state
 // (GET /api/state/stream)
 func (_ Unimplemented) GetApiStateStream(w http.ResponseWriter, r *http.Request) {
-	w.WriteHeader(http.StatusNotImplemented)
-}
-
-// Worker connect (WebSocket)
-// (GET /api/workers/connect)
-func (_ Unimplemented) GetApiWorkersConnect(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusNotImplemented)
 }
 
@@ -95,20 +86,6 @@ func (siw *ServerInterfaceWrapper) GetApiStateStream(w http.ResponseWriter, r *h
 
 	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		siw.Handler.GetApiStateStream(w, r)
-	}))
-
-	for _, middleware := range siw.HandlerMiddlewares {
-		handler = middleware(handler)
-	}
-
-	handler.ServeHTTP(w, r)
-}
-
-// GetApiWorkersConnect operation middleware
-func (siw *ServerInterfaceWrapper) GetApiWorkersConnect(w http.ResponseWriter, r *http.Request) {
-
-	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		siw.Handler.GetApiWorkersConnect(w, r)
 	}))
 
 	for _, middleware := range siw.HandlerMiddlewares {
@@ -250,9 +227,6 @@ func HandlerWithOptions(si ServerInterface, options ChiServerOptions) http.Handl
 	})
 	r.Group(func(r chi.Router) {
 		r.Get(options.BaseURL+"/api/state/stream", wrapper.GetApiStateStream)
-	})
-	r.Group(func(r chi.Router) {
-		r.Get(options.BaseURL+"/api/workers/connect", wrapper.GetApiWorkersConnect)
 	})
 	r.Group(func(r chi.Router) {
 		r.Get(options.BaseURL+"/healthz", wrapper.GetHealthz)

--- a/api/generated/spec.gen.go
+++ b/api/generated/spec.gen.go
@@ -18,14 +18,13 @@ import (
 // Base64 encoded, gzipped, json marshaled Swagger object
 var swaggerSpec = []string{
 
-	"H4sIAAAAAAAC/6STQW8TMRCF/8pqTiAt2Q29VHsLCEHFgUg59BDl4DjT2M2ubWZm04Zo/zuyvU0gKqWI",
-	"k7We9+z3zXiPoH0XvEMnDM0RGHVPVg4LbbDDtPUBFSHNejFJkArQwDptQwlyCPHbiAQYhqEE6+58lIqV",
-	"NlbcHT0Ws/kNlLBHYusdNDCd1JMahhJ8QKeChQauJvXkCkoISky6uVLBVixKMH5tUeLiA5IS693NBhr4",
-	"jDILdpE0JRBy8I5z7vd1HRftnaBLVhVCa3UyV/ccY4w8KlU3GxtLqp1TvERsPEeoxxOjX9+jlky5QdZk",
-	"g2ScnCDuP3UQmuXvvVuuhlUJ3HedokOOXjDSHqngk/uMXLEQqu415Ius/Cu/4KNUuEcn786HnxswQrKQ",
-	"ddvnID9FazFa/4k1J/wD7oOnHRJX2jsX2/sy8W1WfxzFF9DTehqXi+E8WNHGum0xJy9e+5Zz/FO+fGgx",
-	"Jije3OJ64fUO5W2OaVC1Yn68FO3LKPnPVxh+eXtHiJ3q+bnhxGu+95ZwA83ySbd6xUv99vWCPQcvtEG9",
-	"y4Y8Jk5T7akdf+6mqlqvVWs8S3NdX9cwrIafAQAA//99uvy4QAQAAA==",
+	"H4sIAAAAAAAC/6STQW/UMBCF/0o055AEeql8WyQEFQcq7XGVg+tMa5fENjOTVZdV/juyne6CtIJFPVn2",
+	"vOd53zg5gglTDB69MKgjMJqZnBy2xuKE+egjakLazGKzIBdAwUM+hhrkENPeikRYlqUG5x9DkoqTMVX8",
+	"I71Um/s7qGGPxC54UPC+6ZoOlhpCRK+jAwU3TdfcQA1Ri82dWx1dy6IF0+4JJS0hImlxwd8NoOAzyia6",
+	"bdbUQMgxeC65P3RdWkzwgj5bdYyjM9ncPnOKsfLoXB0Gl0p6vKfURFy6R2jGE2N4eEYjhXJANuSiFJyS",
+	"IJ2/ThDU7s/Z7fqlr4HnadJ0KNErRtojVXxyn5FbFkI9XUO+Lcp/8gu+SIt79PLufPl5ACskCzn/dAny",
+	"U7JWq/W/WEvCC7gW9Sj2598ov6ySNz5v/O1Rj5AizHyJOrX5MTvCAdTuVddf8Ql8+1pmcoIuwStj0Xwv",
+	"hsLPeVwzjetfo9p2DEaPNrCo2+62g6VffgUAAP//jDJSXpkDAAA=",
 }
 
 // GetSwagger returns the content of the embedded swagger specification file

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -24,12 +24,6 @@ paths:
                   status:
                     type: string
                 required: [status]
-  /api/workers/connect:
-    get:
-      summary: Worker connect (WebSocket)
-      responses:
-        '101':
-          description: Switching Protocols
   /api/state:
     get:
       security: [ { BearerAuth: [] } ]

--- a/debian/examples/worker.env
+++ b/debian/examples/worker.env
@@ -1,6 +1,6 @@
 # Example environment file for nfrx-llm
 # Uncomment and set values as needed.
-# SERVER_URL=ws://localhost:8080/api/workers/connect
+# SERVER_URL=ws://localhost:8080/api/llm/connect
 # CLIENT_KEY=secret
 # COMPLETION_BASE_URL=http://127.0.0.1:11434/v1
 # CLIENT_NAME=MyWorker

--- a/deploy/systemd/worker.env.example
+++ b/deploy/systemd/worker.env.example
@@ -1,6 +1,6 @@
 # Example environment file for nfrx-llm
 # Uncomment and set values as needed.
-# SERVER_URL=ws://localhost:8080/api/workers/connect
+# SERVER_URL=ws://localhost:8080/api/llm/connect
 # CLIENT_KEY=secret
 # COMPLETION_BASE_URL=http://127.0.0.1:11434/v1
 # CLIENT_NAME=MyWorker

--- a/doc/env.md
+++ b/doc/env.md
@@ -49,7 +49,7 @@ The worker optionally reads settings from a YAML config file. Defaults:
 |----------|------------|---------|---------|----------|
 | `CONFIG_FILE` | — | worker config file path | OS-specific | `--config` |
 | `LOG_DIR` | — | directory for worker log files | OS-specific (none on Linux) | `--log-dir` |
-| `SERVER_URL` | `server_url` | server WebSocket URL for registration | `ws://localhost:8080/api/workers/connect` | `--server-url` |
+| `SERVER_URL` | `server_url` | server WebSocket URL for registration | `ws://localhost:8080/api/llm/connect` | `--server-url` |
 | `CLIENT_KEY` | `client_key` | shared secret for authenticating with the server | unset | `--client-key` |
 | `COMPLETION_BASE_URL` | `completion_base_url` | base URL of the completion API | `http://127.0.0.1:11434/v1` | `--completion-base-url` |
 | `COMPLETION_API_KEY` | — | API key for the completion API | unset | `--completion-api-key` |

--- a/doc/server-endpoints.md
+++ b/doc/server-endpoints.md
@@ -29,16 +29,16 @@ These endpoints are present when the `llm` plugin is enabled.
 
 | Verb & Endpoint | Parameters | Description | Auth |
 | --- | --- | --- | --- |
-| `GET /api/workers/connect` (WS) | Initial message `{ type: "register", client_key?: string, worker_id?: string, worker_name?: string, models?: [string], max_concurrency?: int, embedding_batch_size?: int }` | Worker connects to server. | Client key |
+| `GET /api/llm/connect` (WS) | Initial message `{ type: "register", client_key?: string, worker_id?: string, worker_name?: string, models?: [string], max_concurrency?: int, embedding_batch_size?: int }` | Worker connects to server. | Client key |
 
 ### Client Usage
 
 | Verb & Endpoint | Parameters | Description | Auth |
 | --- | --- | --- | --- |
-| `POST /api/v1/chat/completions` | Body `{ model: string, messages: [{role: string, content: string}], stream?: bool, ... }` | Proxy OpenAI chat completions. | API key |
-| `POST /api/v1/embeddings` | Body `{ model: string, input: any, ... }` | Proxy OpenAI embeddings; large input arrays are automatically batched per worker. | API key |
-| `GET /api/v1/models` | – | List models. | API key |
-| `GET /api/v1/models/{id}` | Path `{id}` | Get model details. | API key |
+| `POST /api/llm/v1/chat/completions` | Body `{ model: string, messages: [{role: string, content: string}], stream?: bool, ... }` | Proxy OpenAI chat completions. | API key |
+| `POST /api/llm/v1/embeddings` | Body `{ model: string, input: any, ... }` | Proxy OpenAI embeddings; large input arrays are automatically batched per worker. | API key |
+| `GET /api/llm/v1/models` | – | List models. | API key |
+| `GET /api/llm/v1/models/{id}` | Path `{id}` | Get model details. | API key |
 
 ## MCP API
 

--- a/examples/config/worker.yaml
+++ b/examples/config/worker.yaml
@@ -1,5 +1,5 @@
 # Example configuration for nfrx-llm
-server_url: ws://localhost:8080/api/workers/connect
+server_url: ws://localhost:8080/api/llm/connect
 # log_level: info             # logging verbosity (all, debug, info, warn, error, fatal, none)
 # client_key: ""              # shared secret for authenticating with the server
 completion_base_url: http://127.0.0.1:11434/v1

--- a/examples/llm-proxy/docker-compose.yaml
+++ b/examples/llm-proxy/docker-compose.yaml
@@ -25,7 +25,7 @@ services:
     image: ghcr.io/gaspardpetit/nfrx-llm:main
     environment:
       <<: *common_env
-      SERVER_URL: "ws://server:8080/api/workers/connect"
+      SERVER_URL: "ws://server:8080/api/llm/connect"
       COMPLETION_BASE_URL: "http://ollama:11434/v1"
       CLIENT_NAME: "Alpha"
       STATUS_ADDR: "0.0.0.0:4555"

--- a/examples/llm-proxy/example.md
+++ b/examples/llm-proxy/example.md
@@ -27,7 +27,7 @@ services:
     depends_on: [ollama]
     environment:
       <<: *common_env
-      SERVER_URL: "ws://server:8080/api/workers/connect"
+      SERVER_URL: "ws://server:8080/api/llm/connect"
       COMPLETION_BASE_URL: "http://ollama:11434/v1"
       CLIENT_NAME: "Alpha"
       STATUS_ADDR: "0.0.0.0:4555"
@@ -49,6 +49,6 @@ docker exec ollama ollama pull gemma3n:e2b
 ```
 
 ```
-docker run --rm -e OPENAI_API_KEY=test123 -e OPENAI_API_BASE=http://host.docker.internal:8080/api/v1/ ghcr.io/tbckr/sgpt:latest -m gemma3n:e2b "Tell me an IT joke about http proxies"
+docker run --rm -e OPENAI_API_KEY=test123 -e OPENAI_API_BASE=http://host.docker.internal:8080/api/llm/v1/ ghcr.io/tbckr/sgpt:latest -m gemma3n:e2b "Tell me an IT joke about http proxies"
 ```
 

--- a/modules/common/spi/plugin.go
+++ b/modules/common/spi/plugin.go
@@ -1,8 +1,6 @@
 package spi
 
 import (
-	"net/http"
-
 	"github.com/go-chi/chi/v5"
 	"github.com/prometheus/client_golang/prometheus"
 )
@@ -21,8 +19,4 @@ type WorkerProvider interface {
 
 type RelayProvider interface {
 	RegisterRelayEndpoints(r chi.Router)
-}
-
-type RelayWS interface {
-	WSHandler(clientKey string) http.Handler
 }

--- a/modules/llm/agent/internal/config/worker.go
+++ b/modules/llm/agent/internal/config/worker.go
@@ -41,7 +41,7 @@ func (c *WorkerConfig) BindFlags() {
 	c.LogDir = commoncfg.GetEnv("LOG_DIR", logDir)
 	c.LogLevel = commoncfg.GetEnv("LOG_LEVEL", "info")
 
-	c.ServerURL = commoncfg.GetEnv("SERVER_URL", "ws://localhost:8080/api/workers/connect")
+	c.ServerURL = commoncfg.GetEnv("SERVER_URL", "ws://localhost:8080/api/llm/connect")
 	c.ClientKey = commoncfg.GetEnv("CLIENT_KEY", "")
 	base := commoncfg.GetEnv("COMPLETION_BASE_URL", "http://127.0.0.1:11434/v1")
 	c.CompletionBaseURL = base
@@ -88,7 +88,7 @@ func (c *WorkerConfig) BindFlags() {
 		c.Reconnect = b
 	}
 
-	flag.StringVar(&c.ServerURL, "server-url", c.ServerURL, "server WebSocket URL for registration (e.g. ws://localhost:8080/api/workers/connect)")
+	flag.StringVar(&c.ServerURL, "server-url", c.ServerURL, "server WebSocket URL for registration (e.g. ws://localhost:8080/api/llm/connect)")
 	flag.StringVar(&c.ClientKey, "client-key", c.ClientKey, "shared secret for authenticating with the server")
 	flag.StringVar(&c.CompletionBaseURL, "completion-base-url", c.CompletionBaseURL, "base URL of the completion API (e.g. http://127.0.0.1:11434/v1)")
 	flag.StringVar(&c.CompletionAPIKey, "completion-api-key", c.CompletionAPIKey, "API key for the completion API; leave empty for no auth")

--- a/modules/llm/ext/openai/chat_completions.go
+++ b/modules/llm/ext/openai/chat_completions.go
@@ -15,7 +15,7 @@ import (
 	"github.com/gaspardpetit/nfrx/modules/common/spi"
 )
 
-// ChatCompletionsHandler handles POST /api/v1/chat/completions as a pass-through.
+// ChatCompletionsHandler handles POST /api/llm/v1/chat/completions as a pass-through.
 func ChatCompletionsHandler(reg spi.WorkerRegistry, sched spi.Scheduler, metrics spi.Metrics, timeout time.Duration) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		if r.Body == nil {

--- a/modules/llm/ext/openai/embeddings.go
+++ b/modules/llm/ext/openai/embeddings.go
@@ -20,7 +20,7 @@ import (
 	"github.com/gaspardpetit/nfrx/modules/common/spi"
 )
 
-// EmbeddingsHandler handles POST /api/v1/embeddings as a pass-through.
+// EmbeddingsHandler handles POST /api/llm/v1/embeddings as a pass-through.
 func EmbeddingsHandler(reg spi.WorkerRegistry, sched spi.Scheduler, metrics spi.Metrics, timeout time.Duration, maxParallel int) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		if r.Body == nil {

--- a/modules/llm/ext/openai/models.go
+++ b/modules/llm/ext/openai/models.go
@@ -11,7 +11,7 @@ import (
 	"github.com/gaspardpetit/nfrx/modules/common/spi"
 )
 
-// ListModelsHandler handles GET /api/v1/models.
+// ListModelsHandler handles GET /api/llm/v1/models.
 func ListModelsHandler(reg spi.WorkerRegistry) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		models := reg.AggregatedModels()
@@ -36,7 +36,7 @@ func ListModelsHandler(reg spi.WorkerRegistry) http.HandlerFunc {
 	}
 }
 
-// GetModelHandler handles GET /api/v1/models/{id}.
+// GetModelHandler handles GET /api/llm/v1/models/{id}.
 func GetModelHandler(reg spi.WorkerRegistry) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		id := chi.URLParam(r, "id")

--- a/modules/mcp/ext/options.go
+++ b/modules/mcp/ext/options.go
@@ -4,4 +4,5 @@ import "time"
 
 type Options struct {
 	RequestTimeout time.Duration
+	ClientKey      string
 }

--- a/server/cmd/nfrx/main.go
+++ b/server/cmd/nfrx/main.go
@@ -83,7 +83,7 @@ func main() {
 	var plugins []plugin.Plugin
 	var mcpReg *mcp.Plugin
 	if hasPlugin(cfg.Plugins, "mcp") {
-		mcpReg = mcp.New(adapters.ServerState{}, mcp.Options{RequestTimeout: cfg.RequestTimeout}, cfg.PluginOptions["mcp"])
+		mcpReg = mcp.New(adapters.ServerState{}, mcp.Options{RequestTimeout: cfg.RequestTimeout, ClientKey: cfg.ClientKey}, cfg.PluginOptions["mcp"])
 		plugins = append(plugins, mcpReg)
 	}
 	var mcpBroker *mcpbroker.Registry

--- a/server/internal/api/chat_completions_test.go
+++ b/server/internal/api/chat_completions_test.go
@@ -41,7 +41,7 @@ func TestChatCompletionsHeaders(t *testing.T) {
 	}()
 
 	reqBody := `{"model":"m","stream":true}`
-	req := httptest.NewRequest(http.MethodPost, "/api/v1/chat/completions", strings.NewReader(reqBody))
+	req := httptest.NewRequest(http.MethodPost, "/api/llm/v1/chat/completions", strings.NewReader(reqBody))
 	req.Header.Set("Content-Type", "application/json")
 	rec := &flushRecorder{ResponseRecorder: httptest.NewRecorder()}
 	h.ServeHTTP(rec, req)
@@ -77,7 +77,7 @@ func TestChatCompletionsOpaque(t *testing.T) {
 		ch <- ctrl.HTTPProxyResponseEndMessage{Type: "http_proxy_response_end", RequestID: req.RequestID}
 	}()
 
-	req := httptest.NewRequest(http.MethodPost, "/api/v1/chat/completions", strings.NewReader(`{"model":"m"}`))
+	req := httptest.NewRequest(http.MethodPost, "/api/llm/v1/chat/completions", strings.NewReader(`{"model":"m"}`))
 	req.Header.Set("Content-Type", "application/json")
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, req)
@@ -102,7 +102,7 @@ func TestChatCompletionsEarlyError(t *testing.T) {
 		ch <- ctrl.HTTPProxyResponseEndMessage{Type: "http_proxy_response_end", RequestID: req.RequestID, Error: &ctrl.HTTPProxyError{Code: "upstream_error", Message: "boom"}}
 	}()
 
-	req := httptest.NewRequest(http.MethodPost, "/api/v1/chat/completions", bytes.NewReader([]byte(`{"model":"m"}`)))
+	req := httptest.NewRequest(http.MethodPost, "/api/llm/v1/chat/completions", bytes.NewReader([]byte(`{"model":"m"}`)))
 	req.Header.Set("Content-Type", "application/json")
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, req)

--- a/server/internal/api/embeddings_test.go
+++ b/server/internal/api/embeddings_test.go
@@ -34,7 +34,7 @@ func TestEmbeddings(t *testing.T) {
 		ch <- ctrl.HTTPProxyResponseEndMessage{Type: "http_proxy_response_end", RequestID: req.RequestID}
 	}()
 
-	req := httptest.NewRequest(http.MethodPost, "/api/v1/embeddings", strings.NewReader(`{"model":"m"}`))
+	req := httptest.NewRequest(http.MethodPost, "/api/llm/v1/embeddings", strings.NewReader(`{"model":"m"}`))
 	req.Header.Set("Content-Type", "application/json")
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, req)
@@ -62,7 +62,7 @@ func TestEmbeddingsEarlyError(t *testing.T) {
 		ch <- ctrl.HTTPProxyResponseEndMessage{Type: "http_proxy_response_end", RequestID: req.RequestID, Error: &ctrl.HTTPProxyError{Code: "upstream_error", Message: "boom"}}
 	}()
 
-	req := httptest.NewRequest(http.MethodPost, "/api/v1/embeddings", bytes.NewReader([]byte(`{"model":"m"}`)))
+	req := httptest.NewRequest(http.MethodPost, "/api/llm/v1/embeddings", bytes.NewReader([]byte(`{"model":"m"}`)))
 	req.Header.Set("Content-Type", "application/json")
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, req)
@@ -104,7 +104,7 @@ func TestEmbeddingsBatching(t *testing.T) {
 		}
 	}()
 
-	req := httptest.NewRequest(http.MethodPost, "/api/v1/embeddings", bytes.NewReader([]byte(`{"model":"m","input":["a","b"]}`)))
+	req := httptest.NewRequest(http.MethodPost, "/api/llm/v1/embeddings", bytes.NewReader([]byte(`{"model":"m","input":["a","b"]}`)))
 	req.Header.Set("Content-Type", "application/json")
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, req)
@@ -191,7 +191,7 @@ func TestEmbeddingsParallelSplit(t *testing.T) {
 		errCh <- nil
 	}()
 
-	req := httptest.NewRequest(http.MethodPost, "/api/v1/embeddings", bytes.NewReader([]byte(`{"model":"m","input":["a","b","c","d","e","f"]}`)))
+	req := httptest.NewRequest(http.MethodPost, "/api/llm/v1/embeddings", bytes.NewReader([]byte(`{"model":"m","input":["a","b","c","d","e","f"]}`)))
 	req.Header.Set("Content-Type", "application/json")
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, req)

--- a/server/internal/api/impl.go
+++ b/server/internal/api/impl.go
@@ -45,7 +45,3 @@ func (a *API) GetApiState(w http.ResponseWriter, r *http.Request) {
 func (a *API) GetApiStateStream(w http.ResponseWriter, r *http.Request) {
 	(&StateHandler{Metrics: a.Metrics, MCP: a.MCP}).GetStateStream(w, r)
 }
-
-func (a *API) GetApiWorkersConnect(w http.ResponseWriter, r *http.Request) {
-	http.NotFound(w, r)
-}

--- a/server/internal/server/server.go
+++ b/server/internal/server/server.go
@@ -36,16 +36,7 @@ func New(cfg config.ServerConfig, stateReg *serverstate.Registry, plugins []plug
 	preg := prometheus.NewRegistry()
 	prometheus.DefaultRegisterer = preg
 	prometheus.DefaultGatherer = preg
-	pregistry := plugin.Load(plugin.Context{Router: r, Metrics: preg, State: adapters.NewStateRegistry(stateReg)}, plugins)
-	for _, wp := range pregistry.WorkerProviders() {
-		wp.RegisterWebSocket(r)
-	}
-	for _, rp := range pregistry.RelayProviders() {
-		rp.RegisterRelayEndpoints(r)
-		if rws, ok := rp.(plugin.RelayWS); ok {
-			r.Handle("/api/mcp/connect", rws.WSHandler(cfg.ClientKey))
-		}
-	}
+	plugin.Load(r, preg, adapters.NewStateRegistry(stateReg), plugins)
 
 	r.Get("/state", StateHandler())
 

--- a/server/internal/server/server_test.go
+++ b/server/internal/server/server_test.go
@@ -18,7 +18,7 @@ import (
 
 func TestMetricsEndpointDefaultPort(t *testing.T) {
 	cfg := config.ServerConfig{Port: 8080, MetricsAddr: ":8080", RequestTimeout: time.Second}
-	mcpPlugin := mcp.New(adapters.ServerState{}, mcp.Options{RequestTimeout: cfg.RequestTimeout}, nil)
+	mcpPlugin := mcp.New(adapters.ServerState{}, mcp.Options{RequestTimeout: cfg.RequestTimeout, ClientKey: cfg.ClientKey}, nil)
 	stateReg := serverstate.NewRegistry()
 	llmPlugin := llm.New(cfg, "test", "", "", mcpPlugin.Registry(), nil)
 	h := New(cfg, stateReg, []plugin.Plugin{mcpPlugin, llmPlugin})
@@ -36,7 +36,7 @@ func TestMetricsEndpointDefaultPort(t *testing.T) {
 
 func TestMetricsEndpointSeparatePort(t *testing.T) {
 	cfg := config.ServerConfig{Port: 8080, MetricsAddr: ":9090", RequestTimeout: time.Second}
-	mcpPlugin := mcp.New(adapters.ServerState{}, mcp.Options{RequestTimeout: cfg.RequestTimeout}, nil)
+	mcpPlugin := mcp.New(adapters.ServerState{}, mcp.Options{RequestTimeout: cfg.RequestTimeout, ClientKey: cfg.ClientKey}, nil)
 	stateReg := serverstate.NewRegistry()
 	llmPlugin := llm.New(cfg, "test", "", "", mcpPlugin.Registry(), nil)
 	h := New(cfg, stateReg, []plugin.Plugin{mcpPlugin, llmPlugin})
@@ -54,7 +54,7 @@ func TestMetricsEndpointSeparatePort(t *testing.T) {
 
 func TestStatePage(t *testing.T) {
 	cfg := config.ServerConfig{Port: 8080, RequestTimeout: time.Second}
-	mcpPlugin := mcp.New(adapters.ServerState{}, mcp.Options{RequestTimeout: cfg.RequestTimeout}, nil)
+	mcpPlugin := mcp.New(adapters.ServerState{}, mcp.Options{RequestTimeout: cfg.RequestTimeout, ClientKey: cfg.ClientKey}, nil)
 	stateReg := serverstate.NewRegistry()
 	llmPlugin := llm.New(cfg, "test", "", "", mcpPlugin.Registry(), nil)
 	h := New(cfg, stateReg, []plugin.Plugin{mcpPlugin, llmPlugin})
@@ -76,7 +76,7 @@ func TestStatePage(t *testing.T) {
 
 func TestCORSAllowedOrigins(t *testing.T) {
 	cfg := config.ServerConfig{Port: 8080, RequestTimeout: time.Second, AllowedOrigins: []string{"https://example.com"}}
-	mcpPlugin := mcp.New(adapters.ServerState{}, mcp.Options{RequestTimeout: cfg.RequestTimeout}, nil)
+	mcpPlugin := mcp.New(adapters.ServerState{}, mcp.Options{RequestTimeout: cfg.RequestTimeout, ClientKey: cfg.ClientKey}, nil)
 	stateReg := serverstate.NewRegistry()
 	llmPlugin := llm.New(cfg, "test", "", "", mcpPlugin.Registry(), nil)
 	h := New(cfg, stateReg, []plugin.Plugin{mcpPlugin, llmPlugin})
@@ -106,15 +106,15 @@ func TestCORSAllowedOrigins(t *testing.T) {
 
 func TestDisableLLMPlugin(t *testing.T) {
 	cfg := config.ServerConfig{Port: 8080, MetricsAddr: ":8080", RequestTimeout: time.Second}
-	mcpPlugin := mcp.New(adapters.ServerState{}, mcp.Options{RequestTimeout: cfg.RequestTimeout}, nil)
+	mcpPlugin := mcp.New(adapters.ServerState{}, mcp.Options{RequestTimeout: cfg.RequestTimeout, ClientKey: cfg.ClientKey}, nil)
 	stateReg := serverstate.NewRegistry()
 	h := New(cfg, stateReg, []plugin.Plugin{mcpPlugin})
 	ts := httptest.NewServer(h)
 	defer ts.Close()
 
-	resp, err := http.Get(ts.URL + "/api/v1/models")
+	resp, err := http.Get(ts.URL + "/api/llm/v1/models")
 	if err != nil {
-		t.Fatalf("GET /api/v1/models: %v", err)
+		t.Fatalf("GET /api/llm/v1/models: %v", err)
 	}
 	if resp.StatusCode != http.StatusNotFound {
 		t.Fatalf("expected 404, got %d", resp.StatusCode)

--- a/server/test/e2e_api_key_test.go
+++ b/server/test/e2e_api_key_test.go
@@ -17,14 +17,14 @@ import (
 
 func TestAPIKeyEnforcement(t *testing.T) {
 	cfg := config.ServerConfig{APIKey: "test123", RequestTimeout: 5 * time.Second}
-	mcpPlugin := mcp.New(adapters.ServerState{}, mcp.Options{RequestTimeout: cfg.RequestTimeout}, nil)
+	mcpPlugin := mcp.New(adapters.ServerState{}, mcp.Options{RequestTimeout: cfg.RequestTimeout, ClientKey: cfg.ClientKey}, nil)
 	stateReg := serverstate.NewRegistry()
 	llmPlugin := llm.New(cfg, "test", "", "", mcpPlugin.Registry(), nil)
 	handler := server.New(cfg, stateReg, []plugin.Plugin{mcpPlugin, llmPlugin})
 	srv := httptest.NewServer(handler)
 	defer srv.Close()
 
-	resp, err := http.Get(srv.URL + "/api/v1/models")
+	resp, err := http.Get(srv.URL + "/api/llm/v1/models")
 	if err != nil {
 		t.Fatalf("get without key: %v", err)
 	}
@@ -35,7 +35,7 @@ func TestAPIKeyEnforcement(t *testing.T) {
 		t.Fatalf("close body: %v", err)
 	}
 
-	req, _ := http.NewRequest(http.MethodGet, srv.URL+"/api/v1/models", nil)
+	req, _ := http.NewRequest(http.MethodGet, srv.URL+"/api/llm/v1/models", nil)
 	req.Header.Set("Authorization", "Bearer test123")
 	resp, err = http.DefaultClient.Do(req)
 	if err != nil {

--- a/server/test/e2e_auth_test.go
+++ b/server/test/e2e_auth_test.go
@@ -23,7 +23,7 @@ import (
 
 func TestWorkerAuth(t *testing.T) {
 	cfg := config.ServerConfig{ClientKey: "secret", RequestTimeout: 5 * time.Second}
-	mcpPlugin := mcp.New(adapters.ServerState{}, mcp.Options{RequestTimeout: cfg.RequestTimeout}, nil)
+	mcpPlugin := mcp.New(adapters.ServerState{}, mcp.Options{RequestTimeout: cfg.RequestTimeout, ClientKey: cfg.ClientKey}, nil)
 	stateReg := serverstate.NewRegistry()
 	llmPlugin := llm.New(cfg, "test", "", "", mcpPlugin.Registry(), nil)
 	handler := server.New(cfg, stateReg, []plugin.Plugin{mcpPlugin, llmPlugin})
@@ -31,7 +31,7 @@ func TestWorkerAuth(t *testing.T) {
 	defer srv.Close()
 
 	ctx := context.Background()
-	wsURL := strings.Replace(srv.URL, "http", "ws", 1) + "/api/workers/connect"
+	wsURL := strings.Replace(srv.URL, "http", "ws", 1) + "/api/llm/connect"
 
 	// bad key
 	connBad, _, err := websocket.Dial(ctx, wsURL, nil)
@@ -75,7 +75,7 @@ func TestWorkerAuth(t *testing.T) {
 		}
 		time.Sleep(20 * time.Millisecond)
 	}
-	req, _ := http.NewRequest(http.MethodGet, srv.URL+"/api/v1/models", nil)
+	req, _ := http.NewRequest(http.MethodGet, srv.URL+"/api/llm/v1/models", nil)
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil || resp.StatusCode != http.StatusOK {
 		t.Fatalf("models: %v %d", err, resp.StatusCode)
@@ -87,7 +87,7 @@ func TestWorkerAuth(t *testing.T) {
 
 func TestWorkerClientKeyUnexpected(t *testing.T) {
 	cfg := config.ServerConfig{RequestTimeout: 5 * time.Second}
-	mcpPlugin := mcp.New(adapters.ServerState{}, mcp.Options{RequestTimeout: cfg.RequestTimeout}, nil)
+	mcpPlugin := mcp.New(adapters.ServerState{}, mcp.Options{RequestTimeout: cfg.RequestTimeout, ClientKey: cfg.ClientKey}, nil)
 	stateReg := serverstate.NewRegistry()
 	llmPlugin := llm.New(cfg, "test", "", "", mcpPlugin.Registry(), nil)
 	handler := server.New(cfg, stateReg, []plugin.Plugin{mcpPlugin, llmPlugin})
@@ -95,7 +95,7 @@ func TestWorkerClientKeyUnexpected(t *testing.T) {
 	defer srv.Close()
 
 	ctx := context.Background()
-	wsURL := strings.Replace(srv.URL, "http", "ws", 1) + "/api/workers/connect"
+	wsURL := strings.Replace(srv.URL, "http", "ws", 1) + "/api/llm/connect"
 	conn, _, err := websocket.Dial(ctx, wsURL, nil)
 	if err != nil {
 		t.Fatalf("dial: %v", err)
@@ -113,7 +113,7 @@ func TestWorkerClientKeyUnexpected(t *testing.T) {
 
 func TestMCPAuth(t *testing.T) {
 	cfg := config.ServerConfig{ClientKey: "secret", RequestTimeout: 5 * time.Second}
-	mcpPlugin := mcp.New(adapters.ServerState{}, mcp.Options{RequestTimeout: cfg.RequestTimeout}, nil)
+	mcpPlugin := mcp.New(adapters.ServerState{}, mcp.Options{RequestTimeout: cfg.RequestTimeout, ClientKey: cfg.ClientKey}, nil)
 	stateReg := serverstate.NewRegistry()
 	llmPlugin := llm.New(cfg, "test", "", "", mcpPlugin.Registry(), nil)
 	handler := server.New(cfg, stateReg, []plugin.Plugin{mcpPlugin, llmPlugin})
@@ -155,7 +155,7 @@ func TestMCPAuth(t *testing.T) {
 
 	// unexpected key when server has none
 	cfg = config.ServerConfig{RequestTimeout: 5 * time.Second}
-	mcpReg := mcp.New(adapters.ServerState{}, mcp.Options{RequestTimeout: cfg.RequestTimeout}, nil)
+	mcpReg := mcp.New(adapters.ServerState{}, mcp.Options{RequestTimeout: cfg.RequestTimeout, ClientKey: cfg.ClientKey}, nil)
 	stateReg = serverstate.NewRegistry()
 	llmPlugin = llm.New(cfg, "test", "", "", mcpReg.Registry(), nil)
 	handler = server.New(cfg, stateReg, []plugin.Plugin{mcpReg, llmPlugin})

--- a/server/test/e2e_chat_completions_proxy_test.go
+++ b/server/test/e2e_chat_completions_proxy_test.go
@@ -26,7 +26,7 @@ import (
 
 func TestE2EChatCompletionsProxy(t *testing.T) {
 	cfg := config.ServerConfig{ClientKey: "secret", APIKey: "apikey", RequestTimeout: 5 * time.Second}
-	mcpPlugin := mcp.New(adapters.ServerState{}, mcp.Options{RequestTimeout: cfg.RequestTimeout}, nil)
+	mcpPlugin := mcp.New(adapters.ServerState{}, mcp.Options{RequestTimeout: cfg.RequestTimeout, ClientKey: cfg.ClientKey}, nil)
 	stateReg := serverstate.NewRegistry()
 	llmPlugin := llm.New(cfg, "test", "", "", mcpPlugin.Registry(), nil)
 	handler := server.New(cfg, stateReg, []plugin.Plugin{mcpPlugin, llmPlugin})
@@ -67,14 +67,14 @@ func TestE2EChatCompletionsProxy(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	wsURL := strings.Replace(srv.URL, "http", "ws", 1) + "/api/workers/connect"
+	wsURL := strings.Replace(srv.URL, "http", "ws", 1) + "/api/llm/connect"
 	go func() {
 		_ = worker.Run(ctx, worker.Config{ServerURL: wsURL, ClientKey: "secret", CompletionBaseURL: ollama.URL + "/v1", CompletionAPIKey: "secret-123", ClientID: "w1", ClientName: "w1", MaxConcurrency: 2, EmbeddingBatchSize: 0})
 	}()
 
 	// wait for worker registration
 	for i := 0; i < 20; i++ {
-		resp, err := http.Get(srv.URL + "/api/v1/models")
+		resp, err := http.Get(srv.URL + "/api/llm/v1/models")
 		if err == nil {
 			var v struct {
 				Data []struct {
@@ -93,7 +93,7 @@ func TestE2EChatCompletionsProxy(t *testing.T) {
 	}
 
 	reqBody := []byte(`{"model":"llama3","stream":true}`)
-	req, _ := http.NewRequest(http.MethodPost, srv.URL+"/api/v1/chat/completions", bytes.NewReader(reqBody))
+	req, _ := http.NewRequest(http.MethodPost, srv.URL+"/api/llm/v1/chat/completions", bytes.NewReader(reqBody))
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Authorization", "Bearer apikey")
 	resp, err := http.DefaultClient.Do(req)

--- a/server/test/e2e_model_update_test.go
+++ b/server/test/e2e_model_update_test.go
@@ -23,7 +23,7 @@ import (
 
 func TestWorkerModelRefresh(t *testing.T) {
 	cfg := config.ServerConfig{RequestTimeout: 5 * time.Second}
-	mcpPlugin := mcp.New(adapters.ServerState{}, mcp.Options{RequestTimeout: cfg.RequestTimeout}, nil)
+	mcpPlugin := mcp.New(adapters.ServerState{}, mcp.Options{RequestTimeout: cfg.RequestTimeout, ClientKey: cfg.ClientKey}, nil)
 	stateReg := serverstate.NewRegistry()
 	llmPlugin := llm.New(cfg, "test", "", "", mcpPlugin.Registry(), nil)
 	handler := server.New(cfg, stateReg, []plugin.Plugin{mcpPlugin, llmPlugin})
@@ -31,7 +31,7 @@ func TestWorkerModelRefresh(t *testing.T) {
 	defer srv.Close()
 
 	ctx := context.Background()
-	wsURL := strings.Replace(srv.URL, "http", "ws", 1) + "/api/workers/connect"
+	wsURL := strings.Replace(srv.URL, "http", "ws", 1) + "/api/llm/connect"
 	conn, _, err := websocket.Dial(ctx, wsURL, nil)
 	if err != nil {
 		t.Fatalf("dial: %v", err)
@@ -46,7 +46,7 @@ func TestWorkerModelRefresh(t *testing.T) {
 
 	waitForModels := func(n int, expect string) {
 		for i := 0; i < 50; i++ {
-			resp, err := http.Get(srv.URL + "/api/v1/models")
+			resp, err := http.Get(srv.URL + "/api/llm/v1/models")
 			if err == nil {
 				var lr struct {
 					Data []struct {

--- a/server/test/e2e_models_api_test.go
+++ b/server/test/e2e_models_api_test.go
@@ -23,7 +23,7 @@ import (
 
 func TestModelsAPI(t *testing.T) {
 	cfg := config.ServerConfig{RequestTimeout: 5 * time.Second}
-	mcpPlugin := mcp.New(adapters.ServerState{}, mcp.Options{RequestTimeout: cfg.RequestTimeout}, nil)
+	mcpPlugin := mcp.New(adapters.ServerState{}, mcp.Options{RequestTimeout: cfg.RequestTimeout, ClientKey: cfg.ClientKey}, nil)
 	stateReg := serverstate.NewRegistry()
 	llmPlugin := llm.New(cfg, "test", "", "", mcpPlugin.Registry(), nil)
 	handler := server.New(cfg, stateReg, []plugin.Plugin{mcpPlugin, llmPlugin})
@@ -31,7 +31,7 @@ func TestModelsAPI(t *testing.T) {
 	defer srv.Close()
 
 	ctx := context.Background()
-	wsURL := strings.Replace(srv.URL, "http", "ws", 1) + "/api/workers/connect"
+	wsURL := strings.Replace(srv.URL, "http", "ws", 1) + "/api/llm/connect"
 
 	// Worker Alpha
 	connA, _, err := websocket.Dial(ctx, wsURL, nil)
@@ -57,7 +57,7 @@ func TestModelsAPI(t *testing.T) {
 
 	// wait for registration
 	for i := 0; i < 50; i++ {
-		resp, err := http.Get(srv.URL + "/api/v1/models")
+		resp, err := http.Get(srv.URL + "/api/llm/v1/models")
 		if err == nil {
 			var lr struct {
 				Data []struct {
@@ -76,7 +76,7 @@ func TestModelsAPI(t *testing.T) {
 		time.Sleep(20 * time.Millisecond)
 	}
 
-	resp, err := http.Get(srv.URL + "/api/v1/models")
+	resp, err := http.Get(srv.URL + "/api/llm/v1/models")
 	if err != nil {
 		t.Fatalf("list models: %v", err)
 	}
@@ -100,12 +100,12 @@ func TestModelsAPI(t *testing.T) {
 		}
 	}
 
-	resp, err = http.Get(srv.URL + "/api/v1/models/llama3:8b")
+	resp, err = http.Get(srv.URL + "/api/llm/v1/models/llama3:8b")
 	if err != nil || resp.StatusCode != http.StatusOK {
 		t.Fatalf("get model: %v %d", err, resp.StatusCode)
 	}
 	_ = resp.Body.Close()
-	resp, err = http.Get(srv.URL + "/api/v1/models/doesnotexist")
+	resp, err = http.Get(srv.URL + "/api/llm/v1/models/doesnotexist")
 	if err != nil || resp.StatusCode != http.StatusNotFound {
 		t.Fatalf("missing model: %v %d", err, resp.StatusCode)
 	}
@@ -114,7 +114,7 @@ func TestModelsAPI(t *testing.T) {
 	_ = connB.Close(websocket.StatusNormalClosure, "")
 	// wait for deregistration
 	for i := 0; i < 50; i++ {
-		resp, err := http.Get(srv.URL + "/api/v1/models")
+		resp, err := http.Get(srv.URL + "/api/llm/v1/models")
 		if err == nil {
 			var lr struct {
 				Data []struct {
@@ -133,7 +133,7 @@ func TestModelsAPI(t *testing.T) {
 		time.Sleep(20 * time.Millisecond)
 	}
 
-	resp, err = http.Get(srv.URL + "/api/v1/models")
+	resp, err = http.Get(srv.URL + "/api/llm/v1/models")
 	if err != nil {
 		t.Fatalf("list after disconnect: %v", err)
 	}

--- a/server/test/e2e_prune_test.go
+++ b/server/test/e2e_prune_test.go
@@ -22,7 +22,7 @@ import (
 
 func TestHeartbeatPrune(t *testing.T) {
 	cfg := config.ServerConfig{ClientKey: "secret", RequestTimeout: 5 * time.Second}
-	mcpPlugin := mcp.New(adapters.ServerState{}, mcp.Options{RequestTimeout: cfg.RequestTimeout}, nil)
+	mcpPlugin := mcp.New(adapters.ServerState{}, mcp.Options{RequestTimeout: cfg.RequestTimeout, ClientKey: cfg.ClientKey}, nil)
 	stateReg := serverstate.NewRegistry()
 	llmPlugin := llm.New(cfg, "test", "", "", mcpPlugin.Registry(), nil)
 	handler := server.New(cfg, stateReg, []plugin.Plugin{mcpPlugin, llmPlugin})
@@ -30,7 +30,7 @@ func TestHeartbeatPrune(t *testing.T) {
 	defer srv.Close()
 
 	ctx := context.Background()
-	wsURL := strings.Replace(srv.URL, "http", "ws", 1) + "/api/workers/connect"
+	wsURL := strings.Replace(srv.URL, "http", "ws", 1) + "/api/llm/connect"
 	conn, _, err := websocket.Dial(ctx, wsURL, nil)
 	if err != nil {
 		t.Fatalf("dial: %v", err)


### PR DESCRIPTION
## Summary
- add server-owned surface registration to mount plugins under `/api/{id}` and auto-wire optional capabilities
- route LLM APIs and worker WebSocket under `/api/llm`, update MCP relay mounting
- let plugins manage their own `/connect` endpoints and drop LLM-specific path from the OpenAPI spec

## Testing
- `make lint`
- `make build`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68af1567e15c832c8ea5b22a23ff025b