### PR TITLE
Feat/request failures as warnings

### DIFF
--- a/modules/llm/agent/internal/ollama/client.go
+++ b/modules/llm/agent/internal/ollama/client.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"strings"
@@ -35,6 +36,10 @@ func (c *Client) Tags(ctx context.Context) ([]string, error) {
 	defer func() {
 		_ = resp.Body.Close()
 	}()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
+		return nil, fmt.Errorf("tags status %s body=%q", resp.Status, summarizeBody(body, 256))
+	}
 	var v struct {
 		Models []struct {
 			Name string `json:"name"`
@@ -100,4 +105,18 @@ func ReadLines(r io.Reader) <-chan string {
 		close(ch)
 	}()
 	return ch
+}
+
+func summarizeBody(body []byte, limit int) string {
+	if limit <= 0 || len(body) == 0 {
+		return ""
+	}
+	s := strings.TrimSpace(string(body))
+	if len(s) <= limit {
+		return s
+	}
+	if limit <= 3 {
+		return s[:limit]
+	}
+	return s[:limit-3] + "..."
 }

--- a/modules/llm/agent/internal/openai/client.go
+++ b/modules/llm/agent/internal/openai/client.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"strings"
 )
@@ -40,7 +41,8 @@ func (c *Client) Models(ctx context.Context) ([]string, error) {
 		_ = resp.Body.Close()
 	}()
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, fmt.Errorf("models status %s", resp.Status)
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
+		return nil, fmt.Errorf("models status %s body=%q", resp.Status, summarizeBody(body, 256))
 	}
 	var v struct {
 		Data []struct {
@@ -57,4 +59,18 @@ func (c *Client) Models(ctx context.Context) ([]string, error) {
 		}
 	}
 	return models, nil
+}
+
+func summarizeBody(body []byte, limit int) string {
+	if limit <= 0 || len(body) == 0 {
+		return ""
+	}
+	s := strings.TrimSpace(string(body))
+	if len(s) <= limit {
+		return s
+	}
+	if limit <= 3 {
+		return s[:limit]
+	}
+	return s[:limit-3] + "..."
 }

