### PR TITLE
refactor: unify plugin interfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,7 +177,9 @@ A typical deployment looks like this:
 
 nfrx exposes a small plugin interface so new modules can register routes,
 metrics and state. Skeleton implementations for worker-based and relay-based
-plugins live under [templates/](templates/).
+plugins live under [templates/](templates/). Plugins receive generic
+`spi.Router` and `spi.MetricsRegistry` abstractions for HTTP wiring and
+metrics registration, keeping them decoupled from specific frameworks.
 
 ## macOS Menu Bar App
 

--- a/modules/common/spi/plugin.go
+++ b/modules/common/spi/plugin.go
@@ -1,17 +1,37 @@
 package spi
 
-import (
-	"github.com/go-chi/chi/v5"
-	"github.com/prometheus/client_golang/prometheus"
-)
+import "net/http"
 
+// Middleware represents an HTTP middleware function.
+type Middleware func(http.Handler) http.Handler
+
+// Router abstracts the HTTP router used by plugins.
+type Router interface {
+	Handle(pattern string, h http.Handler)
+	Group(fn func(r Router))
+	Route(pattern string, fn func(r Router))
+	Use(mw ...Middleware)
+	Get(pattern string, h http.Handler)
+	Post(pattern string, h http.Handler)
+}
+
+// Collector represents a metric collector.
+type Collector interface{}
+
+// MetricsRegistry abstracts the Prometheus registry used by plugins.
+type MetricsRegistry interface {
+	MustRegister(...Collector)
+}
+
+// Plugin is implemented by all plugins.
 type Plugin interface {
 	ID() string
-	RegisterRoutes(r chi.Router)
-	RegisterMetrics(reg *prometheus.Registry)
+	RegisterRoutes(r Router)
+	RegisterMetrics(reg MetricsRegistry)
 	RegisterState(reg StateRegistry)
 }
 
+// WorkerProvider is implemented by plugins that handle load-balanced workers.
 type WorkerProvider interface {
 	Scheduler() Scheduler
 }

--- a/modules/llm/ext/openai/mount.go
+++ b/modules/llm/ext/openai/mount.go
@@ -2,10 +2,9 @@ package openai
 
 import (
 	"github.com/gaspardpetit/nfrx/modules/common/spi"
-	"github.com/go-chi/chi/v5"
 )
 
-func Mount(v1 chi.Router, reg spi.WorkerRegistry, sched spi.Scheduler, metrics spi.Metrics, opts Options) {
+func Mount(v1 spi.Router, reg spi.WorkerRegistry, sched spi.Scheduler, metrics spi.Metrics, opts Options) {
 	v1.Post("/chat/completions", ChatCompletionsHandler(reg, sched, metrics, opts.RequestTimeout))
 	v1.Post("/embeddings", EmbeddingsHandler(reg, sched, metrics, opts.RequestTimeout, opts.MaxParallelEmbeddings))
 	v1.Get("/models", ListModelsHandler(reg))

--- a/modules/mcp/ext/mcpplugin.go
+++ b/modules/mcp/ext/mcpplugin.go
@@ -1,9 +1,6 @@
 package mcp
 
 import (
-	"github.com/go-chi/chi/v5"
-	"github.com/prometheus/client_golang/prometheus"
-
 	"github.com/gaspardpetit/nfrx/modules/common/spi"
 	mcpbroker "github.com/gaspardpetit/nfrx/modules/mcp/ext/mcpbroker"
 )
@@ -24,13 +21,13 @@ func New(state spi.ServerState, opts Options, pluginOpts map[string]string) *Plu
 func (p *Plugin) ID() string { return "mcp" }
 
 // RegisterRoutes registers HTTP routes; MCP uses relay endpoints only.
-func (p *Plugin) RegisterRoutes(r chi.Router) {
+func (p *Plugin) RegisterRoutes(r spi.Router) {
 	r.Handle("/connect", p.broker.WSHandler(p.clientKey))
 	r.Handle("/id/{id}", p.broker.HTTPHandler())
 }
 
 // RegisterMetrics registers Prometheus collectors; MCP has none currently.
-func (p *Plugin) RegisterMetrics(reg *prometheus.Registry) {}
+func (p *Plugin) RegisterMetrics(reg spi.MetricsRegistry) {}
 
 // RegisterState registers MCP state elements.
 func (p *Plugin) RegisterState(reg spi.StateRegistry) {

--- a/server/internal/metrics/prom.go
+++ b/server/internal/metrics/prom.go
@@ -4,6 +4,8 @@ import (
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/gaspardpetit/nfrx/modules/common/spi"
 )
 
 var (
@@ -83,7 +85,7 @@ var (
 )
 
 // Register registers all metrics with the provided registerer.
-func Register(r prometheus.Registerer) {
+func Register(r spi.MetricsRegistry) {
 	r.MustRegister(buildInfo, modelRequests, modelTokens, requestDuration, workerTokens, workerProcessing, modelEmbeddings, workerEmbeddings, workerEmbeddingProcessing)
 }
 

--- a/server/templates/relayplugin/relayplugin.go
+++ b/server/templates/relayplugin/relayplugin.go
@@ -1,9 +1,6 @@
 package relayplugin
 
 import (
-	"github.com/go-chi/chi/v5"
-	"github.com/prometheus/client_golang/prometheus"
-
 	"github.com/gaspardpetit/nfrx/modules/common/spi"
 )
 
@@ -17,13 +14,13 @@ func New() *Plugin { return &Plugin{} }
 func (p *Plugin) ID() string { return "relay-template" }
 
 // RegisterRoutes installs HTTP routes served by this plugin.
-func (p *Plugin) RegisterRoutes(r chi.Router) {
+func (p *Plugin) RegisterRoutes(r spi.Router) {
 	// r.Post("/api/relay", p.handleRequest)
 	// r.Handle("/api/relay/connect", p.handleRelay)
 }
 
 // RegisterMetrics adds Prometheus collectors.
-func (p *Plugin) RegisterMetrics(reg *prometheus.Registry) {
+func (p *Plugin) RegisterMetrics(reg spi.MetricsRegistry) {
 	// reg.MustRegister(myCollector)
 }
 

--- a/server/templates/workerplugin/workerplugin.go
+++ b/server/templates/workerplugin/workerplugin.go
@@ -1,9 +1,6 @@
 package workerplugin
 
 import (
-	"github.com/go-chi/chi/v5"
-	"github.com/prometheus/client_golang/prometheus"
-
 	"github.com/gaspardpetit/nfrx/modules/common/spi"
 )
 
@@ -17,13 +14,13 @@ func New() *Plugin { return &Plugin{} }
 func (p *Plugin) ID() string { return "worker-template" }
 
 // RegisterRoutes installs HTTP routes served by this plugin.
-func (p *Plugin) RegisterRoutes(r chi.Router) {
+func (p *Plugin) RegisterRoutes(r spi.Router) {
 	// r.Post("/api/example", p.handleRequest)
 	// r.Get("/api/example/connect", p.handleConnect)
 }
 
 // RegisterMetrics adds Prometheus collectors.
-func (p *Plugin) RegisterMetrics(reg *prometheus.Registry) {
+func (p *Plugin) RegisterMetrics(reg spi.MetricsRegistry) {
 	// reg.MustRegister(myCollector)
 }
 


### PR DESCRIPTION
## Summary
- expose generic Router and MetricsRegistry abstractions in the plugin SPI
- adapt server plugin loader to wrap chi router and prometheus registry
- update llm and mcp plugins and templates to use the new interfaces

## Testing
- `make lint`
- `make build`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68af527867fc832cb6031343bf39536c