### PR TITLE
fix(ci): reset changelog state before checkout

### DIFF
--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -1,0 +1,64 @@
+name: post-release
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  update-files:
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Install changelog tools
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y devscripts jq
+
+      - name: Compute version metadata (from release tag)
+        id: meta
+        shell: bash
+        run: |
+          set -euo pipefail
+          TAG="${{ github.event.release.tag_name }}"
+          UPSTREAM="${TAG#v}"
+          UPSTREAM="${UPSTREAM//-/'~'}"
+          DEBVER="${UPSTREAM}-1"
+          {
+            echo "tag=${TAG}"
+            echo "debver=${DEBVER}"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Update post-release files
+        shell: bash
+        env:
+          DEBFULLNAME: "CI"
+          DEBEMAIL: "ci@example.invalid"
+          DEB_VERSION: ${{ steps.meta.outputs.debver }}
+          BUILD_KIND:  release
+        run: |
+          set -euo pipefail
+          chmod +x .github/scripts/deb_changelog.sh
+          .github/scripts/deb_changelog.sh
+
+      - name: Commit changes
+        shell: bash
+        run: |
+          set -euo pipefail
+          TAG="${{ steps.meta.outputs.tag }}"
+          git config user.name  "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          if ! git diff --quiet; then
+            git add -A
+            git commit -m "chore(release): update version files for ${TAG} [skip ci]"
+            git push
+          else
+            echo "No post-release updates to commit."
+          fi
+

--- a/.github/workflows/release-deb.yml
+++ b/.github/workflows/release-deb.yml
@@ -68,37 +68,6 @@ jobs:
           .github/scripts/deb_changelog.sh
           head -40 debian/changelog || true
 
-      - name: Commit changelog back to default branch
-        shell: bash
-        run: |
-          set -euo pipefail
-          TAG="${{ steps.meta.outputs.tag }}"
-          BRANCH="${{ github.event.repository.default_branch }}"
-
-          cp debian/changelog /tmp/debian.changelog
-
-          # Reset working tree to allow switching branches
-          git reset --hard
-
-          git fetch origin "$BRANCH" --depth=1
-          git checkout "$BRANCH"
-
-          git pull --ff-only origin "$BRANCH" || true
-
-          mkdir -p debian
-          mv /tmp/debian.changelog debian/changelog
-
-          git config user.name  "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-
-          if ! git diff --quiet -- debian/changelog; then
-            git add debian/changelog
-            git commit -m "chore(debian): update changelog for ${TAG} [skip ci]"
-            git push origin "$BRANCH"
-          else
-            echo "No changelog changes to commit."
-          fi
-
       - name: Build (binary package only)
         env:
           DEB_HOST_ARCH: ${{ matrix.arch }}

--- a/.github/workflows/release-deb.yml
+++ b/.github/workflows/release-deb.yml
@@ -77,6 +77,9 @@ jobs:
 
           cp debian/changelog /tmp/debian.changelog
 
+          # Reset working tree to allow switching branches
+          git reset --hard
+
           git fetch origin "$BRANCH" --depth=1
           git checkout "$BRANCH"
 


### PR DESCRIPTION
## Summary
- reset working tree in release-deb changelog commit step before switching branches

## Testing
- `make lint`
- `make build`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68afbd10bd38832cbee5ff18d5f36b01