### PR TITLE
feat: add ASR worker proxy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,7 @@ The repository contains four binaries:
 - `nfrx-llm`: connects to the server and forwards requests to a local Ollama
 - `nfrx-mcp`: bridges private MCP providers to the public server
 - `nfrx-docling`: connects to the server and forwards document conversion requests to a local Docling service
+- `nfrx-asr`: connects to the server and forwards audio transcription requests to a local ASR service
 
 ## Build & Commands
 - Build all binaries: `make build`
@@ -48,7 +49,7 @@ The repository contains four binaries:
 
 ## Git Hygiene
 - Always review `git status` before committing. Avoid adding built executables or other generated artifacts.
-- Do not commit the server binaries produced by `make build` (they appear at repo root): `nfrx`, `nfrx-llm`, `nfrx-mcp`, `nfrx-docling`.
+- Do not commit the server binaries produced by `make build` (they appear at repo root): `nfrx`, `nfrx-llm`, `nfrx-mcp`, `nfrx-docling`, `nfrx-asr`.
 - If you accidentally stage generated files, unstage them before committing (e.g., `git restore --staged <file>`).
 - Prefer small, focused commits with descriptive messages. Group refactors and moves separately from behavioral changes.
 

--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,7 @@ build:
 	go build $(GOFLAGS) -ldflags "$(LDFLAGS)" ./modules/llm/agent/cmd/nfrx-llm
 	go build $(GOFLAGS) -ldflags "$(LDFLAGS)" ./modules/mcp/agent/cmd/nfrx-mcp
 	go build $(GOFLAGS) -ldflags "$(LDFLAGS)" ./modules/docling/agent/cmd/nfrx-docling
+	go build $(GOFLAGS) -ldflags "$(LDFLAGS)" ./modules/asr/agent/cmd/nfrx-asr
 
 test:
 	go test ./... -race -count=1

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ PORT=${MY_SERVER_PORT} CLIENT_KEY="${MY_CLIENT_KEY}" API_KEY="${MY_API_KEY}" \
 
 You may then choose to expose an LLM provider, an MCP server and/or a RAG system from private hardware behind a NAT/Firewall.
 
-Set `PLUGINS` to control which modules load (`llm`, `mcp`, `docling`; defaults to all available). For example, `PLUGINS=llm` disables the MCP relay.
+Set `PLUGINS` to control which modules load (`llm`, `mcp`, `docling`, `asr`; defaults to all available). For example, `PLUGINS=llm` disables the MCP relay.
 
 ### Expose a local Docling converter (document extraction)
 