--- a/modules/llm/ext/openai/embeddings.go
+++ b/modules/llm/ext/openai/embeddings.go
@@ -126,6 +126,10 @@ func EmbeddingsHandler(reg spi.WorkerRegistry, sched spi.Scheduler, metrics spi.
 		success := false
 		var errMsg string
 		embeddingsCount := uint64(1)
+		var upstreamStatus int
+		var errorBytes int
+		debugErrorBody := logx.Log.Debug().Enabled()
+		var errorBody []byte
 		var idle *time.Timer
 		var timeoutCh <-chan time.Time
 		if timeout > 0 {
@@ -196,6 +200,7 @@ func EmbeddingsHandler(reg spi.WorkerRegistry, sched spi.Scheduler, metrics spi.
 				}
 				switch m := msg.(type) {
 				case ctrl.HTTPProxyResponseHeadersMessage:
+					upstreamStatus = m.Status
 					headersSent = true
 					for k, v := range m.Headers {
 						if !strings.EqualFold(k, "Transfer-Encoding") && !strings.EqualFold(k, "Connection") {
@@ -218,6 +223,12 @@ func EmbeddingsHandler(reg spi.WorkerRegistry, sched spi.Scheduler, metrics spi.
 					}
 				case ctrl.HTTPProxyResponseChunkMessage:
 					if len(m.Data) > 0 {
+						if upstreamStatus >= http.StatusBadRequest {
+							errorBytes += len(m.Data)
+							if debugErrorBody {
+								errorBody = append(errorBody, m.Data...)
+							}
+						}
 						if _, err := w.Write(m.Data); err != nil {
 							logx.Log.Error().Err(err).Msg("write chunk")
 						} else {
@@ -238,6 +249,16 @@ func EmbeddingsHandler(reg spi.WorkerRegistry, sched spi.Scheduler, metrics spi.
 						logx.Log.Error().Str("request_id", logID).Str("worker_id", worker.ID()).Str("worker_name", worker.Name()).Str("model", meta.Model).Str("error_code", m.Error.Code).Str("error", m.Error.Message).Msg("upstream error")
 					} else {
 						success = true
+					}
+					if upstreamStatus >= http.StatusBadRequest && errorBytes > 0 {
+						lvl := logx.Log.Warn()
+						if upstreamStatus >= http.StatusInternalServerError || upstreamStatus == http.StatusUnauthorized || upstreamStatus == http.StatusForbidden {
+							lvl = logx.Log.Error()
+						}
+						lvl.Str("request_id", logID).Str("worker_id", worker.ID()).Str("worker_name", worker.Name()).Str("model", meta.Model).Int("status", upstreamStatus).Int("body_bytes", errorBytes).Msg("upstream response body observed")
+						if debugErrorBody {
+							logx.Log.Debug().Str("request_id", logID).Str("worker_id", worker.ID()).Str("worker_name", worker.Name()).Str("model", meta.Model).Int("status", upstreamStatus).Bytes("body", errorBody).Msg("upstream response body detail")
+						}
 					}
 					logx.Log.Info().Str("request_id", logID).Str("worker_id", worker.ID()).Str("worker_name", worker.Name()).Str("model", meta.Model).Dur("duration", time.Since(start)).Msg("complete")
 					return

--- a/modules/llm/ext/openai/generation_proxy.go
+++ b/modules/llm/ext/openai/generation_proxy.go
@@ -77,6 +77,10 @@ func generationProxyHandler(reg spi.WorkerRegistry, sched spi.Scheduler, metrics
 		var tokensIn, tokensOut uint64
 		var sseBuf string
 		var bodyBuf []byte
+		var upstreamStatus int
+		var errorBytes int
+		debugErrorBody := logx.Log.Debug().Enabled()
+		var errorBody []byte
 		var idle *time.Timer
 		var timeoutCh <-chan time.Time
 
@@ -287,6 +291,7 @@ func generationProxyHandler(reg spi.WorkerRegistry, sched spi.Scheduler, metrics
 				switch m := msg.(type) {
 				case ctrl.HTTPProxyResponseHeadersMessage:
 					priorHeadersSent := headersSent
+					upstreamStatus = m.Status
 					headersSent = true
 					for k, v := range m.Headers {
 						if strings.EqualFold(k, "Transfer-Encoding") || strings.EqualFold(k, "Connection") {
@@ -312,6 +317,12 @@ func generationProxyHandler(reg spi.WorkerRegistry, sched spi.Scheduler, metrics
 					}
 				case ctrl.HTTPProxyResponseChunkMessage:
 					if len(m.Data) > 0 {
+						if upstreamStatus >= http.StatusBadRequest {
+							errorBytes += len(m.Data)
+							if debugErrorBody {
+								errorBody = append(errorBody, m.Data...)
+							}
+						}
 						if _, err := w.Write(m.Data); err != nil {
 							logx.Log.Error().Err(err).Msg("write chunk")
 						} else {
@@ -370,6 +381,16 @@ func generationProxyHandler(reg spi.WorkerRegistry, sched spi.Scheduler, metrics
 						logx.Log.Error().Str("request_id", logID).Str("worker_id", worker.ID()).Str("worker_name", worker.Name()).Str("model", meta.Model).Str("error_code", m.Error.Code).Str("error", m.Error.Message).Str("path", spec.endpointPath).Msg("upstream error")
 					} else {
 						success = true
+					}
+					if upstreamStatus >= http.StatusBadRequest && errorBytes > 0 {
+						lvl := logx.Log.Warn()
+						if upstreamStatus >= http.StatusInternalServerError || upstreamStatus == http.StatusUnauthorized || upstreamStatus == http.StatusForbidden {
+							lvl = logx.Log.Error()
+						}
+						lvl.Str("request_id", logID).Str("worker_id", worker.ID()).Str("worker_name", worker.Name()).Str("model", meta.Model).Int("status", upstreamStatus).Str("path", spec.endpointPath).Int("body_bytes", errorBytes).Msg("upstream response body observed")
+						if debugErrorBody {
+							logx.Log.Debug().Str("request_id", logID).Str("worker_id", worker.ID()).Str("worker_name", worker.Name()).Str("model", meta.Model).Int("status", upstreamStatus).Str("path", spec.endpointPath).Bytes("body", errorBody).Msg("upstream response body detail")
+						}
 					}
 					logx.Log.Info().Str("request_id", logID).Str("worker_id", worker.ID()).Str("worker_name", worker.Name()).Str("model", meta.Model).Bool("stream", meta.Stream).Str("path", spec.endpointPath).Dur("duration", time.Since(start)).Msg("complete")
 					return

--- a/sdk/base/agent/workerproxy/http_proxy.go
+++ b/sdk/base/agent/workerproxy/http_proxy.go
@@ -40,7 +40,7 @@ func handleHTTPProxy(ctx context.Context, cfg Config, sendCh chan []byte, req ct
 	}
 	httpReq, err := http.NewRequestWithContext(reqCtx, req.Method, url, bytes.NewReader(req.Body))
 	if err != nil {
-		sendProxyError(reqCtx, req.RequestID, sendCh, err)
+		sendProxyError(reqCtx, req.RequestID, req.Method, url, sendCh, err)
 		return
 	}
 	for k, v := range req.Headers {
@@ -55,7 +55,7 @@ func handleHTTPProxy(ctx context.Context, cfg Config, sendCh chan []byte, req ct
 	httpReq.Header.Set("Connection", "close")
 	resp, err := http.DefaultClient.Do(httpReq)
 	if err != nil {
-		sendProxyError(reqCtx, req.RequestID, sendCh, err)
+		sendProxyError(reqCtx, req.RequestID, req.Method, url, sendCh, err)
 		return
 	}
 	defer func() { _ = resp.Body.Close() }()
@@ -123,7 +123,7 @@ func handleHTTPProxy(ctx context.Context, cfg Config, sendCh chan []byte, req ct
 	logx.Log.Info().Str("request_id", req.RequestID).Msg("proxy end")
 }
 
-func sendProxyError(ctx context.Context, id string, sendCh chan []byte, err error) {
+func sendProxyError(ctx context.Context, id, method, url string, sendCh chan []byte, err error) {
 	h := ctrl.HTTPProxyResponseHeadersMessage{Type: "http_proxy_response_headers", RequestID: id, Status: 502, Headers: map[string]string{"Content-Type": "application/json"}}
 	hb, _ := json.Marshal(h)
 	sendMsg(ctx, sendCh, hb)
@@ -133,6 +133,6 @@ func sendProxyError(ctx context.Context, id string, sendCh chan []byte, err erro
 	end := ctrl.HTTPProxyResponseEndMessage{Type: "http_proxy_response_end", RequestID: id, Error: &ctrl.HTTPProxyError{Code: "upstream_error", Message: err.Error()}}
 	eb, _ := json.Marshal(end)
 	sendMsg(ctx, sendCh, eb)
-	logx.Log.Error().Str("request_id", id).Err(err).Msg("proxy error")
+	logx.Log.Error().Str("request_id", id).Str("method", method).Str("url", url).Err(err).Msg("proxy error")
 	SetLastError(err.Error())
 }

--- a/sdk/base/agent/workerproxy/http_proxy.go
+++ b/sdk/base/agent/workerproxy/http_proxy.go
@@ -67,6 +67,17 @@ func handleHTTPProxy(ctx context.Context, cfg Config, sendCh chan []byte, req ct
 	hmsg := ctrl.HTTPProxyResponseHeadersMessage{Type: "http_proxy_response_headers", RequestID: req.RequestID, Status: resp.StatusCode, Headers: hdrs}
 	b, _ := json.Marshal(hmsg)
 	sendMsg(reqCtx, sendCh, b)
+	if resp.StatusCode >= http.StatusBadRequest {
+		lvl := logx.Log.Warn()
+		if resp.StatusCode >= http.StatusInternalServerError {
+			lvl = logx.Log.Error()
+		}
+		lvl.Str("request_id", req.RequestID).
+			Str("method", req.Method).
+			Str("url", url).
+			Int("status", resp.StatusCode).
+			Msg("proxy upstream response")
+	}
 	if evt := logx.Log.Debug(); evt.Enabled() {
 		evt.Str("request_id", req.RequestID).
 			Int("status", resp.StatusCode).

--- a/sdk/base/agent/workerproxy/run.go
+++ b/sdk/base/agent/workerproxy/run.go
@@ -236,7 +236,11 @@ func connectAndServe(ctx context.Context, cancelAll context.CancelFunc, cfg Conf
 	if err != nil {
 		if resp != nil {
 			// Log status and a subset of headers to help diagnose proxy issues
-			logx.Log.Warn().Err(err).Str("server", cfg.ServerURL).Int("status", resp.StatusCode).Interface("headers", resp.Header).Msg("websocket dial failed")
+			lvl := logx.Log.Warn()
+			if resp.StatusCode >= http.StatusInternalServerError || resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden {
+				lvl = logx.Log.Error()
+			}
+			lvl.Err(err).Str("server", cfg.ServerURL).Int("status", resp.StatusCode).Interface("headers", resp.Header).Msg("websocket dial failed")
 		} else {
 			logx.Log.Warn().Err(err).Str("server", cfg.ServerURL).Msg("websocket dial failed")
 		}
@@ -366,7 +370,11 @@ func connectAndServe(ctx context.Context, cancelAll context.CancelFunc, cfg Conf
 			SetConnectedToServer(false)
 			var ce websocket.CloseError
 			if errors.As(err, &ce) {
-				logx.Log.Error().Str("reason", ce.Reason).Msg("server connection closed")
+				lvl := logx.Log.Error()
+				if ce.Code == websocket.StatusNormalClosure || ce.Code == websocket.StatusGoingAway {
+					lvl = logx.Log.Warn()
+				}
+				lvl.Int("code", int(ce.Code)).Str("reason", ce.Reason).Msg("server connection closed")
 			} else {
 				logx.Log.Error().Err(err).Msg("server read error")
 			}
@@ -381,12 +389,14 @@ func connectAndServe(ctx context.Context, cancelAll context.CancelFunc, cfg Conf
 			Type string `json:"type"`
 		}
 		if err := json.Unmarshal(data, &env); err != nil {
+			logx.Log.Warn().Err(err).Str("body", summarizeBody(data, 512)).Msg("server message decode failed")
 			continue
 		}
 		switch env.Type {
 		case "http_proxy_request":
 			var hr ctrl.HTTPProxyRequestMessage
 			if err := json.Unmarshal(data, &hr); err != nil {
+				logx.Log.Warn().Err(err).Str("type", env.Type).Str("body", summarizeBody(data, 512)).Msg("server message decode failed")
 				continue
 			}
 			if IsDraining() {
@@ -408,6 +418,8 @@ func connectAndServe(ctx context.Context, cancelAll context.CancelFunc, cfg Conf
 					delete(reqCancels, hc.RequestID)
 				}
 				jobMu.Unlock()
+			} else {
+				logx.Log.Warn().Err(err).Str("type", env.Type).Str("body", summarizeBody(data, 512)).Msg("server message decode failed")
 			}
 		}
 	}

--- a/sdk/base/agent/workerproxy/summarize.go
+++ b/sdk/base/agent/workerproxy/summarize.go
@@ -1,0 +1,17 @@
+package workerproxy
+
+import "strings"
+
+func summarizeBody(body []byte, limit int) string {
+	if limit <= 0 || len(body) == 0 {
+		return ""
+	}
+	s := strings.TrimSpace(string(body))
+	if len(s) <= limit {
+		return s
+	}
+	if limit <= 3 {
+		return s[:limit]
+	}
+	return s[:limit-3] + "..."
+}

--- a/sdk/base/worker/partition.go
+++ b/sdk/base/worker/partition.go
@@ -270,6 +270,9 @@ func proxyHTTPOnce(ctx context.Context, worker spi.WorkerRef, reqID, logID, mode
 	start := time.Now()
 	var status int
 	var buf bytes.Buffer
+	var errorBytes int
+	debugErrorBody := logx.Log.Debug().Enabled()
+	var errorBody []byte
 	success := false
 	errMsg := ""
 	var idle *time.Timer
@@ -327,6 +330,12 @@ func proxyHTTPOnce(ctx context.Context, worker spi.WorkerRef, reqID, logID, mode
 			case ctrl.HTTPProxyResponseChunkMessage:
 				if len(m.Data) > 0 {
 					buf.Write(m.Data)
+					if status >= http.StatusBadRequest {
+						errorBytes += len(m.Data)
+						if debugErrorBody {
+							errorBody = append(errorBody, m.Data...)
+						}
+					}
 				}
 			case ctrl.HTTPProxyResponseEndMessage:
 				if m.Error != nil {
@@ -341,6 +350,16 @@ func proxyHTTPOnce(ctx context.Context, worker spi.WorkerRef, reqID, logID, mode
 				}
 				metrics.RecordJobEnd(worker.ID(), model, dur, 0, 0, embCount, success, errMsg)
 				metrics.SetWorkerStatus(worker.ID(), spi.StatusIdle)
+				if status >= http.StatusBadRequest && errorBytes > 0 {
+					lvl := logx.Log.Warn()
+					if status >= http.StatusInternalServerError || status == http.StatusUnauthorized || status == http.StatusForbidden {
+						lvl = logx.Log.Error()
+					}
+					lvl.Str("request_id", logID).Str("worker_id", worker.ID()).Str("worker_name", worker.Name()).Str("model", model).Str("path", path).Int("status", status).Int("body_bytes", errorBytes).Msg("upstream response body observed")
+					if debugErrorBody {
+						logx.Log.Debug().Str("request_id", logID).Str("worker_id", worker.ID()).Str("worker_name", worker.Name()).Str("model", model).Str("path", path).Int("status", status).Bytes("body", errorBody).Msg("upstream response body detail")
+					}
+				}
 				logx.Log.Info().Str("request_id", logID).Str("worker_id", worker.ID()).Str("worker_name", worker.Name()).Str("model", model).Dur("duration", dur).Msg("complete")
 				return buf.Bytes(), status, success && errMsg == "", errMsg
 			}

--- a/sdk/base/worker/ws.go
+++ b/sdk/base/worker/ws.go
@@ -43,18 +43,25 @@ func WSHandler(reg *Registry, metrics *MetricsRegistry, clientKey string, state 
 			Type string `json:"type"`
 		}
 		if err := json.Unmarshal(data, &env); err != nil || env.Type != "register" {
-			logx.Log.Warn().Err(err).Str("remote", r.RemoteAddr).Msg("ws invalid first message; expected register")
+			logx.Log.Warn().Err(err).Str("remote", r.RemoteAddr).Int("body_bytes", len(data)).Msg("ws invalid first message; expected register")
+			if evt := logx.Log.Debug(); evt.Enabled() {
+				evt.Err(err).Str("remote", r.RemoteAddr).Bytes("body", data).Msg("ws invalid first message detail")
+			}
 			_ = c.Close(websocket.StatusPolicyViolation, "expected register")
 			return
 		}
 		var rm ctrl.RegisterMessage
 		if err := json.Unmarshal(data, &rm); err != nil {
-			logx.Log.Error().Err(err).Str("remote", r.RemoteAddr).Msg("ws decode register")
+			logx.Log.Error().Err(err).Str("remote", r.RemoteAddr).Int("body_bytes", len(data)).Msg("ws decode register")
+			if evt := logx.Log.Debug(); evt.Enabled() {
+				evt.Err(err).Str("remote", r.RemoteAddr).Bytes("body", data).Msg("ws decode register detail")
+			}
 			return
 		}
 		// Authorize via header roles or bearer token; if no expected key is configured, allow
 		authorized := clientKey == "" || hasAnyAllowedRole(r.Header.Get("X-User-Roles"), allowedRoles) || checkBearer(r.Header.Get("Authorization"), clientKey)
 		if !authorized {
+			logx.Log.Warn().Str("remote", r.RemoteAddr).Str("worker_id", rm.WorkerID).Str("worker_name", rm.WorkerName).Msg("ws unauthorized register")
 			_ = c.Close(websocket.StatusPolicyViolation, "unauthorized")
 			return
 		}
@@ -123,10 +130,10 @@ func WSHandler(reg *Registry, metrics *MetricsRegistry, clientKey string, state 
 				var ce websocket.CloseError
 				if errors.As(err, &ce) {
 					lvl := logx.Log.Info()
-					if ce.Code != websocket.StatusNormalClosure {
+					if ce.Code != websocket.StatusNormalClosure && ce.Code != websocket.StatusGoingAway {
 						lvl = logx.Log.Error()
 					}
-					lvl.Str("worker_id", wk.ID).Str("worker_name", wk.Name).Str("reason", ce.Reason).Msg("disconnected")
+					lvl.Str("worker_id", wk.ID).Str("worker_name", wk.Name).Int("code", int(ce.Code)).Str("reason", ce.Reason).Msg("disconnected")
 				} else {
 					logx.Log.Error().Err(err).Str("worker_id", wk.ID).Str("worker_name", wk.Name).Msg("disconnected")
 				}
@@ -136,7 +143,10 @@ func WSHandler(reg *Registry, metrics *MetricsRegistry, clientKey string, state 
 				Type string `json:"type"`
 			}
 			if err := json.Unmarshal(msg, &env); err != nil {
-				logx.Log.Debug().Err(err).Str("worker_id", wk.ID).Str("worker_name", wk.Name).Msg("ws decode message")
+				logx.Log.Warn().Err(err).Str("worker_id", wk.ID).Str("worker_name", wk.Name).Int("body_bytes", len(msg)).Msg("ws decode message")
+				if evt := logx.Log.Debug(); evt.Enabled() {
+					evt.Err(err).Str("worker_id", wk.ID).Str("worker_name", wk.Name).Bytes("body", msg).Msg("ws decode message detail")
+				}
 				continue
 			}
 			switch env.Type {
@@ -145,6 +155,11 @@ func WSHandler(reg *Registry, metrics *MetricsRegistry, clientKey string, state 
 				if err := json.Unmarshal(msg, &m); err == nil {
 					reg.UpdateHeartbeat(wk.ID)
 					metrics.RecordHeartbeat(wk.ID, m.HostCPUPercent, m.HostRAMUsedPercent)
+				} else {
+					logx.Log.Warn().Err(err).Str("worker_id", wk.ID).Str("worker_name", wk.Name).Str("type", env.Type).Int("body_bytes", len(msg)).Msg("ws decode message")
+					if evt := logx.Log.Debug(); evt.Enabled() {
+						evt.Err(err).Str("worker_id", wk.ID).Str("worker_name", wk.Name).Str("type", env.Type).Bytes("body", msg).Msg("ws decode message detail")
+					}
 				}
 			case "status_update":
 				var m ctrl.StatusUpdateMessage
@@ -171,6 +186,11 @@ func WSHandler(reg *Registry, metrics *MetricsRegistry, clientKey string, state 
 					if m.Status != "" {
 						metrics.SetWorkerStatus(wk.ID, WorkerStatus(m.Status))
 					}
+				} else {
+					logx.Log.Warn().Err(err).Str("worker_id", wk.ID).Str("worker_name", wk.Name).Str("type", env.Type).Int("body_bytes", len(msg)).Msg("ws decode message")
+					if evt := logx.Log.Debug(); evt.Enabled() {
+						evt.Err(err).Str("worker_id", wk.ID).Str("worker_name", wk.Name).Str("type", env.Type).Bytes("body", msg).Msg("ws decode message detail")
+					}
 				}
 			case "job_chunk":
 				var m ctrl.JobChunkMessage
@@ -180,6 +200,11 @@ func WSHandler(reg *Registry, metrics *MetricsRegistry, clientKey string, state 
 					wk.mu.Unlock()
 					if ok {
 						ch <- m
+					}
+				} else {
+					logx.Log.Warn().Err(err).Str("worker_id", wk.ID).Str("worker_name", wk.Name).Str("type", env.Type).Int("body_bytes", len(msg)).Msg("ws decode message")
+					if evt := logx.Log.Debug(); evt.Enabled() {
+						evt.Err(err).Str("worker_id", wk.ID).Str("worker_name", wk.Name).Str("type", env.Type).Bytes("body", msg).Msg("ws decode message detail")
 					}
 				}
 			case "job_result":
@@ -195,6 +220,11 @@ func WSHandler(reg *Registry, metrics *MetricsRegistry, clientKey string, state 
 						ch <- m
 						close(ch)
 					}
+				} else {
+					logx.Log.Warn().Err(err).Str("worker_id", wk.ID).Str("worker_name", wk.Name).Str("type", env.Type).Int("body_bytes", len(msg)).Msg("ws decode message")
+					if evt := logx.Log.Debug(); evt.Enabled() {
+						evt.Err(err).Str("worker_id", wk.ID).Str("worker_name", wk.Name).Str("type", env.Type).Bytes("body", msg).Msg("ws decode message detail")
+					}
 				}
 			case "job_error":
 				var m ctrl.JobErrorMessage
@@ -209,6 +239,11 @@ func WSHandler(reg *Registry, metrics *MetricsRegistry, clientKey string, state 
 						ch <- m
 						close(ch)
 					}
+				} else {
+					logx.Log.Warn().Err(err).Str("worker_id", wk.ID).Str("worker_name", wk.Name).Str("type", env.Type).Int("body_bytes", len(msg)).Msg("ws decode message")
+					if evt := logx.Log.Debug(); evt.Enabled() {
+						evt.Err(err).Str("worker_id", wk.ID).Str("worker_name", wk.Name).Str("type", env.Type).Bytes("body", msg).Msg("ws decode message detail")
+					}
 				}
 			case "http_proxy_response_headers":
 				var m ctrl.HTTPProxyResponseHeadersMessage
@@ -219,6 +254,11 @@ func WSHandler(reg *Registry, metrics *MetricsRegistry, clientKey string, state 
 					if ok {
 						ch <- m
 					}
+				} else {
+					logx.Log.Warn().Err(err).Str("worker_id", wk.ID).Str("worker_name", wk.Name).Str("type", env.Type).Int("body_bytes", len(msg)).Msg("ws decode message")
+					if evt := logx.Log.Debug(); evt.Enabled() {
+						evt.Err(err).Str("worker_id", wk.ID).Str("worker_name", wk.Name).Str("type", env.Type).Bytes("body", msg).Msg("ws decode message detail")
+					}
 				}
 			case "http_proxy_response_chunk":
 				var m ctrl.HTTPProxyResponseChunkMessage
@@ -228,6 +268,11 @@ func WSHandler(reg *Registry, metrics *MetricsRegistry, clientKey string, state 
 					wk.mu.Unlock()
 					if ok {
 						ch <- m
+					}
+				} else {
+					logx.Log.Warn().Err(err).Str("worker_id", wk.ID).Str("worker_name", wk.Name).Str("type", env.Type).Int("body_bytes", len(msg)).Msg("ws decode message")
+					if evt := logx.Log.Debug(); evt.Enabled() {
+						evt.Err(err).Str("worker_id", wk.ID).Str("worker_name", wk.Name).Str("type", env.Type).Bytes("body", msg).Msg("ws decode message detail")
 					}
 				}
 			case "http_proxy_response_end":
@@ -242,6 +287,11 @@ func WSHandler(reg *Registry, metrics *MetricsRegistry, clientKey string, state 
 					if ok {
 						ch <- m
 						close(ch)
+					}
+				} else {
+					logx.Log.Warn().Err(err).Str("worker_id", wk.ID).Str("worker_name", wk.Name).Str("type", env.Type).Int("body_bytes", len(msg)).Msg("ws decode message")
+					if evt := logx.Log.Debug(); evt.Enabled() {
+						evt.Err(err).Str("worker_id", wk.ID).Str("worker_name", wk.Name).Str("type", env.Type).Bytes("body", msg).Msg("ws decode message detail")
 					}
 				}
 			default:


### PR DESCRIPTION
This pull request improves error handling, logging, and diagnostics across both the LLM agent/internal clients and the worker proxy infrastructure. The main focus is on enhanced visibility for upstream HTTP errors, including logging partial error bodies for debugging, and more informative logs for connection and protocol errors. Additionally, a utility for summarizing response bodies is introduced and reused in multiple places.

**Enhanced Error Logging and Diagnostics**

* Added detailed logging for upstream HTTP error responses, including capturing and logging the size and (optionally) the content of error bodies in `generation_proxy.go`, `embeddings.go`, and `partition.go`, with log severity adjusted based on status code. [[1]](diffhunk://#diff-645c8bcd2398794e3a68a63f1ad1133463f8d2082b59b2ca1f398bab44c1b050R80-R83) [[2]](diffhunk://#diff-645c8bcd2398794e3a68a63f1ad1133463f8d2082b59b2ca1f398bab44c1b050R320-R325) [[3]](diffhunk://#diff-645c8bcd2398794e3a68a63f1ad1133463f8d2082b59b2ca1f398bab44c1b050R385-R394) [[4]](diffhunk://#diff-48dc5b55d7be9ce061f6137e0b722eeec3415ce0fc36071c85e118e691a5a9daR129-R132) [[5]](diffhunk://#diff-48dc5b55d7be9ce061f6137e0b722eeec3415ce0fc36071c85e118e691a5a9daR226-R231) [[6]](diffhunk://#diff-48dc5b55d7be9ce061f6137e0b722eeec3415ce0fc36071c85e118e691a5a9daR253-R262) [[7]](diffhunk://#diff-97ff99848e9b7d1e256c0e5513aff094430a7e82299f65f1d67c792459479f1aR273-R275) [[8]](diffhunk://#diff-97ff99848e9b7d1e256c0e5513aff094430a7e82299f65f1d67c792459479f1aR333-R338) [[9]](diffhunk://#diff-97ff99848e9b7d1e256c0e5513aff094430a7e82299f65f1d67c792459479f1aR353-R362)
* Improved logging for HTTP proxy errors and upstream status codes, including method and URL, in `http_proxy.go`. [[1]](diffhunk://#diff-0d053f64e0b6d0e92a018f3a271a161c1c4703d4a7ea456dfdce90aec56622bdL43-R43) [[2]](diffhunk://#diff-0d053f64e0b6d0e92a018f3a271a161c1c4703d4a7ea456dfdce90aec56622bdL58-R58) [[3]](diffhunk://#diff-0d053f64e0b6d0e92a018f3a271a161c1c4703d4a7ea456dfdce90aec56622bdR70-R80) [[4]](diffhunk://#diff-0d053f64e0b6d0e92a018f3a271a161c1c4703d4a7ea456dfdce90aec56622bdL115-R126) [[5]](diffhunk://#diff-0d053f64e0b6d0e92a018f3a271a161c1c4703d4a7ea456dfdce90aec56622bdL125-R136)

**Utility and Code Reuse**

* Introduced a `summarizeBody` utility function to trim and limit error body output, and reused it in both agent/internal and workerproxy codebases. [[1]](diffhunk://#diff-e8af046018acd9fc0f9b0dc70163a51e47ce15c359be7600f9e89c4c497bbe1aR1-R17) [[2]](diffhunk://#diff-8678c43f351433c888356dca40685bc57dd5e385e6681829a79f2c810a1500f1R109-R122) [[3]](diffhunk://#diff-65519ecd82710ae00dfc2cacb1c302f4fb7c1b539c0dc7c0c34dbfd182ab28fcR63-R76) [[4]](diffhunk://#diff-1bca4a1ffa9664748e06d7a8121c0220558b91537feccd62cd5ff34765c6b2fcR392-R399) [[5]](diffhunk://#diff-1bca4a1ffa9664748e06d7a8121c0220558b91537feccd62cd5ff34765c6b2fcR421-R422)

**Client Error Reporting**

* Enhanced HTTP client error messages in `ollama/client.go` and `openai/client.go` to include a summarized portion of the response body on non-2xx responses, aiding in debugging. [[1]](diffhunk://#diff-8678c43f351433c888356dca40685bc57dd5e385e6681829a79f2c810a1500f1R39-R42) [[2]](diffhunk://#diff-65519ecd82710ae00dfc2cacb1c302f4fb7c1b539c0dc7c0c34dbfd182ab28fcL43-R45)

**Connection and Protocol Error Logging**

* Improved logging for websocket connection failures and protocol errors, with dynamic log levels and additional context such as close codes and summarized message bodies in `run.go` and `ws.go`. [[1]](diffhunk://#diff-1bca4a1ffa9664748e06d7a8121c0220558b91537feccd62cd5ff34765c6b2fcL239-R243) [[2]](diffhunk://#diff-1bca4a1ffa9664748e06d7a8121c0220558b91537feccd62cd5ff34765c6b2fcL369-R377) [[3]](diffhunk://#diff-1bca4a1ffa9664748e06d7a8121c0220558b91537feccd62cd5ff34765c6b2fcR392-R399) [[4]](diffhunk://#diff-1bca4a1ffa9664748e06d7a8121c0220558b91537feccd62cd5ff34765c6b2fcR421-R422) [[5]](diffhunk://#diff-761d08f955751ecaef3f17a56936899878d91fdc3334495e23dc77e5925288a6L46-R64)

These changes collectively provide better operational visibility and easier debugging for upstream and protocol errors in the LLM infrastructure.