### PR TITLE
refactor plugin route registration

### DIFF
--- a/modules/common/spi/plugin.go
+++ b/modules/common/spi/plugin.go
@@ -13,10 +13,5 @@ type Plugin interface {
 }
 
 type WorkerProvider interface {
-	RegisterWebSocket(r chi.Router)
 	Scheduler() Scheduler
-}
-
-type RelayProvider interface {
-	RegisterRelayEndpoints(r chi.Router)
 }

--- a/modules/mcp/ext/mcpplugin.go
+++ b/modules/mcp/ext/mcpplugin.go
@@ -24,7 +24,10 @@ func New(state spi.ServerState, opts Options, pluginOpts map[string]string) *Plu
 func (p *Plugin) ID() string { return "mcp" }
 
 // RegisterRoutes registers HTTP routes; MCP uses relay endpoints only.
-func (p *Plugin) RegisterRoutes(r chi.Router) {}
+func (p *Plugin) RegisterRoutes(r chi.Router) {
+	r.Handle("/connect", p.broker.WSHandler(p.clientKey))
+	r.Handle("/id/{id}", p.broker.HTTPHandler())
+}
 
 // RegisterMetrics registers Prometheus collectors; MCP has none currently.
 func (p *Plugin) RegisterMetrics(reg *prometheus.Registry) {}
@@ -34,14 +37,7 @@ func (p *Plugin) RegisterState(reg spi.StateRegistry) {
 	reg.Add(spi.StateElement{ID: "mcp", Data: func() any { return p.broker.Snapshot() }})
 }
 
-// RegisterRelayEndpoints wires MCP relay HTTP/WS endpoints.
-func (p *Plugin) RegisterRelayEndpoints(r chi.Router) {
-	r.Handle("/connect", p.broker.WSHandler(p.clientKey))
-	r.Handle("/id/{id}", p.broker.HTTPHandler())
-}
-
 // Registry exposes the underlying broker for tests.
 func (p *Plugin) Registry() *mcpbroker.Registry { return p.broker }
 
 var _ spi.Plugin = (*Plugin)(nil)
-var _ spi.RelayProvider = (*Plugin)(nil)

--- a/server/internal/server/server.go
+++ b/server/internal/server/server.go
@@ -9,9 +9,12 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 
+	"github.com/gaspardpetit/nfrx/api/generated"
+	"github.com/gaspardpetit/nfrx/modules/mcp/ext/mcpbroker"
 	"github.com/gaspardpetit/nfrx/server/internal/adapters"
 	"github.com/gaspardpetit/nfrx/server/internal/api"
 	"github.com/gaspardpetit/nfrx/server/internal/config"
+	ctrlsrv "github.com/gaspardpetit/nfrx/server/internal/ctrlsrv"
 	"github.com/gaspardpetit/nfrx/server/internal/plugin"
 	"github.com/gaspardpetit/nfrx/server/internal/serverstate"
 )