@@ -92,6 +92,45 @@ curl -X POST "https://${MY_SERVER_ADDR}/api/docling/v1/convert/source" \
 ```
 
 For file uploads, POST multipart/form-data to `/api/docling/v1/convert/file` with the same headers.
+
+### Expose a local ASR transcriber (speech to text)
+
+Run the ASR agent on your private machine to proxy audio transcription requests to a local service such as Verbatim.
+
+##### Docker
+
+```bash
+docker run --rm \
+  -e SERVER_URL="wss://${MY_SERVER_ADDR}/api/asr/connect" \
+  -e CLIENT_KEY="${MY_CLIENT_KEY}" \
+  -e ASR_BASE_URL="http://host.docker.internal:5002/v1" \
+  ghcr.io/gaspardpetit/nfrx-asr:main
+```
+
+##### Bare (Linux)
+
+```bash
+SERVER_URL="wss://${MY_SERVER_ADDR}/api/asr/connect" \
+CLIENT_KEY="${MY_CLIENT_KEY}" \
+ASR_BASE_URL="http://127.0.0.1:5002/v1" \
+nfrx-asr   # or: go run ./modules/asr/agent/cmd/nfrx-asr
+```
+
+After connecting, list available models:
+
+```bash
+curl "https://${MY_SERVER_ADDR}/api/asr/v1/models" \
+  -H "Authorization: Bearer ${MY_API_KEY}"
+```
+
+Then transcribe audio via the public server:
+
+```bash
+curl -X POST "https://${MY_SERVER_ADDR}/api/asr/v1/audio/transcriptions" \
+  -H "Authorization: Bearer ${MY_API_KEY}" \
+  -F file="@speech.mp3" \
+  -F model="gpt-4o-transcribe"
+```
 
 ### Expose a local LLM worker (Ollama shown)
 
@@ -670,6 +709,7 @@ For manual end-to-end verification on a clean VM, see [desktop/windows/ACCEPTANC
 | Model alias fallback | ✅ | Falls back to base model when exact quantization not available |
 | OpenAI-compatible `POST /api/llm/v1/chat/completions` | ✅ | Proxied to workers without payload mutation |
 | OpenAI-compatible `POST /api/llm/v1/embeddings` | ✅ | Requests with large input arrays are split and processed in parallel across workers respecting each worker's ideal embedding batch size |
+| OpenAI-compatible `POST /api/asr/v1/audio/transcriptions` | ✅ | Proxies audio transcription requests, including SSE streaming |
 | API key authentication for clients | ✅ | `Authorization: Bearer <API_KEY>` for `/api` (including `/api/llm/v1`) |
 | Client key authentication | ✅ | Workers authenticate over WebSocket using `CLIENT_KEY` |
 | Dynamic model discovery | ✅ | Workers advertise supported models; server aggregates |

--- a/debian/control
+++ b/debian/control
@@ -30,3 +30,9 @@ Architecture: any
 Depends: ${misc:Depends}, adduser
 Description: nfrx docling worker component (daemon)
  The docling worker for nfrx.
+
+Package: nfrx-asr
+Architecture: any
+Depends: ${misc:Depends}, adduser
+Description: nfrx asr worker component (daemon)
+ The asr worker for nfrx.

--- a/debian/examples/asr.env
+++ b/debian/examples/asr.env
@@ -1,0 +1,21 @@
+# Example environment file for nfrx-asr
+
+# WebSocket URL of the server connect endpoint for the asr plugin
+# e.g., ws://server:8080/api/asr/connect
+SERVER_URL=ws://localhost:8080/api/asr/connect
+
+# Optional shared secret that the server expects
+# CLIENT_KEY=secret
+
+# Upstream ASR service base URL and optional API key
+ASR_BASE_URL=http://127.0.0.1:5002/v1
+# ASR_API_KEY=
+
+# Concurrency and behavior
+MAX_CONCURRENCY=2
+REQUEST_TIMEOUT=300
+RECONNECT=true
+
+# Local status/metrics endpoints
+# STATUS_ADDR=127.0.0.1:4558
+# METRICS_PORT=9093

--- a/debian/nfrx-asr.install
+++ b/debian/nfrx-asr.install
@@ -1,0 +1,3 @@
+build/bin/nfrx-asr usr/bin/
+debian/nfrx-asr.service usr/lib/systemd/system/
+debian/examples/asr.env etc/nfrx/asr.env

--- a/debian/nfrx-asr.service
+++ b/debian/nfrx-asr.service
@@ -1,0 +1,27 @@
+[Unit]
+Description=nfrx asr worker
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+User=nfrx
+Group=nfrx
+EnvironmentFile=-/etc/nfrx/asr.env
+ExecStart=/usr/bin/nfrx-asr $ASR_FLAGS
+Restart=on-failure
+RestartSec=3s
+AmbientCapabilities=
+NoNewPrivileges=true
+ProtectSystem=full
+ProtectHome=true
+PrivateTmp=true
+CapabilityBoundingSet=
+StateDirectory=nfrx
+RuntimeDirectory=nfrx
+ProtectKernelLogs=true
+ProtectKernelModules=true
+ProtectControlGroups=true
+LockPersonality=true
+
+[Install]
+WantedBy=multi-user.target

--- a/debian/rules
+++ b/debian/rules
@@ -39,14 +39,15 @@ GO_LDFLAGS := $(GO_STRIP_FLAGS) \
 override_dh_auto_build:
 	mkdir -p build/bin
 	set -e; \
-	for pkg in \
-	    server/cmd/nfrx \
-	    modules/llm/agent/cmd/nfrx-llm \
-	    modules/mcp/agent/cmd/nfrx-mcp \
-	    modules/docling/agent/cmd/nfrx-docling; do \
-	    bin=$$(basename $$pkg); \
-	    go build -ldflags "$(GO_LDFLAGS)" -o build/bin/$$bin ./$$pkg; \
-	done
+        for pkg in \
+            server/cmd/nfrx \
+            modules/llm/agent/cmd/nfrx-llm \
+            modules/mcp/agent/cmd/nfrx-mcp \
+            modules/docling/agent/cmd/nfrx-docling \
+            modules/asr/agent/cmd/nfrx-asr; do \
+            bin=$$(basename $$pkg); \
+            go build -ldflags "$(GO_LDFLAGS)" -o build/bin/$$bin ./$$pkg; \
+        done
 
 override_dh_auto_install:
 	# Installation handled via .install files

--- a/deploy/Dockerfile.asr
+++ b/deploy/Dockerfile.asr
@@ -1,0 +1,14 @@
+FROM --platform=$BUILDPLATFORM golang:1.24 AS build
+WORKDIR /src
+COPY go.mod go.sum ./
+COPY sdk/go.mod sdk/go.mod
+RUN go mod download
+COPY . .
+ARG TARGETOS TARGETARCH VERSION=dev GIT_SHA=unknown BUILD_DATE=unknown
+RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH \
+    go build -ldflags "-s -w -X main.version=${VERSION} -X main.buildSHA=${GIT_SHA} -X main.buildDate=${BUILD_DATE}" \
+      -o /out/nfrx-asr ./modules/asr/agent/cmd/nfrx-asr
+
+FROM gcr.io/distroless/base-debian12
+COPY --from=build /out/nfrx-asr /nfrx-asr
+ENTRYPOINT ["/nfrx-asr"]

--- a/doc/env.md
+++ b/doc/env.md
@@ -63,6 +63,29 @@ The worker optionally reads settings from a YAML config file. Defaults:
 | `RECONNECT` | — | reconnect to server on failure | `false` | `--reconnect`, `-r` |
 | `REQUEST_TIMEOUT` | — | seconds without backend feedback before failing a job | `300` | `--request-timeout` |
 
+## nfrx-asr
+
+The worker optionally reads settings from a YAML config file. Defaults:
+
+- macOS: `~/Library/Application Support/nfrx/asr.yaml`
+- Windows: `%ProgramData%\\nfrx\\asr.yaml`
+- Linux: `/etc/nfrx/asr.yaml`
+
+| Variable | Config key | Purpose | Default | CLI flag |
+|----------|------------|---------|---------|----------|
+| `CONFIG_FILE` | — | worker config file path | OS-specific | `--config` |
+| `SERVER_URL` | `server_url` | server WebSocket URL for registration | `ws://localhost:8080/api/asr/connect` | `--server-url` |
+| `CLIENT_KEY` | `client_key` | shared secret for authenticating with the server | unset | `--client-key` |
+| `ASR_BASE_URL` | `asr_base_url` | base URL of the ASR service | `http://127.0.0.1:5002/v1` | `--asr-base-url` |
+| `ASR_API_KEY` | `asr_api_key` | API key for the ASR service | unset | `--asr-api-key` |
+| `MAX_CONCURRENCY` | `max_concurrency` | maximum number of jobs processed concurrently | `2` | `--max-concurrency` |
+| `CLIENT_ID` | — | client identifier | unset | `--client-id` |
+| `CLIENT_NAME` | — | worker display name | hostname (or random) | `--client-name` |
+| `STATUS_ADDR` | `status_addr` | local status HTTP listen address | unset (disabled) | `--status-addr` |
+| `METRICS_PORT` | `metrics_addr` | Prometheus metrics listen address or port | unset (disabled) | `--metrics-port` |
+| `DRAIN_TIMEOUT` | — | time to wait for in-flight jobs on shutdown | `1m` | `--drain-timeout` |
+| `REQUEST_TIMEOUT` | — | seconds without backend feedback before failing a job | `300` | `--request-timeout` |
+| `RECONNECT` | — | reconnect to server on failure | `false` | `--reconnect`, `-r` |
 
 ## nfrx-mcp
 

