### PR TITLE
Add worker affinity support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,4 @@ desktop/windows/**/obj/
 /nfrx-docling
 /nfrx-asr
 **/__pycache__/*
+**/obj

--- a/README.md
+++ b/README.md
@@ -264,6 +264,8 @@ The jobs API provides a lightweight in‑memory queue with SSE updates and trans
 
 See `doc/api/jobs.md` for full details, SSE event formats, and auth notes.
 
+Jobs can optionally target a specific `worker_id`, a shared `worker_group`, or both. Claims include the worker identity so claimed jobs remain traceable.
+
 ### Client flow
 
 1) Create a job:
@@ -299,7 +301,13 @@ curl -X POST http://localhost:8080/api/jobs/<job_id>/cancel
 ```
 curl -s -X POST http://localhost:8080/api/jobs/claim \
   -H "Content-Type: application/json" \
-  -d '{"types":["asr.transcribe"],"max_wait_seconds":30}'
+  -d '{"types":["asr.transcribe"],"max_wait_seconds":30,"worker_id":"worker-17","worker_group":"asr-cache-a"}'
+```
+
+Or keep a worker SSE stream open and receive claimed jobs as they become available:
+
+```
+curl -N "http://localhost:8080/api/jobs/stream?types=asr.transcribe&worker_id=worker-17&worker_group=asr-cache-a"
 ```
 
 2) Request payload channel (worker reads, client writes):