@@ -37,6 +40,36 @@ func New(cfg config.ServerConfig, stateReg *serverstate.Registry, plugins []plug
 	prometheus.DefaultRegisterer = preg
 	prometheus.DefaultGatherer = preg
 	plugin.Load(r, preg, adapters.NewStateRegistry(stateReg), plugins)
+
+	var metricsReg *ctrlsrv.MetricsRegistry
+	var mcpReg *mcpbroker.Registry
+	for _, p := range plugins {
+		if mp, ok := p.(interface {
+			MetricsRegistry() *ctrlsrv.MetricsRegistry
+		}); ok {
+			metricsReg = mp.MetricsRegistry()
+		}
+		if rp, ok := p.(interface{ Registry() *mcpbroker.Registry }); ok {
+			mcpReg = rp.Registry()
+		}
+	}
+	impl := &api.API{Metrics: metricsReg, MCP: mcpReg}
+	wrapper := generated.ServerInterfaceWrapper{Handler: impl}
+
+	r.Get("/healthz", wrapper.GetHealthz)
+	r.Route("/api", func(ar chi.Router) {
+		ar.Route("/client", func(cr chi.Router) {
+			cr.Get("/openapi.json", api.OpenAPIHandler())
+			cr.Get("/*", api.SwaggerHandler())
+		})
+		ar.Group(func(g chi.Router) {
+			if cfg.APIKey != "" {
+				g.Use(api.APIKeyMiddleware(cfg.APIKey))
+			}
+			g.Get("/state", wrapper.GetApiState)
+			g.Get("/state/stream", wrapper.GetApiStateStream)
+		})
+	})
 
 	r.Get("/state", StateHandler())
 

--- a/server/templates/relayplugin/README.md
+++ b/server/templates/relayplugin/README.md
@@ -6,10 +6,6 @@ per-client services (similar to the MCP relay).
 Steps to adapt:
 
 1. Change `ID()` to a unique identifier.
-2. Register HTTP routes in `RegisterRoutes`.
+2. Register HTTP routes and WebSocket endpoints in `RegisterRoutes`.
 3. Add Prometheus collectors via `RegisterMetrics`.
 4. Publish state elements in `RegisterState`.
-5. Expose per-client relay endpoints from `RegisterRelayEndpoints`.
-
-The server will automatically detect the `RelayProvider` capability when the
-plugin is loaded.

--- a/server/templates/relayplugin/relayplugin.go
+++ b/server/templates/relayplugin/relayplugin.go
@@ -7,7 +7,7 @@ import (
 	"github.com/gaspardpetit/nfrx/modules/common/spi"
 )
 
-// Plugin is a minimal example implementing plugin.Plugin and plugin.RelayProvider.
+// Plugin is a minimal example implementing plugin.Plugin.
 type Plugin struct{}
 
 // New returns a new instance of the plugin.
@@ -19,6 +19,7 @@ func (p *Plugin) ID() string { return "relay-template" }
 // RegisterRoutes installs HTTP routes served by this plugin.
 func (p *Plugin) RegisterRoutes(r chi.Router) {
 	// r.Post("/api/relay", p.handleRequest)
+	// r.Handle("/api/relay/connect", p.handleRelay)
 }
 
 // RegisterMetrics adds Prometheus collectors.
@@ -29,9 +30,4 @@ func (p *Plugin) RegisterMetrics(reg *prometheus.Registry) {
 // RegisterState exposes values under /state.
 func (p *Plugin) RegisterState(reg spi.StateRegistry) {
 	// reg.Add(spi.StateElement{ID: "relay", Data: func() any { return "ok" }})
-}
-
-// RegisterRelayEndpoints attaches relay-specific routes.
-func (p *Plugin) RegisterRelayEndpoints(r chi.Router) {
-	// r.HandleFunc("/api/relay/connect", p.handleRelay)
 }

--- a/server/templates/workerplugin/README.md
+++ b/server/templates/workerplugin/README.md
@@ -4,11 +4,10 @@ This package provides a starting point for plugins that expose load-balanced
 workers.  Copy the directory and implement your own logic:
 
 1. Update `ID()` with a unique identifier.
-2. Register any HTTP routes in `RegisterRoutes`.
+2. Register any HTTP routes and WebSocket endpoints in `RegisterRoutes`.
 3. Add Prometheus collectors via `RegisterMetrics`.
 4. Publish state elements in `RegisterState`.
-5. Attach a worker WebSocket endpoint in `RegisterWebSocket`.
-6. Provide a scheduler that dispatches tasks in `Scheduler`.
+5. Provide a scheduler that dispatches tasks in `Scheduler`.
 
 The server will automatically detect the `WorkerProvider` capability when the
 plugin is loaded.

--- a/server/templates/workerplugin/workerplugin.go
+++ b/server/templates/workerplugin/workerplugin.go
@@ -19,6 +19,7 @@ func (p *Plugin) ID() string { return "worker-template" }
 // RegisterRoutes installs HTTP routes served by this plugin.
 func (p *Plugin) RegisterRoutes(r chi.Router) {
 	// r.Post("/api/example", p.handleRequest)
+	// r.Get("/api/example/connect", p.handleConnect)
 }
 
 // RegisterMetrics adds Prometheus collectors.
@@ -29,11 +30,6 @@ func (p *Plugin) RegisterMetrics(reg *prometheus.Registry) {
 // RegisterState exposes values under /state.
 func (p *Plugin) RegisterState(reg spi.StateRegistry) {
 	// reg.Add(spi.StateElement{ID: "example", Data: func() any { return "ok" }})
-}
-
-// RegisterWebSocket registers the worker connect endpoint.
-func (p *Plugin) RegisterWebSocket(r chi.Router) {
-	// r.Get("/api/example/connect", p.handleConnect)
 }
 
 // Scheduler returns the dispatch scheduler for this plugin.


### PR DESCRIPTION
## Summary
- have server register health, state, and client routes instead of llm plugin
- remove RegisterWebSocket and RelayProvider interfaces; plugins attach all routes themselves
- update llm and mcp plugins plus templates accordingly

## Testing
- `make lint`
- `make build`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68af2d3797d8832cae34bd41c0f11461