--- a/doc/server-endpoints.md
+++ b/doc/server-endpoints.md
@@ -57,6 +57,24 @@ These endpoints are present when the `llm` plugin is enabled.
 | `GET /api/llm/v1/models` | – | List models. | API key |
 | `GET /api/llm/v1/models/{id}` | Path `{id}` | Get model details. | API key |
 
+## Audio Transcription API
+
+These endpoints are present when the `asr` plugin is enabled.
+
+### Worker Registration
+
+| Verb & Endpoint | Parameters | Description | Auth |
+| --- | --- | --- | --- |
+| `GET /api/asr/connect` (WS) | Initial message `{ type: "register", client_key?: string, worker_id?: string, worker_name?: string, models?: [string], max_concurrency?: int }` | Worker connects to server. | Client key |
+
+### Client Usage
+
+| Verb & Endpoint | Parameters | Description | Auth |
+| --- | --- | --- | --- |
+| `GET /api/asr/v1/models` | – | List models. | API key |
+| `GET /api/asr/v1/models/{id}` | Path `{id}` | Get model details. | API key |
+| `POST /api/asr/v1/audio/transcriptions` | Multipart form data: `file`, `model`, optional fields; `stream=true` for SSE | Proxy audio transcription requests. | API key |
+
 ## MCP API
 
 These endpoints are present when the `mcp` plugin is enabled.

--- a/modules/asr/agent/cmd/nfrx-asr/main.go
+++ b/modules/asr/agent/cmd/nfrx-asr/main.go
@@ -1,0 +1,95 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"net/http"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/gaspardpetit/nfrx/core/logx"
+	aconfig "github.com/gaspardpetit/nfrx/modules/asr/agent/internal/config"
+	wp "github.com/gaspardpetit/nfrx/sdk/base/agent/workerproxy"
+)
+
+var (
+	version   = "dev"
+	buildSHA  = "unknown"
+	buildDate = "unknown"
+)
+
+func main() {
+	showVersion := flag.Bool("version", false, "print version and exit")
+	var cfg aconfig.WorkerConfig
+	cfg.BindFlags()
+	flag.Parse()
+	if *showVersion {
+		fmt.Printf("nfrx-asr version=%s sha=%s date=%s\n", version, buildSHA, buildDate)
+		return
+	}
+	if cfg.ConfigFile != "" {
+		if err := cfg.LoadFile(cfg.ConfigFile); err != nil && !errors.Is(err, os.ErrNotExist) {
+			logx.Log.Fatal().Err(err).Str("path", cfg.ConfigFile).Msg("load config")
+		}
+	}
+	logx.Configure(cfg.LogLevel)
+	wp.SetBuildInfo(version, buildSHA, buildDate)
+	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer cancel()
+
+	probe := func(pctx context.Context) (wp.ProbeResult, error) {
+		req, err := http.NewRequestWithContext(pctx, http.MethodGet, cfg.BaseURL+"/models", nil)
+		if err != nil {
+			return wp.ProbeResult{Ready: false}, err
+		}
+		if cfg.APIKey != "" {
+			req.Header.Set("Authorization", "Bearer "+cfg.APIKey)
+		}
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			return wp.ProbeResult{Ready: false}, err
+		}
+		defer func() { _ = resp.Body.Close() }()
+		if resp.StatusCode >= 400 {
+			return wp.ProbeResult{Ready: false}, fmt.Errorf("status %s", resp.Status)
+		}
+		var v struct {
+			Data []struct {
+				ID string `json:"id"`
+			} `json:"data"`
+		}
+		if err := json.NewDecoder(resp.Body).Decode(&v); err != nil {
+			return wp.ProbeResult{Ready: false}, err
+		}
+		models := make([]string, 0, len(v.Data))
+		for _, m := range v.Data {
+			models = append(models, m.ID)
+		}
+		return wp.ProbeResult{Ready: true, Models: models, MaxConcurrency: cfg.MaxConcurrency}, nil
+	}
+
+	gcfg := wp.Config{
+		ServerURL:      cfg.ServerURL,
+		ClientKey:      cfg.ClientKey,
+		BaseURL:        cfg.BaseURL,
+		APIKey:         cfg.APIKey,
+		ProbeFunc:      probe,
+		MaxConcurrency: cfg.MaxConcurrency,
+		ClientID:       cfg.ClientID,
+		ClientName:     cfg.ClientName,
+		StatusAddr:     cfg.StatusAddr,
+		MetricsAddr:    cfg.MetricsAddr,
+		TokenBasename:  "asr",
+		DrainTimeout:   cfg.DrainTimeout,
+		RequestTimeout: cfg.RequestTimeout,
+		Reconnect:      cfg.Reconnect,
+		ConfigFile:     cfg.ConfigFile,
+	}
+	if err := wp.Run(ctx, gcfg); err != nil {
+		logx.Log.Fatal().Err(err).Msg("agent exited")
+	}
+}