--- a/api/generated/types.gen.go
+++ b/api/generated/types.gen.go
@@ -15,20 +15,28 @@ const (
 type JobClaimRequest struct {
 	MaxWaitSeconds *int      `json:"max_wait_seconds,omitempty"`
 	Types          *[]string `json:"types,omitempty"`
+	WorkerGroup    *string   `json:"worker_group,omitempty"`
+	WorkerId       *string   `json:"worker_id,omitempty"`
 }
 
 // JobClaimResponse defines model for JobClaimResponse.
 type JobClaimResponse struct {
-	JobId    string                  `json:"job_id"`
-	Metadata *map[string]interface{} `json:"metadata,omitempty"`
-	Type     string                  `json:"type"`
+	ClaimedWorkerGroup *string                 `json:"claimed_worker_group,omitempty"`
+	ClaimedWorkerId    *string                 `json:"claimed_worker_id,omitempty"`
+	JobId              string                  `json:"job_id"`
+	Metadata           *map[string]interface{} `json:"metadata,omitempty"`
+	Type               string                  `json:"type"`
+	WorkerGroup        *string                 `json:"worker_group,omitempty"`
+	WorkerId           *string                 `json:"worker_id,omitempty"`
 }
 
 // JobCreateRequest defines model for JobCreateRequest.
 type JobCreateRequest struct {
-	Metadata *map[string]interface{} `json:"metadata,omitempty"`
-	Priority *int                    `json:"priority,omitempty"`
-	Type     string                  `json:"type"`
+	Metadata    *map[string]interface{} `json:"metadata,omitempty"`
+	Priority    *int                    `json:"priority,omitempty"`
+	Type        string                  `json:"type"`
+	WorkerGroup *string                 `json:"worker_group,omitempty"`
+	WorkerId    *string                 `json:"worker_id,omitempty"`
 }
 
 // JobCreateResponse defines model for JobCreateResponse.
@@ -52,17 +60,21 @@ type JobStatusUpdateRequest struct {
 
 // JobView defines model for JobView.
 type JobView struct {
-	CreatedAt     time.Time                `json:"created_at"`
-	Error         *JobError                `json:"error,omitempty"`
-	Id            string                   `json:"id"`
-	Metadata      *map[string]interface{}  `json:"metadata,omitempty"`
-	Payloads      *map[string]TransferInfo `json:"payloads,omitempty"`
-	Progress      *map[string]interface{}  `json:"progress,omitempty"`
-	QueuePosition *int                     `json:"queue_position,omitempty"`
-	Results       *map[string]TransferInfo `json:"results,omitempty"`
-	Status        string                   `json:"status"`
-	Type          string                   `json:"type"`
-	UpdatedAt     time.Time                `json:"updated_at"`
+	ClaimedWorkerGroup *string                  `json:"claimed_worker_group,omitempty"`
+	ClaimedWorkerId    *string                  `json:"claimed_worker_id,omitempty"`
+	CreatedAt          time.Time                `json:"created_at"`
+	Error              *JobError                `json:"error,omitempty"`
+	Id                 string                   `json:"id"`
+	Metadata           *map[string]interface{}  `json:"metadata,omitempty"`
+	Payloads           *map[string]TransferInfo `json:"payloads,omitempty"`
+	Progress           *map[string]interface{}  `json:"progress,omitempty"`
+	QueuePosition      *int                     `json:"queue_position,omitempty"`
+	Results            *map[string]TransferInfo `json:"results,omitempty"`
+	Status             string                   `json:"status"`
+	Type               string                   `json:"type"`
+	UpdatedAt          time.Time                `json:"updated_at"`
+	WorkerGroup        *string                  `json:"worker_group,omitempty"`
+	WorkerId           *string                  `json:"worker_id,omitempty"`
 }
 
 // TransferCreateResponse defines model for TransferCreateResponse.

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -57,6 +57,10 @@ components:
         metadata:
           type: object
           additionalProperties: true
+        worker_id:
+          type: string
+        worker_group:
+          type: string
       required: [type]
     JobCreateResponse:
       type: object
@@ -75,6 +79,10 @@ components:
             type: string
         max_wait_seconds:
           type: integer
+        worker_id:
+          type: string
+        worker_group:
+          type: string
     JobClaimResponse:
       type: object
       properties:
@@ -85,6 +93,14 @@ components:
         metadata:
           type: object
           additionalProperties: true
+        worker_id:
+          type: string
+        worker_group:
+          type: string
+        claimed_worker_id:
+          type: string
+        claimed_worker_group:
+          type: string
       required: [job_id, type]
     JobStatusUpdateRequest:
       type: object
@@ -109,6 +125,14 @@ components:
         metadata:
           type: object
           additionalProperties: true
+        worker_id:
+          type: string
+        worker_group:
+          type: string
+        claimed_worker_id:
+          type: string
+        claimed_worker_group:
+          type: string
         progress:
           type: object
           additionalProperties: true
@@ -273,6 +297,34 @@ paths:
                 $ref: '#/components/schemas/JobClaimResponse'
         '204':
           description: No jobs available
+  /api/jobs/stream:
+    get:
+      security: [ { BearerAuth: [] } ]
+      summary: Stream compatible queued jobs for a worker
+      parameters:
+        - in: query
+          name: types
+          required: false
+          schema:
+            type: string
+          description: Optional comma-separated list of accepted job types.
+        - in: query
+          name: worker_id
+          required: false
+          schema:
+            type: string
+        - in: query
+          name: worker_group
+          required: false
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Event stream of claimed jobs
+          content:
+            text/event-stream:
+              schema:
+                type: string
   /api/jobs/{job_id}:
     get:
       security: [ { BearerAuth: [] } ]

--- a/doc/api/jobs.md
+++ b/doc/api/jobs.md
@@ -45,7 +45,8 @@ Request body:
 ```json
 {
   "type": "asr.transcribe",
-  "metadata": {"filename": "sample.wav"}
+  "metadata": {"filename": "sample.wav"},
+  "worker_group": "asr-cache-a"
 }
 ```
 
@@ -92,6 +93,9 @@ Response (example):
   "type": "asr.transcribe",
   "status": "awaiting_payload",
   "metadata": {"filename": "sample.wav"},
+  "worker_group": "asr-cache-a",
+  "claimed_worker_id": "worker-17",
+  "claimed_worker_group": "asr-cache-a",
   "payloads": {
     "payload": {
       "key": "payload",
@@ -222,12 +226,16 @@ Request body (optional):
 ```json
 {
   "types": ["asr.transcribe", "doc.convert"],
-  "max_wait_seconds": 30
+  "max_wait_seconds": 30,
+  "worker_id": "worker-17",
+  "worker_group": "asr-cache-a"
 }
 ```
 
 - `types` filters which job types the worker will accept. Omit to claim any type.
 - `max_wait_seconds` controls long-poll wait; `0` returns immediately.
+- `worker_id` identifies the claiming worker for traceability and exact-targeted jobs.
+- `worker_group` identifies the affinity pool for group-targeted jobs.
 
 Response (200):
 
@@ -235,7 +243,10 @@ Response (200):
 {
   "job_id": "<uuid>",
   "type": "asr.transcribe",
-  "metadata": {"filename": "sample.wav"}
+  "metadata": {"filename": "sample.wav"},
+  "worker_group": "asr-cache-a",
+  "claimed_worker_id": "worker-17",
+  "claimed_worker_group": "asr-cache-a"
 }
 ```
 
@@ -246,7 +257,46 @@ curl:
 ```bash
 curl -s -X POST http://localhost:8080/api/jobs/claim \
   -H "Content-Type: application/json" \
-  -d '{"types":["asr.transcribe"],"max_wait_seconds":30}'
+  -d '{"types":["asr.transcribe"],"max_wait_seconds":30,"worker_id":"worker-17","worker_group":"asr-cache-a"}'
+```
+
+Authorization (worker):
+
+```
+Authorization: Bearer <CLIENT_KEY>
+```
+
+or
+
+```
+X-User-Roles: <client_role>
+```
+
+---
+
+### Stream compatible jobs (worker SSE)
+
+`GET /api/jobs/stream`
+
+Query parameters:
+
+- `types` optional comma-separated job types
+- `worker_id` optional claiming worker identity
+- `worker_group` optional claiming worker affinity group
+
+The server applies the same compatibility rules as `POST /api/jobs/claim`. Each emitted `job` event claims the job immediately for that worker identity.
+
+Example:
+
+```text
+event: job
+data: {"job_id":"...","type":"asr.transcribe","worker_group":"asr-cache-a","claimed_worker_id":"worker-17","claimed_worker_group":"asr-cache-a"}
+```
+
+curl:
+
+```bash
+curl -N "http://localhost:8080/api/jobs/stream?types=asr.transcribe&worker_id=worker-17&worker_group=asr-cache-a"
 ```
 
 Authorization (worker):
@@ -430,6 +480,8 @@ Transfer channels are created by `/payload` and `/result` (optional `key`) or di
 
 - Transfer channels are one‑time, time‑limited, and in‑memory only.
 - Jobs are in‑memory; a server restart clears the queue.
+- Jobs may optionally target a `worker_id`, a `worker_group`, or both. A worker claim is compatible only when it satisfies all requested affinity fields.
+- Claimed jobs record `claimed_worker_id` and `claimed_worker_group` for traceability.
 - For clients without SSE, poll `GET /api/jobs/{job_id}` and look for `payloads` / `results` fields.
 - When no SSE client is connected, jobs are canceled after `JOBS_CLIENT_TTL` (default `30s`).
 
@@ -475,6 +527,8 @@ async def main() -> None:
         session = await runner.create_job_session(
             job_type="asr.transcribe",
             metadata={"language": "en"},
+            worker_id=None,
+            worker_group=None,
             payload_provider=payload_provider,
             result_consumer=result_consumer,
         )

--- a/examples/dotnet/example-nfrx-jobs-client/Program.cs
+++ b/examples/dotnet/example-nfrx-jobs-client/Program.cs
@@ -24,6 +24,8 @@ class Program
         var session = await runner.CreateJobSessionAsync(
             jobType: "asr.transcribe",
             metadata: new Dictionary<string, object> { { "language", "en" } },
+            workerId: null,
+            workerGroup: null,
             payloadProvider: async (key, payload) =>
             {
                 _ = key;

--- a/examples/dotnet/nfrx-sdk/NfrxJobsClient.cs
+++ b/examples/dotnet/nfrx-sdk/NfrxJobsClient.cs
@@ -24,13 +24,25 @@ public sealed class NfrxJobsClient
         _http = httpClient;
     }
 
-    public async Task<JobCreateResponse> CreateJobAsync(string jobType, Dictionary<string, object>? metadata)
+    public async Task<JobCreateResponse> CreateJobAsync(
+        string jobType,
+        Dictionary<string, object>? metadata,
+        string? workerId = null,
+        string? workerGroup = null)
     {
         var payload = new Dictionary<string, object>
         {
             { "type", jobType },
             { "metadata", metadata ?? new Dictionary<string, object>() }
         };
+        if (!string.IsNullOrWhiteSpace(workerId))
+        {
+            payload["worker_id"] = workerId;
+        }
+        if (!string.IsNullOrWhiteSpace(workerGroup))
+        {
+            payload["worker_group"] = workerGroup;
+        }
         using var req = new HttpRequestMessage(HttpMethod.Post, _baseUrl + "/api/jobs");
         AddAuth(req);
         req.Content = new StringContent(JsonSerializer.Serialize(payload), Encoding.UTF8, "application/json");
@@ -157,10 +169,12 @@ public sealed class NfrxJobsRunner : IDisposable
     public async Task<JobSession> CreateJobSessionAsync(
         string jobType,
         Dictionary<string, object>? metadata,
+        string? workerId,
+        string? workerGroup,
         PayloadProvider payloadProvider,
         ResultConsumer resultConsumer)
     {
-        var created = await _jobs.CreateJobAsync(jobType, metadata);
+        var created = await _jobs.CreateJobAsync(jobType, metadata, workerId, workerGroup);
         return new JobSession(created.JobId, payloadProvider, resultConsumer);
     }
 
@@ -273,6 +287,8 @@ public sealed class NfrxJobsWorker : IDisposable
     public async Task<JobClaimResponse?> ClaimJobAsync(
         List<string>? types,
         int maxWaitSeconds,
+        string? workerId = null,
+        string? workerGroup = null,
         CancellationToken cancellationToken = default)
     {
         var payload = new Dictionary<string, object>();
@@ -281,6 +297,14 @@ public sealed class NfrxJobsWorker : IDisposable
             payload["types"] = types;
         }
         payload["max_wait_seconds"] = maxWaitSeconds;
+        if (!string.IsNullOrWhiteSpace(workerId))
+        {
+            payload["worker_id"] = workerId;
+        }
+        if (!string.IsNullOrWhiteSpace(workerGroup))
+        {
+            payload["worker_group"] = workerGroup;
+        }
         using var req = new HttpRequestMessage(HttpMethod.Post, _baseUrl + "/api/jobs/claim");
         AddAuth(req);
         req.Content = new StringContent(JsonSerializer.Serialize(payload), Encoding.UTF8, "application/json");
@@ -380,10 +404,12 @@ public sealed class NfrxJobsWorker : IDisposable
         Func<JobClaimResponse, byte[], Task<(byte[] Result, string? ErrorMessage)>> handler,
         List<string>? types,
         int maxWaitSeconds,
+        string? workerId = null,
+        string? workerGroup = null,
         WorkerStatusHandler? onStatus = null,
         CancellationToken cancellationToken = default)
     {
-        var job = await ClaimJobAsync(types, maxWaitSeconds, cancellationToken).ConfigureAwait(false);
+        var job = await ClaimJobAsync(types, maxWaitSeconds, workerId, workerGroup, cancellationToken).ConfigureAwait(false);
         if (job == null)
         {
             return false;
@@ -477,10 +503,18 @@ public sealed class JobCreateResponse
 
 public sealed class JobClaimResponse
 {
+    [JsonPropertyName("claimed_worker_group")]
+    public string? ClaimedWorkerGroup { get; set; }
+    [JsonPropertyName("claimed_worker_id")]
+    public string? ClaimedWorkerId { get; set; }
     [JsonPropertyName("job_id")]
     public string JobId { get; set; } = string.Empty;
     public string Type { get; set; } = string.Empty;
     public Dictionary<string, JsonElement>? Metadata { get; set; }
+    [JsonPropertyName("worker_group")]
+    public string? WorkerGroup { get; set; }
+    [JsonPropertyName("worker_id")]
+    public string? WorkerId { get; set; }
 }
 
 public sealed class TransferRequest

--- a/examples/python/example_nfrx_jobs_client.py
+++ b/examples/python/example_nfrx_jobs_client.py
@@ -60,8 +60,18 @@ class NfrxJobsClient:
             headers["Authorization"] = f"Bearer {self._auth.api_key}"
         return headers
 
-    async def create_job(self, job_type: str, metadata: Optional[Dict[str, Any]] = None) -> JobCreateResponse:
+    async def create_job(
+        self,
+        job_type: str,
+        metadata: Optional[Dict[str, Any]] = None,
+        worker_id: Optional[str] = None,
+        worker_group: Optional[str] = None,
+    ) -> JobCreateResponse:
         payload = {"type": job_type, "metadata": metadata or {}}
+        if worker_id:
+            payload["worker_id"] = worker_id
+        if worker_group:
+            payload["worker_group"] = worker_group
         resp = await self._client.post("/api/jobs", json=payload, headers=self._headers())
         resp.raise_for_status()
         return resp.json()
@@ -125,10 +135,12 @@ class NfrxJobsRunner:
         self,
         job_type: str,
         metadata: Optional[Dict[str, Any]],
+        worker_id: Optional[str],
+        worker_group: Optional[str],
         payload_provider: PayloadProvider,
         result_consumer: ResultConsumer,
     ) -> JobSession:
-        created = await self._jobs.create_job(job_type, metadata)
+        created = await self._jobs.create_job(job_type, metadata, worker_id, worker_group)
         return JobSession(
             job_id=created["job_id"],
             payload_provider=payload_provider,
@@ -250,6 +262,8 @@ async def run(args: argparse.Namespace) -> int:
         session = await runner.create_job_session(
             args.job_type,
             metadata,
+            args.worker_id,
+            args.worker_group,
             payload_provider,
             result_consumer,
         )
@@ -287,6 +301,8 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--poll", action="store_true", help="poll job once after creation")
     parser.add_argument("--sse", action="store_true", help="stream job events (SSE)")
     parser.add_argument("--timeout", type=float, default=10.0, help="SSE timeout in seconds")
+    parser.add_argument("--worker-id", default=None, help="target an exact worker")
+    parser.add_argument("--worker-group", default=None, help="target a worker affinity group")
     parser.add_argument("--payload-file", default=None, help="file to upload on payload event")
     parser.add_argument("--payload-content-type", default=None, help="Content-Type for payload upload")
     parser.add_argument("--result-file", default=None, help="file to write on result event")

--- a/examples/python/example_nfrx_jobs_worker.py
+++ b/examples/python/example_nfrx_jobs_worker.py
@@ -48,13 +48,21 @@ class NfrxJobsWorker:
         return headers
 
     async def claim_job(
-        self, types: Optional[list[str]] = None, max_wait_seconds: Optional[int] = None
+        self,
+        types: Optional[list[str]] = None,
+        max_wait_seconds: Optional[int] = None,
+        worker_id: Optional[str] = None,
+        worker_group: Optional[str] = None,
     ) -> Optional[JobClaim]:
         payload: Dict[str, Any] = {}
         if types:
             payload["types"] = types
         if max_wait_seconds is not None:
             payload["max_wait_seconds"] = max_wait_seconds
+        if worker_id:
+            payload["worker_id"] = worker_id
+        if worker_group:
+            payload["worker_group"] = worker_group
         resp = await self._client.post("/api/jobs/claim", json=payload, headers=self._headers())
         if resp.status_code == 204:
             return None
@@ -94,9 +102,16 @@ class NfrxJobsWorker:
         handler: ProcessHandler,
         types: Optional[list[str]],
         max_wait_seconds: int,
+        worker_id: Optional[str] = None,
+        worker_group: Optional[str] = None,
         on_status: Optional[StatusHandler] = None,
     ) -> bool:
-        job = await self.claim_job(types=types, max_wait_seconds=max_wait_seconds)
+        job = await self.claim_job(
+            types=types,
+            max_wait_seconds=max_wait_seconds,
+            worker_id=worker_id,
+            worker_group=worker_group,
+        )
         if not job:
             print("no job available")
             return False
@@ -164,6 +179,8 @@ async def run(args: argparse.Namespace) -> int:
                 handler=echo_handler,
                 types=types,
                 max_wait_seconds=args.max_wait_seconds,
+                worker_id=args.worker_id,
+                worker_group=args.worker_group,
             )
             if handled and args.once:
                 return 0
@@ -176,6 +193,8 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--base-url", default="http://localhost:8080")
     parser.add_argument("--client-key", default=None)
     parser.add_argument("--types", default=None, help="comma-separated job types")
+    parser.add_argument("--worker-id", default=None, help="claim identity for exact worker targeting")
+    parser.add_argument("--worker-group", default=None, help="claim affinity group for group-targeted jobs")
     parser.add_argument("--max-wait-seconds", type=int, default=30)
     parser.add_argument("--once", action="store_true", help="exit if no job claimed")
     return parser

--- a/go.work.sum
+++ b/go.work.sum
@@ -14,6 +14,7 @@ github.com/chenzhuoyu/iasm v0.9.0/go.mod h1:Xjy2NpN3h7aUqeqM+woSuuvxmIe6+DDsiNLI
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
+github.com/ebitengine/purego v0.9.0/go.mod h1:iIjxzd6CiRiOG0UyXP+V1+jWqUXVjPKLAI0mRfJZTmQ=
 github.com/fatih/structs v1.1.0/go.mod h1:9NiDSp5zOcgEDl+j00MP/WkGVPOlPRLejGD8Ga6PJ7M=
 github.com/flosch/pongo2/v4 v4.0.2/go.mod h1:B5ObFANs/36VwxxlgKpdchIJHMvHB562PW+BWPhwZD8=
 github.com/gabriel-vasile/mimetype v1.4.2/go.mod h1:zApsH/mKG4w07erKIaJPFiX0Tsq9BFQgN3qGY5GnNgA=
@@ -47,12 +48,14 @@ github.com/klauspost/cpuid/v2 v2.2.5/go.mod h1:Lcz8mBdAVJIBVzewtcLocK12l3Y+JytZY
 github.com/labstack/echo/v4 v4.11.4/go.mod h1:noh7EvLwqDsmh/X/HWKPUl1AjzJrhyptRyEbQJfxen8=
 github.com/labstack/gommon v0.4.2/go.mod h1:QlUFxVM+SNXhDL/Z7YhocGIBYOiwB0mXm1+1bAPHPyU=
 github.com/leodido/go-urn v1.2.4/go.mod h1:7ZrI8mTSeBSHl/UaRyKQW1qZeMgak41ANeCNaVckg+4=
+github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0/go.mod h1:zJYVVT2jmtg6P3p1VtQj7WsuWi/y4VnjVBn7F8KPB3I=
 github.com/mailgun/raymond/v2 v2.0.48/go.mod h1:lsgvL50kgt1ylcFJYZiULi5fjPBkkhNfj4KA0W54Z18=
 github.com/microcosm-cc/bluemonday v1.0.25/go.mod h1:ZIOjCQp1OrzBBPIJmfX4qDYFuhU02nx4bn030ixfHLE=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
 github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/pelletier/go-toml/v2 v2.0.9/go.mod h1:tJU2Z3ZkXwnxa4DPO899bsyIoywizdUvyaeZurnPPDc=
+github.com/power-devops/perfstat v0.0.0-20240221224432-82ca36839d55/go.mod h1:OmDBASR4679mdNQnz2pUhc2G8CO2JrUAVFDRBDP/hJE=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/schollz/closestmatch v2.1.0+incompatible/go.mod h1:RtP1ddjLong6gTkbtmuhtR2uUrrJOpYzYRvbcPAid+g=
 github.com/shirou/gopsutil/v4 v4.25.9 h1:JImNpf6gCVhKgZhtaAHJ0serfFGtlfIlSC08eaKdTrU=
@@ -60,6 +63,8 @@ github.com/shirou/gopsutil/v4 v4.25.9/go.mod h1:gxIxoC+7nQRwUl/xNhutXlD8lq+jxTgp
 github.com/sirupsen/logrus v1.8.1/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
 github.com/tdewolff/minify/v2 v2.12.9/go.mod h1:qOqdlDfL+7v0/fyymB+OP497nIxJYSvX4MQWA8OoiXU=
 github.com/tdewolff/parse/v2 v2.6.8/go.mod h1:XHDhaU6IBgsryfdnpzUXBlT6leW/l25yrFBTEb4eIyM=
+github.com/tklauser/go-sysconf v0.3.15/go.mod h1:Dmjwr6tYFIseJw7a3dRLJfsHAMXZ3nEnL/aZY+0IuI4=
+github.com/tklauser/numcpus v0.10.0/go.mod h1:BiTKazU708GQTYF4mB+cmlpT2Is1gLk7XVuEeem8LsQ=
 github.com/twitchyliquid64/golang-asm v0.15.1/go.mod h1:a1lVb/DtPvCB8fslRZhAngC2+aY1QWCk3Cedj/Gdt08=
 github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyCJ6HpOuEn7z0Csc=
 github.com/valyala/fasttemplate v1.2.2/go.mod h1:KHLXt3tVN2HBp8eijSv/kGJopbvo7S+qRAEEKiv+SiQ=

--- a/server/internal/jobs/registry.go
+++ b/server/internal/jobs/registry.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"io"
 	"net/http"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -25,6 +26,10 @@ const (
 	StatusCompleted       = "completed"
 	StatusFailed          = "failed"
 	StatusCanceled        = "canceled"
+
+	workerActiveWindow = time.Minute
+	workerRetention    = 10 * time.Minute
+	maxStateJobs       = 12
 )
 
 type Registry struct {
@@ -37,24 +42,41 @@ type Registry struct {
 	sseCloseDelay time.Duration
 	clientTTL     time.Duration
 	clientTimers  map[string]*time.Timer
+	workers       map[string]*WorkerActivity
 }
 
 type Job struct {
-	ID        string
-	Type      string
-	Status    string
-	Metadata  map[string]any
-	Progress  map[string]any
-	Error     *JobError
-	Payloads  map[string]*TransferInfo
-	Results   map[string]*TransferInfo
-	CreatedAt time.Time
-	UpdatedAt time.Time
+	ID                 string
+	Type               string
+	Status             string
+	Metadata           map[string]any
+	WorkerID           string
+	WorkerGroup        string
+	ClaimedWorkerID    string
+	ClaimedWorkerGroup string
+	Progress           map[string]any
+	Error              *JobError
+	Payloads           map[string]*TransferInfo
+	Results            map[string]*TransferInfo
+	CreatedAt          time.Time
+	UpdatedAt          time.Time
 }
 
 type JobError struct {
 	Code    string `json:"code"`
 	Message string `json:"message"`
+}
+
+type WorkerActivity struct {
+	Key           string
+	WorkerID      string
+	WorkerGroup   string
+	LastSeenAt    time.Time
+	LastClaimAt   time.Time
+	LastClaimMode string
+	LastJobID     string
+	Types         []string
+	StreamCount   int
 }
 
 type TransferInfo struct {
@@ -71,14 +93,18 @@ type Event struct {
 }
 
 type CreateJobRequest struct {
-	Type     string         `json:"type"`
-	Priority int            `json:"priority,omitempty"`
-	Metadata map[string]any `json:"metadata,omitempty"`
+	Type        string         `json:"type"`
+	Priority    int            `json:"priority,omitempty"`
+	Metadata    map[string]any `json:"metadata,omitempty"`
+	WorkerID    string         `json:"worker_id,omitempty"`
+	WorkerGroup string         `json:"worker_group,omitempty"`
 }
 
 type ClaimRequest struct {
 	Types          []string `json:"types,omitempty"`
 	MaxWaitSeconds int      `json:"max_wait_seconds,omitempty"`
+	WorkerID       string   `json:"worker_id,omitempty"`
+	WorkerGroup    string   `json:"worker_group,omitempty"`
 }
 
 type StatusUpdateRequest struct {
@@ -92,17 +118,52 @@ type TransferRequest struct {
 }
 
 type JobView struct {
-	ID            string                   `json:"id"`
-	Type          string                   `json:"type"`
-	Status        string                   `json:"status"`
-	Metadata      map[string]any           `json:"metadata,omitempty"`
-	Progress      map[string]any           `json:"progress,omitempty"`
-	Error         *JobError                `json:"error,omitempty"`
-	Payloads      map[string]*TransferInfo `json:"payloads,omitempty"`
-	Results       map[string]*TransferInfo `json:"results,omitempty"`
-	QueuePosition int                      `json:"queue_position,omitempty"`
-	CreatedAt     string                   `json:"created_at"`
-	UpdatedAt     string                   `json:"updated_at"`
+	ID                 string                   `json:"id"`
+	Type               string                   `json:"type"`
+	Status             string                   `json:"status"`
+	Metadata           map[string]any           `json:"metadata,omitempty"`
+	WorkerID           string                   `json:"worker_id,omitempty"`
+	WorkerGroup        string                   `json:"worker_group,omitempty"`
+	ClaimedWorkerID    string                   `json:"claimed_worker_id,omitempty"`
+	ClaimedWorkerGroup string                   `json:"claimed_worker_group,omitempty"`
+	Progress           map[string]any           `json:"progress,omitempty"`
+	Error              *JobError                `json:"error,omitempty"`
+	Payloads           map[string]*TransferInfo `json:"payloads,omitempty"`
+	Results            map[string]*TransferInfo `json:"results,omitempty"`
+	QueuePosition      int                      `json:"queue_position,omitempty"`
+	CreatedAt          string                   `json:"created_at"`
+	UpdatedAt          string                   `json:"updated_at"`
+}
+
+type WorkerActivityView struct {
+	Key           string   `json:"key"`
+	WorkerID      string   `json:"worker_id,omitempty"`
+	WorkerGroup   string   `json:"worker_group,omitempty"`
+	LastSeenAt    string   `json:"last_seen_at"`
+	LastClaimAt   string   `json:"last_claim_at,omitempty"`
+	LastClaimMode string   `json:"last_claim_mode,omitempty"`
+	LastJobID     string   `json:"last_job_id,omitempty"`
+	Types         []string `json:"types,omitempty"`
+	StreamCount   int      `json:"stream_count,omitempty"`
+	Active        bool     `json:"active"`
+}
+
+type JobsSummary struct {
+	TotalJobs         int `json:"total_jobs"`
+	QueuedJobs        int `json:"queued_jobs"`
+	ClaimedJobs       int `json:"claimed_jobs"`
+	RunningJobs       int `json:"running_jobs"`
+	AwaitingTransfers int `json:"awaiting_transfers"`
+	TerminalJobs      int `json:"terminal_jobs"`
+	ActiveWorkers     int `json:"active_workers"`
+	RecentWorkers     int `json:"recent_workers"`
+	StreamingWorkers  int `json:"streaming_workers"`
+}
+
+type StateView struct {
+	Summary JobsSummary          `json:"summary"`
+	Workers []WorkerActivityView `json:"workers"`
+	Jobs    []JobView            `json:"jobs"`
 }
 
 func NewRegistry(tr *transfer.Registry, sseCloseDelay time.Duration, clientTTL time.Duration) *Registry {
@@ -115,6 +176,7 @@ func NewRegistry(tr *transfer.Registry, sseCloseDelay time.Duration, clientTTL t
 		sseCloseDelay: sseCloseDelay,
 		clientTTL:     clientTTL,
 		clientTimers:  make(map[string]*time.Timer),
+		workers:       make(map[string]*WorkerActivity),
 	}
 }
 
@@ -132,6 +194,7 @@ func (r *Registry) RegisterClientRoutes(router chi.Router) {
 
 func (r *Registry) RegisterWorkerRoutes(router chi.Router) {
 	router.Post("/jobs/claim", r.HandleClaimJob)
+	router.Get("/jobs/stream", r.HandleClaimStream)
 	router.Post("/jobs/{job_id}/payload", r.HandlePayloadRequest)
 	router.Post("/jobs/{job_id}/result", r.HandleResultRequest)
 	router.Post("/jobs/{job_id}/status", r.HandleStatusUpdate)
@@ -148,12 +211,14 @@ func (r *Registry) HandleCreateJob(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 	job := &Job{
-		ID:        uuid.NewString(),
-		Type:      body.Type,
-		Status:    StatusQueued,
-		Metadata:  body.Metadata,
-		CreatedAt: time.Now(),
-		UpdatedAt: time.Now(),
+		ID:          uuid.NewString(),
+		Type:        body.Type,
+		Status:      StatusQueued,
+		Metadata:    body.Metadata,
+		WorkerID:    strings.TrimSpace(body.WorkerID),
+		WorkerGroup: strings.TrimSpace(body.WorkerGroup),
+		CreatedAt:   time.Now(),
+		UpdatedAt:   time.Now(),
 	}
 	r.mu.Lock()
 	r.jobs[job.ID] = job
@@ -284,13 +349,13 @@ func (r *Registry) HandleClaimJob(w http.ResponseWriter, req *http.Request) {
 	}
 	wait := time.Duration(body.MaxWaitSeconds) * time.Second
 	deadline := time.Now().Add(wait)
+	workerID := strings.TrimSpace(body.WorkerID)
+	workerGroup := strings.TrimSpace(body.WorkerGroup)
+	r.recordWorkerSeen(workerID, workerGroup, "poll", body.Types, "")
 	for {
-		if job := r.claimNext(body.Types); job != nil {
-			writeJSON(w, http.StatusOK, map[string]any{
-				"job_id":   job.ID,
-				"type":     job.Type,
-				"metadata": job.Metadata,
-			})
+		if job := r.claimNext(body.Types, workerID, workerGroup); job != nil {
+			r.recordWorkerSeen(workerID, workerGroup, "poll", body.Types, job.ID)
+			writeJSON(w, http.StatusOK, r.claimResponse(job))
 			return
 		}
 		if wait <= 0 {
@@ -309,6 +374,45 @@ func (r *Registry) HandleClaimJob(w http.ResponseWriter, req *http.Request) {
 			return
 		case <-req.Context().Done():
 			return
+		}
+	}
+}
+
+func (r *Registry) HandleClaimStream(w http.ResponseWriter, req *http.Request) {
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("Connection", "keep-alive")
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		http.Error(w, "streaming unsupported", http.StatusInternalServerError)
+		return
+	}
+
+	types := parseListQuery(req.URL.Query()["types"])
+	workerID := strings.TrimSpace(req.URL.Query().Get("worker_id"))
+	workerGroup := strings.TrimSpace(req.URL.Query().Get("worker_group"))
+	r.addWorkerStream(workerID, workerGroup, types)
+	defer r.removeWorkerStream(workerID, workerGroup)
+	keepAlive := time.NewTicker(15 * time.Second)
+	defer keepAlive.Stop()
+
+	ctx := req.Context()
+	for {
+		if job := r.claimNext(types, workerID, workerGroup); job != nil {
+			r.recordWorkerSeen(workerID, workerGroup, "stream", types, job.ID)
+			r.writeEvent(w, Event{Type: "job", Data: r.claimResponse(job)})
+			flusher.Flush()
+			continue
+		}
+		select {
+		case <-ctx.Done():
+			return
+		case <-r.notify:
+			r.recordWorkerSeen(workerID, workerGroup, "stream", types, "")
+		case <-keepAlive.C:
+			r.recordWorkerSeen(workerID, workerGroup, "stream", types, "")
+			_, _ = w.Write([]byte(": keep-alive\n\n"))
+			flusher.Flush()
 		}
 	}
 }
@@ -475,7 +579,7 @@ func (r *Registry) HandleStatusUpdate(w http.ResponseWriter, req *http.Request) 
 	writeJSON(w, http.StatusOK, map[string]any{"status": job.Status})
 }
 
-func (r *Registry) claimNext(types []string) *Job {
+func (r *Registry) claimNext(types []string, workerID, workerGroup string) *Job {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	for i, id := range r.queue {
@@ -486,8 +590,13 @@ func (r *Registry) claimNext(types []string) *Job {
 		if len(types) > 0 && !contains(types, job.Type) {
 			continue
 		}
+		if !isCompatibleClaim(job, workerID, workerGroup) {
+			continue
+		}
 		r.queue = append(r.queue[:i], r.queue[i+1:]...)
 		job.Status = StatusClaimed
+		job.ClaimedWorkerID = workerID
+		job.ClaimedWorkerGroup = workerGroup
 		job.UpdatedAt = time.Now()
 		r.publishLocked(job.ID, Event{Type: "status", Data: r.viewLocked(job)})
 		return job
@@ -669,17 +778,383 @@ func (r *Registry) viewLocked(job *Job) JobView {
 		return JobView{}
 	}
 	return JobView{
-		ID:        job.ID,
-		Type:      job.Type,
-		Status:    job.Status,
-		Metadata:  copyMap(job.Metadata),
-		Progress:  copyMap(job.Progress),
-		Error:     copyError(job.Error),
-		Payloads:  copyTransfers(job.Payloads),
-		Results:   copyTransfers(job.Results),
-		CreatedAt: job.CreatedAt.UTC().Format(time.RFC3339),
-		UpdatedAt: job.UpdatedAt.UTC().Format(time.RFC3339),
+		ID:                 job.ID,
+		Type:               job.Type,
+		Status:             job.Status,
+		Metadata:           copyMap(job.Metadata),
+		WorkerID:           job.WorkerID,
+		WorkerGroup:        job.WorkerGroup,
+		ClaimedWorkerID:    job.ClaimedWorkerID,
+		ClaimedWorkerGroup: job.ClaimedWorkerGroup,
+		Progress:           copyMap(job.Progress),
+		Error:              copyError(job.Error),
+		Payloads:           copyTransfers(job.Payloads),
+		Results:            copyTransfers(job.Results),
+		CreatedAt:          job.CreatedAt.UTC().Format(time.RFC3339),
+		UpdatedAt:          job.UpdatedAt.UTC().Format(time.RFC3339),
 	}
+}
+
+func (r *Registry) claimResponse(job *Job) map[string]any {
+	if job == nil {
+		return map[string]any{}
+	}
+	return map[string]any{
+		"job_id":               job.ID,
+		"type":                 job.Type,
+		"metadata":             copyMap(job.Metadata),
+		"worker_id":            job.WorkerID,
+		"worker_group":         job.WorkerGroup,
+		"claimed_worker_id":    job.ClaimedWorkerID,
+		"claimed_worker_group": job.ClaimedWorkerGroup,
+	}
+}
+
+func (r *Registry) StateSnapshot() StateView {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	now := time.Now()
+	r.pruneWorkersLocked(now)
+
+	state := StateView{
+		Workers: make([]WorkerActivityView, 0, len(r.workers)),
+		Jobs:    make([]JobView, 0, minInt(len(r.jobs), maxStateJobs)),
+	}
+	workerKeys := make([]string, 0, len(r.workers))
+	for key := range r.workers {
+		workerKeys = append(workerKeys, key)
+	}
+	sort.Strings(workerKeys)
+	for _, key := range workerKeys {
+		w := r.workers[key]
+		if w == nil {
+			continue
+		}
+		active := now.Sub(w.LastSeenAt) <= workerActiveWindow
+		if active {
+			state.Summary.ActiveWorkers++
+		}
+		state.Summary.RecentWorkers++
+		if w.StreamCount > 0 {
+			state.Summary.StreamingWorkers++
+		}
+		view := WorkerActivityView{
+			Key:           w.Key,
+			WorkerID:      w.WorkerID,
+			WorkerGroup:   w.WorkerGroup,
+			LastSeenAt:    w.LastSeenAt.UTC().Format(time.RFC3339),
+			LastClaimMode: w.LastClaimMode,
+			LastJobID:     w.LastJobID,
+			Types:         append([]string(nil), w.Types...),
+			StreamCount:   w.StreamCount,
+			Active:        active,
+		}
+		if !w.LastClaimAt.IsZero() {
+			view.LastClaimAt = w.LastClaimAt.UTC().Format(time.RFC3339)
+		}
+		state.Workers = append(state.Workers, view)
+	}
+
+	ids := make([]string, 0, len(r.jobs))
+	for id := range r.jobs {
+		ids = append(ids, id)
+	}
+	sort.Slice(ids, func(i, j int) bool {
+		return r.jobs[ids[i]].UpdatedAt.After(r.jobs[ids[j]].UpdatedAt)
+	})
+	for _, id := range ids {
+		job := r.jobs[id]
+		if job == nil {
+			continue
+		}
+		state.Summary.TotalJobs++
+		switch job.Status {
+		case StatusQueued:
+			state.Summary.QueuedJobs++
+		case StatusClaimed:
+			state.Summary.ClaimedJobs++
+		case StatusRunning:
+			state.Summary.RunningJobs++
+		case StatusAwaitingPayload, StatusAwaitingResult:
+			state.Summary.AwaitingTransfers++
+		case StatusCompleted, StatusFailed, StatusCanceled:
+			state.Summary.TerminalJobs++
+		}
+		if len(state.Jobs) < maxStateJobs {
+			view := r.viewLocked(job)
+			if job.Status == StatusQueued {
+				for i, qid := range r.queue {
+					if qid == id {
+						view.QueuePosition = i + 1
+						break
+					}
+				}
+			}
+			state.Jobs = append(state.Jobs, view)
+		}
+	}
+	return state
+}
+
+func (r *Registry) StateHTML() string {
+	return `
+<div class="jobs-view">
+  <style>
+    .jobs-view { display: grid; gap: 1rem; }
+    .jobs-summary { display: grid; gap: 0.75rem; grid-template-columns: repeat(auto-fit, minmax(140px, 1fr)); }
+    .jobs-card, .jobs-panel { border: 1px solid var(--border); border-radius: var(--radius-md); background: var(--panel-strong); }
+    .jobs-card { padding: 0.85rem 0.95rem; }
+    .jobs-k { color: var(--muted); font-size: 0.76rem; letter-spacing: 0.06em; text-transform: uppercase; }
+    .jobs-v { margin-top: 0.28rem; font-size: 1.45rem; font-weight: 700; line-height: 1; }
+    .jobs-sub { margin-top: 0.25rem; color: var(--muted); font-size: 0.84rem; }
+    .jobs-grid { display: grid; gap: 1rem; grid-template-columns: minmax(280px, 0.95fr) minmax(0, 1.4fr); }
+    .jobs-panel { padding: 0.95rem 1rem; }
+    .jobs-panel h4 { margin: 0 0 0.75rem; font-size: 0.96rem; }
+    .jobs-list { display: grid; gap: 0.65rem; }
+    .jobs-row { display: grid; gap: 0.15rem; padding: 0.7rem 0.75rem; border: 1px solid var(--border); border-radius: var(--radius-sm); background: rgba(255,255,255,0.04); }
+    .jobs-row-head { display: flex; justify-content: space-between; gap: 0.75rem; align-items: center; }
+    .jobs-id { font-family: var(--mono); font-size: 0.8rem; color: var(--muted); }
+    .jobs-pill { display: inline-flex; align-items: center; padding: 0.16rem 0.46rem; border-radius: 999px; border: 1px solid var(--border); font-size: 0.76rem; color: var(--muted); }
+    .jobs-pill.live { color: var(--ok); }
+    .jobs-pill.warn { color: var(--warn); }
+    .jobs-meta { color: var(--muted); font-size: 0.85rem; line-height: 1.35; }
+    .jobs-table { width: 100%; border-collapse: collapse; font-size: 0.88rem; }
+    .jobs-table th, .jobs-table td { text-align: left; padding: 0.56rem 0.45rem; border-bottom: 1px solid var(--border); vertical-align: top; }
+    .jobs-table th { color: var(--muted); font-size: 0.74rem; text-transform: uppercase; letter-spacing: 0.06em; }
+    .jobs-table td { color: var(--text); }
+    .jobs-table code { font-family: var(--mono); font-size: 0.79rem; }
+    .jobs-empty { color: var(--muted); font-size: 0.9rem; }
+    @media (max-width: 900px) { .jobs-grid { grid-template-columns: 1fr; } }
+  </style>
+  <div class="jobs-summary"></div>
+  <div class="jobs-grid">
+    <section class="jobs-panel">
+      <h4>Active Workers</h4>
+      <div class="jobs-list jobs-workers"></div>
+    </section>
+    <section class="jobs-panel">
+      <h4>Recent Jobs</h4>
+      <div class="jobs-jobs"></div>
+    </section>
+  </div>
+  <script>(function(){
+    function esc(v){ return String(v == null ? '' : v).replace(/[&<>"]/g, function(c){ return ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;'})[c]; }); }
+    function rel(ts){
+      if (!ts) return 'never';
+      var d = Math.max(0, Math.round((Date.now() - new Date(ts).getTime())/1000));
+      if (d < 5) return 'just now';
+      if (d < 60) return d + 's ago';
+      if (d < 3600) return Math.floor(d/60) + 'm ago';
+      return Math.floor(d/3600) + 'h ago';
+    }
+    function statusTone(s){
+      s = String(s || '').toLowerCase();
+      if (s === 'running' || s === 'claimed') return 'live';
+      if (s === 'awaiting_payload' || s === 'awaiting_result' || s === 'queued') return 'warn';
+      return '';
+    }
+    function render(state, container){
+      state = state || {};
+      var summary = state.summary || {};
+      var workers = state.workers || [];
+      var jobs = state.jobs || [];
+      var summaryHost = container.querySelector('.jobs-summary');
+      if (summaryHost) {
+        summaryHost.innerHTML = [
+          ['Active Workers', summary.active_workers || 0, 'Seen in the last minute'],
+          ['Streaming', summary.streaming_workers || 0, 'Open worker SSE streams'],
+          ['Queued', summary.queued_jobs || 0, 'Waiting for a compatible worker'],
+          ['Running', summary.running_jobs || 0, 'Currently processing'],
+          ['Awaiting Transfer', summary.awaiting_transfers || 0, 'Payload or result handoff'],
+          ['Terminal', summary.terminal_jobs || 0, 'Completed, failed, or canceled']
+        ].map(function(card){
+          return '<article class="jobs-card"><div class="jobs-k">'+card[0]+'</div><div class="jobs-v">'+card[1]+'</div><div class="jobs-sub">'+card[2]+'</div></article>';
+        }).join('');
+      }
+      var workersHost = container.querySelector('.jobs-workers');
+      if (workersHost) {
+        if (!workers.length) {
+          workersHost.innerHTML = '<div class="jobs-empty">No recent worker claim activity.</div>';
+        } else {
+          workersHost.innerHTML = workers.map(function(w){
+            var name = w.worker_id || '(group only)';
+            var group = w.worker_group || 'none';
+            var tone = w.active ? 'live' : 'warn';
+            return '<div class="jobs-row">' +
+              '<div class="jobs-row-head"><strong>'+esc(name)+'</strong><span class="jobs-pill '+tone+'">'+(w.active ? 'active' : 'recent')+'</span></div>' +
+              '<div class="jobs-id">'+esc(group)+'</div>' +
+              '<div class="jobs-meta">mode '+esc(w.last_claim_mode || 'unknown')+' | seen '+esc(rel(w.last_seen_at))+(w.stream_count ? ' | streams '+esc(w.stream_count) : '')+'</div>' +
+              '<div class="jobs-meta">last job '+esc(w.last_job_id || 'none')+(w.types && w.types.length ? ' | types '+esc(w.types.join(', ')) : '')+'</div>' +
+            '</div>';
+          }).join('');
+        }
+      }
+      var jobsHost = container.querySelector('.jobs-jobs');
+      if (jobsHost) {
+        if (!jobs.length) {
+          jobsHost.innerHTML = '<div class="jobs-empty">No jobs recorded.</div>';
+        } else {
+          jobsHost.innerHTML = '<table class="jobs-table"><thead><tr><th>Status</th><th>Type</th><th>Affinity</th><th>Claimed By</th><th>Updated</th></tr></thead><tbody>' +
+            jobs.map(function(j){
+              var affinity = (j.worker_id || '-') + ' / ' + (j.worker_group || '-');
+              var claimed = (j.claimed_worker_id || '-') + ' / ' + (j.claimed_worker_group || '-');
+              var status = j.status || '';
+              var extra = j.queue_position ? ' #' + j.queue_position : '';
+              return '<tr>' +
+                '<td><span class="jobs-pill '+statusTone(status)+'">'+esc(status + extra)+'</span></td>' +
+                '<td><div>'+esc(j.type || '')+'</div><code>'+esc(j.id || '')+'</code></td>' +
+                '<td>'+esc(affinity)+'</td>' +
+                '<td>'+esc(claimed)+'</td>' +
+                '<td>'+esc(rel(j.updated_at))+'</td>' +
+              '</tr>';
+            }).join('') +
+            '</tbody></table>';
+        }
+      }
+    }
+    if (!window.NFRX) window.NFRX = { _renderers:{}, registerRenderer:function(id,fn){ this._renderers[id]=fn; } };
+    var section = (document.currentScript && document.currentScript.closest('section')) || null;
+    var id = (section && section.dataset && section.dataset.pluginId) || 'jobs';
+    window.NFRX.registerRenderer(id, function(state, container){ render(state, container); });
+  })();</script>
+</div>`
+}
+
+func isCompatibleClaim(job *Job, workerID, workerGroup string) bool {
+	if job == nil {
+		return false
+	}
+	if job.WorkerID != "" && job.WorkerID != workerID {
+		return false
+	}
+	if job.WorkerGroup != "" && job.WorkerGroup != workerGroup {
+		return false
+	}
+	return true
+}
+
+func parseListQuery(values []string) []string {
+	if len(values) == 0 {
+		return nil
+	}
+	res := make([]string, 0, len(values))
+	for _, raw := range values {
+		for _, part := range strings.Split(raw, ",") {
+			part = strings.TrimSpace(part)
+			if part != "" {
+				res = append(res, part)
+			}
+		}
+	}
+	if len(res) == 0 {
+		return nil
+	}
+	return res
+}
+
+func (r *Registry) recordWorkerSeen(workerID, workerGroup, mode string, types []string, jobID string) {
+	key := workerKey(workerID, workerGroup)
+	if key == "" {
+		return
+	}
+	now := time.Now()
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.pruneWorkersLocked(now)
+	w := r.ensureWorkerLocked(workerID, workerGroup)
+	w.LastSeenAt = now
+	if mode != "" {
+		w.LastClaimMode = mode
+	}
+	if len(types) > 0 {
+		w.Types = append([]string(nil), types...)
+	}
+	if jobID != "" {
+		w.LastClaimAt = now
+		w.LastJobID = jobID
+	}
+}
+
+func (r *Registry) addWorkerStream(workerID, workerGroup string, types []string) {
+	key := workerKey(workerID, workerGroup)
+	if key == "" {
+		return
+	}
+	now := time.Now()
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.pruneWorkersLocked(now)
+	w := r.ensureWorkerLocked(workerID, workerGroup)
+	w.LastSeenAt = now
+	w.LastClaimMode = "stream"
+	if len(types) > 0 {
+		w.Types = append([]string(nil), types...)
+	}
+	w.StreamCount++
+}
+
+func (r *Registry) removeWorkerStream(workerID, workerGroup string) {
+	key := workerKey(workerID, workerGroup)
+	if key == "" {
+		return
+	}
+	now := time.Now()
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.pruneWorkersLocked(now)
+	if w := r.workers[key]; w != nil && w.StreamCount > 0 {
+		w.StreamCount--
+		w.LastSeenAt = now
+	}
+}
+
+func (r *Registry) ensureWorkerLocked(workerID, workerGroup string) *WorkerActivity {
+	key := workerKey(workerID, workerGroup)
+	if key == "" {
+		return nil
+	}
+	w := r.workers[key]
+	if w == nil {
+		w = &WorkerActivity{
+			Key:         key,
+			WorkerID:    workerID,
+			WorkerGroup: workerGroup,
+		}
+		r.workers[key] = w
+	}
+	return w
+}
+
+func (r *Registry) pruneWorkersLocked(now time.Time) {
+	for key, w := range r.workers {
+		if w == nil {
+			delete(r.workers, key)
+			continue
+		}
+		if w.StreamCount > 0 {
+			continue
+		}
+		if !w.LastSeenAt.IsZero() && now.Sub(w.LastSeenAt) > workerRetention {
+			delete(r.workers, key)
+		}
+	}
+}
+
+func workerKey(workerID, workerGroup string) string {
+	workerID = strings.TrimSpace(workerID)
+	workerGroup = strings.TrimSpace(workerGroup)
+	if workerID == "" && workerGroup == "" {
+		return ""
+	}
+	return workerID + "::" + workerGroup
+}
+
+func minInt(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
 }
 
 func contains(list []string, v string) bool {

--- a/server/internal/jobs/registry_test.go
+++ b/server/internal/jobs/registry_test.go
@@ -1,6 +1,7 @@
 package jobs
 
 import (
+	"bufio"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -50,5 +51,230 @@ func TestHandleStatusUpdateRejectsTerminalJobs(t *testing.T) {
 	reg.mu.Unlock()
 	if status != StatusCanceled {
 		t.Fatalf("expected status to remain %q, got %q", StatusCanceled, status)
+	}
+}
+
+func TestClaimJobFiltersByWorkerAffinity(t *testing.T) {
+	reg := NewRegistry(transfer.NewRegistry(0), 0, 0)
+	now := time.Now()
+
+	reg.mu.Lock()
+	reg.jobs["job-any"] = &Job{ID: "job-any", Type: "test", Status: StatusQueued, CreatedAt: now, UpdatedAt: now}
+	reg.jobs["job-worker"] = &Job{ID: "job-worker", Type: "test", Status: StatusQueued, WorkerID: "worker-a", CreatedAt: now, UpdatedAt: now}
+	reg.jobs["job-group"] = &Job{ID: "job-group", Type: "test", Status: StatusQueued, WorkerGroup: "group-a", CreatedAt: now, UpdatedAt: now}
+	reg.jobs["job-both"] = &Job{ID: "job-both", Type: "test", Status: StatusQueued, WorkerID: "worker-b", WorkerGroup: "group-a", CreatedAt: now, UpdatedAt: now}
+	reg.queue = []string{"job-worker", "job-group", "job-both", "job-any"}
+	reg.mu.Unlock()
+
+	job := reg.claimNext([]string{"test"}, "worker-a", "group-z")
+	if job == nil || job.ID != "job-worker" {
+		t.Fatalf("expected worker-targeted job, got %#v", job)
+	}
+	if job.ClaimedWorkerID != "worker-a" || job.ClaimedWorkerGroup != "group-z" {
+		t.Fatalf("expected claimed worker fields to be recorded, got %#v", job)
+	}
+
+	job = reg.claimNext([]string{"test"}, "worker-z", "group-a")
+	if job == nil || job.ID != "job-group" {
+		t.Fatalf("expected group-targeted job, got %#v", job)
+	}
+
+	job = reg.claimNext([]string{"test"}, "worker-b", "group-a")
+	if job == nil || job.ID != "job-both" {
+		t.Fatalf("expected exact worker/group job, got %#v", job)
+	}
+
+	job = reg.claimNext([]string{"test"}, "worker-c", "group-c")
+	if job == nil || job.ID != "job-any" {
+		t.Fatalf("expected untargeted job, got %#v", job)
+	}
+}
+
+func TestHandleCreateAndClaimAffinityFields(t *testing.T) {
+	reg := NewRegistry(transfer.NewRegistry(0), 0, 0)
+
+	router := chi.NewRouter()
+	reg.RegisterRoutes(router)
+
+	createReq := httptest.NewRequest(http.MethodPost, "/jobs", strings.NewReader(`{"type":"test","worker_id":"worker-a","worker_group":"group-a"}`))
+	createReq.Header.Set("Content-Type", "application/json")
+	createResp := httptest.NewRecorder()
+	router.ServeHTTP(createResp, createReq)
+	if createResp.Code != http.StatusOK {
+		t.Fatalf("create status = %d, want %d", createResp.Code, http.StatusOK)
+	}
+
+	var created struct {
+		JobID string `json:"job_id"`
+	}
+	if err := json.NewDecoder(createResp.Body).Decode(&created); err != nil {
+		t.Fatalf("decode create: %v", err)
+	}
+
+	claimReq := httptest.NewRequest(http.MethodPost, "/jobs/claim", strings.NewReader(`{"worker_id":"worker-a","worker_group":"group-a","max_wait_seconds":0}`))
+	claimReq.Header.Set("Content-Type", "application/json")
+	claimResp := httptest.NewRecorder()
+	router.ServeHTTP(claimResp, claimReq)
+	if claimResp.Code != http.StatusOK {
+		t.Fatalf("claim status = %d, want %d", claimResp.Code, http.StatusOK)
+	}
+
+	var claimed map[string]any
+	if err := json.NewDecoder(claimResp.Body).Decode(&claimed); err != nil {
+		t.Fatalf("decode claim: %v", err)
+	}
+	if claimed["worker_id"] != "worker-a" {
+		t.Fatalf("expected worker_id in claim response, got %v", claimed["worker_id"])
+	}
+	if claimed["worker_group"] != "group-a" {
+		t.Fatalf("expected worker_group in claim response, got %v", claimed["worker_group"])
+	}
+	if claimed["claimed_worker_id"] != "worker-a" {
+		t.Fatalf("expected claimed_worker_id in claim response, got %v", claimed["claimed_worker_id"])
+	}
+	if claimed["claimed_worker_group"] != "group-a" {
+		t.Fatalf("expected claimed_worker_group in claim response, got %v", claimed["claimed_worker_group"])
+	}
+
+	getReq := httptest.NewRequest(http.MethodGet, "/jobs/"+created.JobID, nil)
+	getResp := httptest.NewRecorder()
+	router.ServeHTTP(getResp, getReq)
+	if getResp.Code != http.StatusOK {
+		t.Fatalf("get status = %d, want %d", getResp.Code, http.StatusOK)
+	}
+
+	var view map[string]any
+	if err := json.NewDecoder(getResp.Body).Decode(&view); err != nil {
+		t.Fatalf("decode get: %v", err)
+	}
+	if view["worker_id"] != "worker-a" || view["worker_group"] != "group-a" {
+		t.Fatalf("expected requested affinity in view, got %#v", view)
+	}
+	if view["claimed_worker_id"] != "worker-a" || view["claimed_worker_group"] != "group-a" {
+		t.Fatalf("expected claimed affinity in view, got %#v", view)
+	}
+}
+
+func TestClaimStreamEmitsCompatibleJobs(t *testing.T) {
+	reg := NewRegistry(transfer.NewRegistry(0), 0, 0)
+	now := time.Now()
+
+	reg.mu.Lock()
+	reg.jobs["job-a"] = &Job{ID: "job-a", Type: "test", Status: StatusQueued, WorkerGroup: "group-a", CreatedAt: now, UpdatedAt: now}
+	reg.jobs["job-b"] = &Job{ID: "job-b", Type: "other", Status: StatusQueued, WorkerGroup: "group-b", CreatedAt: now, UpdatedAt: now}
+	reg.queue = []string{"job-b", "job-a"}
+	reg.mu.Unlock()
+
+	router := chi.NewRouter()
+	reg.RegisterWorkerRoutes(router)
+	srv := httptest.NewServer(router)
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL + "/jobs/stream?types=test&worker_id=worker-17&worker_group=group-a")
+	if err != nil {
+		t.Fatalf("stream request: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("stream status = %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+	if got := resp.Header.Get("Content-Type"); got != "text/event-stream" {
+		t.Fatalf("stream content-type = %q, want %q", got, "text/event-stream")
+	}
+
+	reader := bufio.NewReader(resp.Body)
+	line, err := reader.ReadString('\n')
+	if err != nil {
+		t.Fatalf("read event line: %v", err)
+	}
+	if strings.TrimSpace(line) != "event: job" {
+		t.Fatalf("first line = %q, want event: job", strings.TrimSpace(line))
+	}
+	line, err = reader.ReadString('\n')
+	if err != nil {
+		t.Fatalf("read data line: %v", err)
+	}
+	if !strings.HasPrefix(line, "data: ") {
+		t.Fatalf("data line = %q, want data prefix", line)
+	}
+
+	var payload map[string]any
+	if err := json.Unmarshal([]byte(strings.TrimPrefix(strings.TrimSpace(line), "data: ")), &payload); err != nil {
+		t.Fatalf("decode payload: %v", err)
+	}
+	if payload["job_id"] != "job-a" {
+		t.Fatalf("job_id = %v, want job-a", payload["job_id"])
+	}
+	if payload["claimed_worker_id"] != "worker-17" {
+		t.Fatalf("claimed_worker_id = %v, want worker-17", payload["claimed_worker_id"])
+	}
+	if payload["claimed_worker_group"] != "group-a" {
+		t.Fatalf("claimed_worker_group = %v, want group-a", payload["claimed_worker_group"])
+	}
+
+	reg.mu.Lock()
+	status := reg.jobs["job-a"].Status
+	reg.mu.Unlock()
+	if status != StatusClaimed {
+		t.Fatalf("job status = %q, want %q", status, StatusClaimed)
+	}
+}
+
+func TestStateSnapshotTracksRecentWorkers(t *testing.T) {
+	reg := NewRegistry(transfer.NewRegistry(0), 0, 0)
+	now := time.Now()
+
+	reg.mu.Lock()
+	reg.jobs["job-1"] = &Job{ID: "job-1", Type: "test", Status: StatusQueued, WorkerGroup: "group-a", CreatedAt: now, UpdatedAt: now}
+	reg.queue = []string{"job-1"}
+	reg.mu.Unlock()
+
+	reg.recordWorkerSeen("worker-a", "group-a", "poll", []string{"test"}, "")
+	reg.addWorkerStream("worker-b", "group-b", []string{"test"})
+	state := reg.StateSnapshot()
+
+	if state.Summary.ActiveWorkers != 2 {
+		t.Fatalf("active_workers = %d, want 2", state.Summary.ActiveWorkers)
+	}
+	if state.Summary.StreamingWorkers != 1 {
+		t.Fatalf("streaming_workers = %d, want 1", state.Summary.StreamingWorkers)
+	}
+	if state.Summary.QueuedJobs != 1 {
+		t.Fatalf("queued_jobs = %d, want 1", state.Summary.QueuedJobs)
+	}
+	if len(state.Workers) != 2 {
+		t.Fatalf("workers len = %d, want 2", len(state.Workers))
+	}
+	if len(state.Jobs) != 1 || state.Jobs[0].ID != "job-1" {
+		t.Fatalf("unexpected jobs snapshot: %#v", state.Jobs)
+	}
+}
+
+func TestStateSnapshotPrunesStaleWorkers(t *testing.T) {
+	reg := NewRegistry(transfer.NewRegistry(0), 0, 0)
+	stale := time.Now().Add(-workerRetention - time.Minute)
+
+	reg.mu.Lock()
+	reg.workers[workerKey("worker-old", "group-a")] = &WorkerActivity{
+		Key:         workerKey("worker-old", "group-a"),
+		WorkerID:    "worker-old",
+		WorkerGroup: "group-a",
+		LastSeenAt:  stale,
+	}
+	reg.workers[workerKey("worker-live", "group-b")] = &WorkerActivity{
+		Key:         workerKey("worker-live", "group-b"),
+		WorkerID:    "worker-live",
+		WorkerGroup: "group-b",
+		LastSeenAt:  time.Now(),
+	}
+	reg.mu.Unlock()
+
+	state := reg.StateSnapshot()
+	if len(state.Workers) != 1 {
+		t.Fatalf("workers len = %d, want 1", len(state.Workers))
+	}
+	if state.Workers[0].WorkerID != "worker-live" {
+		t.Fatalf("remaining worker = %q, want worker-live", state.Workers[0].WorkerID)
 	}
 }

--- a/server/internal/server/server.go
+++ b/server/internal/server/server.go
@@ -81,6 +81,11 @@ func New(cfg config.ServerConfig, stateReg *serverstate.Registry, plugins []plug
 	wrapper := generated.ServerInterfaceWrapper{Handler: impl}
 	transferReg := transfer.NewRegistry(60 * time.Second)
 	jobReg := jobs.NewRegistry(transferReg, cfg.JobsSSECloseDelay, cfg.JobsClientTTL)
+	stateReg.Add(serverstate.Element{
+		ID:   "jobs",
+		Data: func() interface{} { return jobReg.StateSnapshot() },
+		HTML: func() string { return jobReg.StateHTML() },
+	})
 
 	r.Get("/healthz", wrapper.GetHealthz)
 	r.Route("/api", func(ar chi.Router) {

--- a/server/internal/server/state.html
+++ b/server/internal/server/state.html
@@ -642,6 +642,9 @@ function pluginSummaryText(id) {
 }
 
 function pluginWorkerCount(state) {
+  if (state && state.summary && state.summary.active_workers != null) {
+    return state.summary.active_workers;
+  }
   return ((state && state.workers) || []).length;
 }
 
@@ -749,6 +752,12 @@ function ensurePluginSection(id, plugins) {
 }
 
 function pluginMetaParts(id, pluginState) {
+  if (id === 'jobs') {
+    var summary = (pluginState && pluginState.summary) || {};
+    return {
+      text: (summary.active_workers || 0) + ' active | queued ' + (summary.queued_jobs || 0) + ' | running ' + (summary.running_jobs || 0)
+    };
+  }
   var workers = pluginWorkerCount(pluginState);
   var server = (pluginState && pluginState.server) || {};
   var queueLen = server.scheduler_queue_len || 0;


### PR DESCRIPTION
This pull request introduces support for targeting jobs to specific workers or worker groups in the jobs API, and ensures that worker identity and affinity are tracked and exposed throughout job creation, claiming, and status reporting. The API, documentation, and client SDKs (Python and .NET) are all updated to support these new features, including a new SSE job stream endpoint for workers.

**API and Protocol Enhancements:**

* Jobs can now be targeted to a specific `worker_id`, a `worker_group`, or both; claims include worker identity and affinity, and claimed jobs record this information for traceability. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R267-R268) [[2]](diffhunk://#diff-49e9fb6defacc8d1e1844008c78b8b85d89bfd91ac5e93388577d22b95f3bbc9R483-R484)
* OpenAPI spec (`api/openapi.yaml`) updated to add `worker_id`, `worker_group`, `claimed_worker_id`, and `claimed_worker_group` fields to job-related schemas, and to document the new `/api/jobs/stream` SSE endpoint. [[1]](diffhunk://#diff-6c08e65eef0374988297d041bd50f87b385613a7e478c3812cb5312cc3e1f1e3R60-R63) [[2]](diffhunk://#diff-6c08e65eef0374988297d041bd50f87b385613a7e478c3812cb5312cc3e1f1e3R82-R85) [[3]](diffhunk://#diff-6c08e65eef0374988297d041bd50f87b385613a7e478c3812cb5312cc3e1f1e3R96-R103) [[4]](diffhunk://#diff-6c08e65eef0374988297d041bd50f87b385613a7e478c3812cb5312cc3e1f1e3R128-R135) [[5]](diffhunk://#diff-6c08e65eef0374988297d041bd50f87b385613a7e478c3812cb5312cc3e1f1e3R300-R327)

**Documentation Updates:**

* `doc/api/jobs.md` and `README.md` updated to document new fields, SSE job streaming, and provide updated usage examples for job creation and claiming with worker targeting. [[1]](diffhunk://#diff-49e9fb6defacc8d1e1844008c78b8b85d89bfd91ac5e93388577d22b95f3bbc9L48-R49) [[2]](diffhunk://#diff-49e9fb6defacc8d1e1844008c78b8b85d89bfd91ac5e93388577d22b95f3bbc9R96-R98) [[3]](diffhunk://#diff-49e9fb6defacc8d1e1844008c78b8b85d89bfd91ac5e93388577d22b95f3bbc9L225-R249) [[4]](diffhunk://#diff-49e9fb6defacc8d1e1844008c78b8b85d89bfd91ac5e93388577d22b95f3bbc9L249-R299) [[5]](diffhunk://#diff-49e9fb6defacc8d1e1844008c78b8b85d89bfd91ac5e93388577d22b95f3bbc9R483-R484) [[6]](diffhunk://#diff-49e9fb6defacc8d1e1844008c78b8b85d89bfd91ac5e93388577d22b95f3bbc9R530-R531) [[7]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L302-R310)

**Client SDK Enhancements:**

* Python client (`example_nfrx_jobs_client.py`, `example_nfrx_jobs_worker.py`) updated to accept and propagate `worker_id` and `worker_group` in job creation and claiming, and to add CLI arguments for these fields. [[1]](diffhunk://#diff-8870408a5c12f5e83b9803819a1b77dd6582c7a2f6bf87288c01b56b1ba8709dL63-R74) [[2]](diffhunk://#diff-8870408a5c12f5e83b9803819a1b77dd6582c7a2f6bf87288c01b56b1ba8709dR138-R143) [[3]](diffhunk://#diff-8870408a5c12f5e83b9803819a1b77dd6582c7a2f6bf87288c01b56b1ba8709dR265-R266) [[4]](diffhunk://#diff-8870408a5c12f5e83b9803819a1b77dd6582c7a2f6bf87288c01b56b1ba8709dR304-R305) [[5]](diffhunk://#diff-6b4e11aaa2540781bc70b01bac6e8d6a16c8d10b0a1c0e8a3be12dac3c97254eL51-R65) [[6]](diffhunk://#diff-6b4e11aaa2540781bc70b01bac6e8d6a16c8d10b0a1c0e8a3be12dac3c97254eR105-R114) [[7]](diffhunk://#diff-6b4e11aaa2540781bc70b01bac6e8d6a16c8d10b0a1c0e8a3be12dac3c97254eR182-R183)
* .NET client (`NfrxJobsClient.cs` and related examples) updated to support `worker_id` and `worker_group` in job creation, claiming, and session APIs, and to expose new fields in response models. [[1]](diffhunk://#diff-56e40a0a9d0e65a44f9dbe6d995e4e095202b5546ee60892205248e429a07f88L27-R45) [[2]](diffhunk://#diff-56e40a0a9d0e65a44f9dbe6d995e4e095202b5546ee60892205248e429a07f88R172-R177) [[3]](diffhunk://#diff-56e40a0a9d0e65a44f9dbe6d995e4e095202b5546ee60892205248e429a07f88R290-R291) [[4]](diffhunk://#diff-56e40a0a9d0e65a44f9dbe6d995e4e095202b5546ee60892205248e429a07f88R300-R307) [[5]](diffhunk://#diff-56e40a0a9d0e65a44f9dbe6d995e4e095202b5546ee60892205248e429a07f88R407-R412) [[6]](diffhunk://#diff-56e40a0a9d0e65a44f9dbe6d995e4e095202b5546ee60892205248e429a07f88R506-R517) [[7]](diffhunk://#diff-10095f20ea8e4ce0bcc1c2cdb0bcdd354fabc7f165f700546921b76ba9b59898R27-R28)

These changes make the jobs API more flexible and enable affinity-based job routing and traceability for worker pools.