### PR TITLE
nfrx.queued event has a type

### DIFF
--- a/modules/llm/ext/openai/generation_proxy.go
+++ b/modules/llm/ext/openai/generation_proxy.go
@@ -386,7 +386,7 @@ func queueStatusWriter(w http.ResponseWriter, flusher http.Flusher, reqID, model
 		w.WriteHeader(http.StatusOK)
 		flusher.Flush()
 	}
-	payload := fmt.Sprintf(`{"request_id":"%s","model":"%s","position":%d}`,
+	payload := fmt.Sprintf(`{"type":"nfrx.queue","request_id":"%s","model":"%s","position":%d}`,
 		reqID, model, pos)
 	_, _ = w.Write([]byte("event: nfrx.queue\n"))
 	_, _ = w.Write([]byte("data: "))

--- a/modules/llm/ext/openai/generation_proxy_test.go
+++ b/modules/llm/ext/openai/generation_proxy_test.go
@@ -27,6 +27,7 @@ func TestQueueStatusWriterUsesDedicatedEvent(t *testing.T) {
 	payload = strings.TrimPrefix(payload, "data: ")
 	payload = strings.TrimSuffix(payload, "\n\n")
 	var msg struct {
+		Type      string `json:"type"`
 		RequestID string `json:"request_id"`
 		Model     string `json:"model"`
 		Position  int    `json:"position"`
@@ -34,7 +35,7 @@ func TestQueueStatusWriterUsesDedicatedEvent(t *testing.T) {
 	if err := json.Unmarshal([]byte(payload), &msg); err != nil {
 		t.Fatalf("unmarshal payload: %v", err)
 	}
-	if msg.RequestID != "req1" || msg.Model != "m" {
+	if msg.Type != "nfrx.queue" || msg.RequestID != "req1" || msg.Model != "m" {
 		t.Fatalf("unexpected queue payload %+v", msg)
 	}
 	if got := msg.Position; got != 2 {


### PR DESCRIPTION
This pull request updates the queue status event payload format in the LLM generation proxy, ensuring that the event type is explicitly included and properly validated in both the implementation and its corresponding test.

Event payload format update:

* The `queueStatusWriter` function now includes a `"type":"nfrx.queue"` field in the event payload, making the event type explicit for consumers.

Test improvements:

* The `TestQueueStatusWriterUsesDedicatedEvent` test has been updated to validate the new `"type"` field, ensuring the payload conforms to the new format and checking for the correct event type.