--- a/modules/asr/agent/internal/config/worker.go
+++ b/modules/asr/agent/internal/config/worker.go
@@ -1,0 +1,101 @@
+package config
+
+import (
+	"flag"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	commoncfg "github.com/gaspardpetit/nfrx/core/config"
+	"github.com/google/uuid"
+	"gopkg.in/yaml.v3"
+)
+
+type WorkerConfig struct {
+	ServerURL      string
+	ClientKey      string
+	BaseURL        string
+	APIKey         string
+	MaxConcurrency int
+	ClientID       string
+	ClientName     string
+	StatusAddr     string
+	MetricsAddr    string
+	DrainTimeout   time.Duration
+	RequestTimeout time.Duration
+	ConfigFile     string
+	LogLevel       string
+	Reconnect      bool
+}
+
+func (c *WorkerConfig) BindFlags() {
+	cfgPath := commoncfg.DefaultConfigPath("asr.yaml")
+	c.ConfigFile = commoncfg.GetEnv("CONFIG_FILE", cfgPath)
+	c.LogLevel = commoncfg.GetEnv("LOG_LEVEL", "info")
+
+	c.ServerURL = commoncfg.GetEnv("SERVER_URL", "ws://localhost:8080/api/asr/connect")
+	c.ClientKey = commoncfg.GetEnv("CLIENT_KEY", "")
+	c.BaseURL = commoncfg.GetEnv("ASR_BASE_URL", "http://127.0.0.1:5002/v1")
+	c.APIKey = commoncfg.GetEnv("ASR_API_KEY", "")
+	if v, err := strconv.Atoi(commoncfg.GetEnv("MAX_CONCURRENCY", "2")); err == nil {
+		c.MaxConcurrency = v
+	} else {
+		c.MaxConcurrency = 2
+	}
+	c.ClientID = commoncfg.GetEnv("CLIENT_ID", "")
+	mp := commoncfg.GetEnv("METRICS_PORT", "")
+	if mp != "" && !strings.Contains(mp, ":") {
+		mp = ":" + mp
+	}
+	c.MetricsAddr = mp
+	if d, err := time.ParseDuration(commoncfg.GetEnv("DRAIN_TIMEOUT", "1m")); err == nil {
+		c.DrainTimeout = d
+	} else {
+		c.DrainTimeout = time.Minute
+	}
+	if v, err := strconv.ParseFloat(commoncfg.GetEnv("REQUEST_TIMEOUT", "300"), 64); err == nil {
+		c.RequestTimeout = time.Duration(v * float64(time.Second))
+	} else {
+		c.RequestTimeout = 5 * time.Minute
+	}
+	host, err := os.Hostname()
+	if err != nil || host == "" {
+		host = "asr-" + uuid.NewString()[:8]
+	}
+	c.ClientName = commoncfg.GetEnv("CLIENT_NAME", host)
+	if b, err := strconv.ParseBool(commoncfg.GetEnv("RECONNECT", "false")); err == nil {
+		c.Reconnect = b
+	}
+
+	flag.StringVar(&c.ConfigFile, "config", c.ConfigFile, "agent config file path")
+	flag.StringVar(&c.LogLevel, "log-level", c.LogLevel, "log verbosity")
+	flag.StringVar(&c.ServerURL, "server-url", c.ServerURL, "server WebSocket URL")
+	flag.StringVar(&c.ClientKey, "client-key", c.ClientKey, "shared secret with server")
+	flag.StringVar(&c.BaseURL, "asr-base-url", c.BaseURL, "ASR service base URL")
+	flag.StringVar(&c.APIKey, "asr-api-key", c.APIKey, "ASR API key for Authorization bearer")
+	flag.IntVar(&c.MaxConcurrency, "max-concurrency", c.MaxConcurrency, "max concurrent jobs")
+	flag.StringVar(&c.ClientID, "client-id", c.ClientID, "client identifier")
+	flag.StringVar(&c.ClientName, "client-name", c.ClientName, "client display name")
+	flag.StringVar(&c.StatusAddr, "status-addr", c.StatusAddr, "local status HTTP listen address")
+	flag.StringVar(&c.MetricsAddr, "metrics-port", c.MetricsAddr, "Prometheus metrics listen address or port")
+	flag.DurationVar(&c.DrainTimeout, "drain-timeout", c.DrainTimeout, "shutdown drain timeout")
+	flag.Func("request-timeout", "request timeout in seconds", func(v string) error {
+		f, err := strconv.ParseFloat(v, 64)
+		if err != nil {
+			return err
+		}
+		c.RequestTimeout = time.Duration(f * float64(time.Second))
+		return nil
+	})
+	flag.BoolVar(&c.Reconnect, "reconnect", c.Reconnect, "reconnect to server on failure")
+	flag.BoolVar(&c.Reconnect, "r", c.Reconnect, "short for --reconnect")
+}
+
+func (c *WorkerConfig) LoadFile(path string) error {
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return err
+	}
+	return yaml.Unmarshal(b, c)
+}

