### PR TITLE
fix: execute plugin scripts in state view

### DIFF
--- a/server/internal/server/state.html
+++ b/server/internal/server/state.html
@@ -114,14 +114,14 @@ async function maybeLoadViews(plugins) {
         if (html && html.trim().length > 0) {
           const section = document.createElement('section');
           section.id = `plugin-${id}`;
+          section.dataset.pluginId = id;
           const h = document.createElement('h3');
           h.textContent = `Plugin: ${id}`;
           const div = document.createElement('div');
-          div.innerHTML = html;
-          section.dataset.pluginId = id;
           section.appendChild(h);
           section.appendChild(div);
           host.appendChild(section);
+          div.innerHTML = html;
         }
       }
     } catch (e) {


### PR DESCRIPTION
## Summary
- attach plugin section to DOM before injecting HTML to run scripts

## Testing
- `make lint` *(fails: make: *** [Makefile:23: lint] Interrupt)*
- `make build`
- `make test` *(fails: signal: interrupt)*

------
https://chatgpt.com/codex/tasks/task_e_68afeecd552c832c8a2d7e1ac32535ec