--- a/modules/asr/ext/asrplugin.go
+++ b/modules/asr/ext/asrplugin.go
@@ -1,0 +1,152 @@
+package asr
+
+import (
+	"net/http"
+	"time"
+
+	opt "github.com/gaspardpetit/nfrx/core/options"
+	"github.com/gaspardpetit/nfrx/sdk/api/spi"
+	basemetrics "github.com/gaspardpetit/nfrx/sdk/base/metrics"
+	baseplugin "github.com/gaspardpetit/nfrx/sdk/base/plugin"
+	baseworker "github.com/gaspardpetit/nfrx/sdk/base/worker"
+)
+
+// Plugin implements the ASR worker-style extension.
+type Plugin struct {
+	baseplugin.Base
+	reg      *baseworker.Registry
+	mxreg    *baseworker.MetricsRegistry
+	sch      baseworker.Scheduler
+	srvState spi.ServerState
+	srvOpts  spi.Options
+	authMW   spi.Middleware
+	mt       modelTracker
+}
+
+func (p *Plugin) RegisterRoutes(r spi.Router) {
+	p.Base.RegisterRoutes(r)
+	r.Handle("/connect", baseworker.WSHandler(p.reg, p.mxreg, p.srvOpts.ClientKey, p.srvState))
+	r.Group(func(g spi.Router) {
+		if p.srvState != nil {
+			g.Use(func(next http.Handler) http.Handler {
+				return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					if p.srvState.IsDraining() {
+						w.Header().Set("Content-Type", "application/json")
+						w.WriteHeader(http.StatusServiceUnavailable)
+						_, _ = w.Write([]byte(`{"error":"draining"}`))
+						return
+					}
+					next.ServeHTTP(w, r)
+				})
+			})
+		}
+		if p.authMW != nil {
+			g.Use(p.authMW)
+		}
+		g.Route("/v1", func(v1 spi.Router) {
+			timeout := p.srvOpts.RequestTimeout
+			v1.Get("/models", listModelsHandler(p.reg, &p.mt))
+			v1.Get("/models/{id}", getModelHandler(p.reg, &p.mt))
+			v1.Post("/audio/transcriptions", transcribeHandler(p.reg, p.sch, p.mxreg, timeout))
+		})
+	})
+}
+
+func (p *Plugin) RegisterMetrics(reg spi.MetricsRegistry) { basemetrics.Register(reg) }
+
+func (p *Plugin) RegisterState(reg spi.StateRegistry) {
+	reg.Add(spi.StateElement{ID: p.ID(), Data: func() any { return p.mxreg.Snapshot() }, HTML: func() string {
+		return `
+<div class="asr-view">
+  <div class="asr-workers"></div>
+  <script>(function(){
+    function statusColor(w){
+      var lastHb = w.last_heartbeat;
+      var inflight = (w.inflight||0);
+      if (w.last_error) return 'red';
+      if (lastHb && (Date.now() - new Date(lastHb).getTime() > 15000)) return 'orange';
+      if (inflight > 0) return 'gold';
+      return 'green';
+    }
+    function sortWorkers(list, sortBy){
+      return list.slice().sort(function(a,b){
+        switch (sortBy){
+          case 'youngest': return new Date(b.connected_at) - new Date(a.connected_at);
+          case 'busyness': {
+            var ba = ((a.inflight||0) + (a.queue_len||0)) / ((a.max_concurrency||1));
+            var bb = ((b.inflight||0) + (b.queue_len||0)) / ((b.max_concurrency||1));
+            return bb - ba;
+          }
+          case 'name': return (a.name||'').localeCompare(b.name||'');
+          case 'completed': return (b.processed_total|0) - (a.processed_total|0);
+          case 'errors': return (b.failures_total|0) - (a.failures_total|0);
+          case 'oldest': default: return new Date(a.connected_at) - new Date(b.connected_at);
+        }
+      });
+    }
+    function render(state, container){
+      var host = container.querySelector('.asr-workers');
+      if (!host) return;
+      var workers = (state && state.workers) || [];
+      var sortSel = document.getElementById('sort');
+      var sortBy = sortSel ? sortSel.value : 'oldest';
+      var list = sortWorkers(workers, sortBy);
+      host.innerHTML='';
+      list.forEach(function(w){
+        var div=document.createElement('div');
+        div.className='worker';
+        var status=statusColor(w);
+        var inflight=(w.inflight||0);
+        var qlen=(w.queue_len||0);
+        var maxc=(w.max_concurrency||1);
+        var busy=Math.min(1, (inflight + qlen) / (maxc || 1));
+        var name=(w.name || w.id || 'worker');
+        var avg=(w.avg_processing_ms||0);
+        var avgText=(avg && avg.toFixed)? avg.toFixed(0) : avg;
+        var processed=(w.processed_total||0);
+        div.innerHTML=
+          '<div class="busy-bar"><div class="fill" style="height:'+Math.round(busy*100)+'%"></div></div>'+
+          '<div class="name"><span class="status-dot" style="background:'+status+'"></span>'+name+'</div>'+
+          '<div>'+(w.status || '')+'</div>'+
+          '<div>inflight: '+inflight+'</div>'+
+          '<div>processed: '+processed+'</div>'+
+          '<div>avg processing: '+avgText+' ms</div>';
+        host.appendChild(div);
+      });
+    }
+    if (!window.NFRX) window.NFRX = { _renderers:{}, registerRenderer:function(id,fn){ this._renderers[id]=fn; } };
+    var section = (document.currentScript && document.currentScript.closest('section')) || null;
+    var id = (section && section.dataset && section.dataset.pluginId) || 'asr';
+    window.NFRX.registerRenderer(id, function(state, container, envelope){ render(state, container); });
+  })();</script>
+</div>`
+	}})
+}
+
+var _ spi.Plugin = (*Plugin)(nil)
+
+func New(state spi.ServerState, version, sha, date string, srvOpts spi.Options, authMW spi.Middleware) *Plugin {
+	reg := baseworker.NewRegistry()
+	mx := baseworker.NewMetricsRegistry(version, sha, date, func() string { return "" })
+	minScore := opt.Float(srvOpts.PluginOptions, Descriptor().ID, "min_score", 0.01)
+	sch := baseworker.NewScoreSchedulerWithMinScore(reg, NewASRScorer(), minScore)
+	go func() {
+		tick := srvOpts.AgentHeartbeatInterval
+		if tick == 0 {
+			tick = baseworker.HeartbeatInterval
+		}
+		expire := srvOpts.AgentHeartbeatExpiry
+		if expire == 0 {
+			expire = baseworker.HeartbeatExpiry
+		}
+		ticker := time.NewTicker(tick)
+		for range ticker.C {
+			reg.PruneExpired(expire)
+			if state != nil && !state.IsDraining() && reg.WorkerCount() == 0 {
+				state.SetStatus("not_ready")
+			}
+		}
+	}()
+	id := Descriptor().ID
+	return &Plugin{Base: baseplugin.NewBase(Descriptor(), srvOpts.PluginOptions[id]), reg: reg, mxreg: mx, sch: sch, srvState: state, srvOpts: srvOpts, authMW: authMW, mt: modelTracker{firstSeen: make(map[string]int64)}}
+}

--- a/modules/asr/ext/descriptor.go
+++ b/modules/asr/ext/descriptor.go
@@ -1,0 +1,11 @@
+package asr
+
+import "github.com/gaspardpetit/nfrx/sdk/api/spi"
+
+func Descriptor() spi.PluginDescriptor {
+	return spi.PluginDescriptor{
+		ID:      "asr",
+		Name:    "ASR",
+		Summary: "Audio transcription (worker-style)",
+	}
+}

--- a/modules/asr/ext/handlers.go
+++ b/modules/asr/ext/handlers.go
@@ -1,0 +1,224 @@
+package asr
+
+import (
+	"bytes"
+	"io"
+	"mime"
+	"mime/multipart"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	chiMiddleware "github.com/go-chi/chi/v5/middleware"
+	"github.com/google/uuid"
+
+	"github.com/gaspardpetit/nfrx/core/logx"
+	ctrl "github.com/gaspardpetit/nfrx/sdk/api/control"
+	basemetrics "github.com/gaspardpetit/nfrx/sdk/base/metrics"
+	baseworker "github.com/gaspardpetit/nfrx/sdk/base/worker"
+)
+
+// transcribeHandler proxies transcription requests to an eligible worker.
+func transcribeHandler(reg *baseworker.Registry, sched baseworker.Scheduler, mx *baseworker.MetricsRegistry, timeout time.Duration) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Body == nil {
+			http.Error(w, "bad request", http.StatusBadRequest)
+			return
+		}
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			http.Error(w, "bad request", http.StatusBadRequest)
+			return
+		}
+		ct := r.Header.Get("Content-Type")
+		if !strings.HasPrefix(ct, "multipart/form-data") {
+			http.Error(w, "bad request", http.StatusBadRequest)
+			return
+		}
+		var model string
+		var stream bool
+		if _, params, err := mime.ParseMediaType(ct); err == nil {
+			boundary := params["boundary"]
+			mr := multipart.NewReader(bytes.NewReader(body), boundary)
+			for {
+				part, err := mr.NextPart()
+				if err == io.EOF {
+					break
+				}
+				if err != nil {
+					break
+				}
+				switch name := part.FormName(); name {
+				case "model":
+					mb, _ := io.ReadAll(part)
+					model = string(mb)
+				case "stream":
+					sb, _ := io.ReadAll(part)
+					stream, _ = strconv.ParseBool(strings.TrimSpace(string(sb)))
+				}
+				_ = part.Close()
+			}
+		}
+		if model == "" {
+			http.Error(w, "no model", http.StatusBadRequest)
+			return
+		}
+		exact := reg.WorkersForLabel(model)
+		wk, err := sched.PickWorker(model)
+		if err != nil {
+			logx.Log.Warn().Str("model", model).Msg("no worker")
+			http.Error(w, "no worker", http.StatusNotFound)
+			return
+		}
+		if len(exact) == 0 {
+			if key, ok := ctrl.AliasKey(model); ok {
+				logx.Log.Info().Str("event", "alias_fallback").Str("requested_id", model).Str("alias_key", key).Str("worker_id", wk.ID).Str("worker_name", wk.Name).Msg("alias fallback")
+			}
+		}
+		reg.IncInFlight(wk.ID)
+		defer reg.DecInFlight(wk.ID)
+		basemetrics.RecordRequest("asr", "worker", "asr.transcribe", model)
+
+		reqID := uuid.NewString()
+		logID := chiMiddleware.GetReqID(r.Context())
+		logx.Log.Info().Str("request_id", logID).Str("worker_id", wk.ID).Str("worker_name", wk.Name).Str("model", model).Bool("stream", stream).Msg("dispatch")
+
+		ch := make(chan interface{}, 16)
+		wk.AddJob(reqID, ch)
+		defer wk.RemoveJob(reqID)
+
+		headers := map[string]string{}
+		for k, vals := range r.Header {
+			if len(vals) == 0 {
+				continue
+			}
+			headers[k] = vals[0]
+		}
+		rid := r.Header.Get("X-Request-Id")
+		if rid == "" {
+			rid = logID
+		}
+		headers["X-Request-Id"] = rid
+		headers["Cache-Control"] = "no-store"
+
+		msg := ctrl.HTTPProxyRequestMessage{
+			Type:      "http_proxy_request",
+			RequestID: reqID,
+			Method:    http.MethodPost,
+			Path:      "/audio/transcriptions",
+			Headers:   headers,
+			Stream:    stream,
+			Body:      body,
+		}
+		select {
+		case wk.Send <- msg:
+			basemetrics.RecordStart("asr", "worker", "asr.transcribe", model)
+			mx.RecordJobStart(wk.ID)
+			mx.SetWorkerStatus(wk.ID, baseworker.StatusWorking)
+		default:
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusServiceUnavailable)
+			_, _ = w.Write([]byte(`{"error":"worker_busy"}`))
+			return
+		}
+
+		flusher, _ := w.(http.Flusher)
+		ctx := r.Context()
+		start := time.Now()
+		headersSent := false
+		success := false
+		var errMsg string
+		var idle *time.Timer
+		var timeoutCh <-chan time.Time
+		if timeout > 0 {
+			idle = time.NewTimer(timeout)
+			timeoutCh = idle.C
+			defer idle.Stop()
+		}
+		defer func() {
+			dur := time.Since(start)
+			mx.RecordJobEnd(wk.ID, "asr", dur, 0, 0, 0, success, errMsg)
+			mx.SetWorkerStatus(wk.ID, baseworker.StatusIdle)
+			basemetrics.RecordComplete("asr", "worker", "asr.transcribe", model, errMsgIf(!success, errMsg), success, dur)
+		}()
+
+		for {
+			select {
+			case <-ctx.Done():
+				select {
+				case wk.Send <- ctrl.HTTPProxyCancelMessage{Type: "http_proxy_cancel", RequestID: reqID}:
+				default:
+				}
+				return
+			case <-timeoutCh:
+				errMsg = "timeout"
+				select {
+				case wk.Send <- ctrl.HTTPProxyCancelMessage{Type: "http_proxy_cancel", RequestID: reqID}:
+				default:
+				}
+				if !headersSent {
+					w.Header().Set("Content-Type", "application/json")
+					w.WriteHeader(http.StatusGatewayTimeout)
+					_, _ = w.Write([]byte(`{"error":"timeout"}`))
+				}
+				return
+			case msg, ok := <-ch:
+				if !ok {
+					if !headersSent {
+						w.Header().Set("Content-Type", "application/json")
+						w.WriteHeader(http.StatusBadGateway)
+						_, _ = w.Write([]byte(`{"error":"upstream_error"}`))
+					}
+					errMsg = "closed"
+					return
+				}
+				if idle != nil {
+					if !idle.Stop() {
+						<-timeoutCh
+					}
+					idle.Reset(timeout)
+					timeoutCh = idle.C
+				}
+				switch m := msg.(type) {
+				case ctrl.HTTPProxyResponseHeadersMessage:
+					headersSent = true
+					for k, v := range m.Headers {
+						if k == "Transfer-Encoding" || k == "Connection" {
+							continue
+						}
+						w.Header().Set(k, v)
+					}
+					if strings.EqualFold(w.Header().Get("Content-Type"), "text/event-stream") {
+						w.Header().Set("Cache-Control", "no-store")
+					}
+					w.WriteHeader(m.Status)
+					if flusher != nil {
+						flusher.Flush()
+					}
+				case ctrl.HTTPProxyResponseChunkMessage:
+					if len(m.Data) > 0 {
+						_, _ = w.Write(m.Data)
+						if flusher != nil {
+							flusher.Flush()
+						}
+					}
+				case ctrl.HTTPProxyResponseEndMessage:
+					if m.Error != nil {
+						errMsg = m.Error.Code
+					} else {
+						success = true
+					}
+					return
+				}
+			}
+		}
+	}
+}
+
+func errMsgIf(cond bool, msg string) string {
+	if cond {
+		return msg
+	}
+	return ""
+}

--- a/modules/asr/ext/models.go
+++ b/modules/asr/ext/models.go
@@ -1,0 +1,115 @@
+package asr
+
+import (
+	"encoding/json"
+	"net/http"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+
+	"github.com/gaspardpetit/nfrx/core/logx"
+	baseworker "github.com/gaspardpetit/nfrx/sdk/base/worker"
+)
+
+// modelTracker tracks first-seen timestamps for models.
+type modelTracker struct {
+	mu        sync.Mutex
+	firstSeen map[string]int64
+}
+
+// listModelsHandler aggregates models across workers.
+func listModelsHandler(reg *baseworker.Registry, mt *modelTracker) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		ws := reg.Snapshot()
+		ownersMap := make(map[string][]string)
+
+		mt.mu.Lock()
+		if mt.firstSeen == nil {
+			mt.firstSeen = make(map[string]int64)
+		}
+		now := time.Now().Unix()
+		for _, w := range ws {
+			name := w.NameValue()
+			for _, id := range w.LabelKeys() {
+				ownersMap[id] = append(ownersMap[id], name)
+				if _, ok := mt.firstSeen[id]; !ok {
+					mt.firstSeen[id] = now
+				}
+			}
+		}
+		type item struct {
+			ID      string `json:"id"`
+			Object  string `json:"object"`
+			Created int64  `json:"created"`
+			OwnedBy string `json:"owned_by"`
+		}
+		var data []item
+		for id, owners := range ownersMap {
+			sort.Strings(owners)
+			data = append(data, item{ID: id, Object: "model", Created: mt.firstSeen[id], OwnedBy: strings.Join(owners, ",")})
+		}
+		sort.Slice(data, func(i, j int) bool { return data[i].ID < data[j].ID })
+		mt.mu.Unlock()
+
+		resp := struct {
+			Object string `json:"object"`
+			Data   []item `json:"data"`
+		}{Object: "list", Data: data}
+
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(resp); err != nil {
+			logx.Log.Error().Err(err).Msg("encode models list")
+		}
+	}
+}
+
+// getModelHandler returns details for a specific model.
+func getModelHandler(reg *baseworker.Registry, mt *modelTracker) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		id := chi.URLParam(r, "id")
+		ws := reg.Snapshot()
+
+		var owners []string
+		mt.mu.Lock()
+		if mt.firstSeen == nil {
+			mt.firstSeen = make(map[string]int64)
+		}
+		now := time.Now().Unix()
+		for _, w := range ws {
+			if w.HasLabel(id) {
+				owners = append(owners, w.NameValue())
+			}
+		}
+		if len(owners) == 0 {
+			mt.mu.Unlock()
+			logx.Log.Warn().Str("model", id).Msg("model not found")
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusNotFound)
+			if err := json.NewEncoder(w).Encode(map[string]string{"error": "model_not_found"}); err != nil {
+				logx.Log.Error().Err(err).Msg("encode model not found")
+			}
+			return
+		}
+		if _, ok := mt.firstSeen[id]; !ok {
+			mt.firstSeen[id] = now
+		}
+		sort.Strings(owners)
+		created := mt.firstSeen[id]
+		mt.mu.Unlock()
+
+		resp := struct {
+			ID      string `json:"id"`
+			Object  string `json:"object"`
+			Created int64  `json:"created"`
+			OwnedBy string `json:"owned_by"`
+		}{ID: id, Object: "model", Created: created, OwnedBy: strings.Join(owners, ",")}
+
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(resp); err != nil {
+			logx.Log.Error().Err(err).Msg("encode model detail")
+		}
+	}
+}

--- a/modules/asr/ext/scorer.go
+++ b/modules/asr/ext/scorer.go
@@ -1,0 +1,29 @@
+package asr
+
+import (
+	ctrl "github.com/gaspardpetit/nfrx/sdk/api/control"
+	baseworker "github.com/gaspardpetit/nfrx/sdk/base/worker"
+)
+
+// asrScorer implements exact model match with alias fallback.
+// Exact matches score 1.0, alias matches score 0.5, others 0.0.
+type asrScorer struct{}
+
+func NewASRScorer() baseworker.Scorer { return asrScorer{} }
+
+func (asrScorer) Score(task string, w *baseworker.Worker) float64 {
+	if w == nil {
+		return 0
+	}
+	if w.Labels != nil && w.Labels[task] {
+		return 1.0
+	}
+	if ak, ok := ctrl.AliasKey(task); ok {
+		for m := range w.Labels {
+			if mk, ok2 := ctrl.AliasKey(m); ok2 && mk == ak {
+				return 0.5
+			}
+		}
+	}
+	return 0
+}

--- a/server/internal/plugin/registry.go
+++ b/server/internal/plugin/registry.go
@@ -3,6 +3,7 @@ package plugin
 import (
 	"net/http"
 
+	asr "github.com/gaspardpetit/nfrx/modules/asr/ext"
 	docling "github.com/gaspardpetit/nfrx/modules/docling/ext"
 	llm "github.com/gaspardpetit/nfrx/modules/llm/ext"
 	mcp "github.com/gaspardpetit/nfrx/modules/mcp/ext"
@@ -65,4 +66,7 @@ func init() {
 	Register("docling", func(state spi.ServerState, connect http.Handler, workers spi.WorkerRegistry, sched spi.Scheduler, metrics spi.Metrics, stateProvider func() any, version, sha, date string, opts spi.Options, authMW spi.Middleware) spi.Plugin {
 		return docling.New(state, version, sha, date, opts, authMW)
 	}, docling.Descriptor())
+	Register("asr", func(state spi.ServerState, connect http.Handler, workers spi.WorkerRegistry, sched spi.Scheduler, metrics spi.Metrics, stateProvider func() any, version, sha, date string, opts spi.Options, authMW spi.Middleware) spi.Plugin {
+		return asr.New(state, version, sha, date, opts, authMW)
+	}, asr.Descriptor())
 }


### PR DESCRIPTION
## Summary
- add nfrx-asr worker proxy and server plugin for audio transcription
- document ASR config and endpoints
- package ASR worker with Dockerfile and Debian files
- expose aggregated ASR model endpoints and default to /v1 backend

## Testing
- `make format`
- `make lint`
- `make build`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68b4d15f5e68832cbe7ad4ae0f920901