### PR TITLE
Feat/transfer api supports properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,6 +266,8 @@ See `doc/api/jobs.md` for full details, SSE event formats, and auth notes.
 
 Jobs can optionally target a specific `worker_id`, a shared `worker_group`, or both. Claims include the worker identity so claimed jobs remain traceable.
 
+The repo also includes secure example client/worker pairs in Python and .NET that demonstrate CMS/X.509 encrypted transfers built on top of job `metadata` and transfer `properties`.
+
 ### Client flow
 
 1) Create a job:

--- a/README.md
+++ b/README.md
@@ -313,7 +313,9 @@ curl -N "http://localhost:8080/api/jobs/stream?types=asr.transcribe&worker_id=wo
 2) Request payload channel (worker reads, client writes):
 
 ```
-curl -s -X POST http://localhost:8080/api/jobs/<job_id>/payload
+curl -s -X POST http://localhost:8080/api/jobs/<job_id>/payload \
+  -H "Content-Type: application/json" \
+  -d '{"properties":{"protocol":"demo-v1","options":{"mode":"header-body","note":"opaque to nfrx"}}}'
 ```
 
 3) Update status/progress:
@@ -327,7 +329,9 @@ curl -X POST http://localhost:8080/api/jobs/<job_id>/status \
 4) Request result channel (worker writes, client reads):
 
 ```
-curl -s -X POST http://localhost:8080/api/jobs/<job_id>/result
+curl -s -X POST http://localhost:8080/api/jobs/<job_id>/result \
+  -H "Content-Type: application/json" \
+  -d '{"properties":{"protocol":"demo-v1","options":{"mode":"header-body","note":"opaque to nfrx"}}}'
 ```
 
 5) Mark completed or failed:

--- a/api/generated/types.gen.go
+++ b/api/generated/types.gen.go
@@ -85,25 +85,28 @@ type TransferCreateResponse struct {
 
 // TransferInfo defines model for TransferInfo.
 type TransferInfo struct {
-	ChannelId string    `json:"channel_id"`
-	ExpiresAt time.Time `json:"expires_at"`
-	Key       *string   `json:"key,omitempty"`
-	Method    string    `json:"method"`
-	Url       string    `json:"url"`
+	ChannelId  string                  `json:"channel_id"`
+	ExpiresAt  time.Time               `json:"expires_at"`
+	Key        *string                 `json:"key,omitempty"`
+	Method     string                  `json:"method"`
+	Properties *map[string]interface{} `json:"properties,omitempty"`
+	Url        string                  `json:"url"`
 }
 
 // TransferRequest defines model for TransferRequest.
 type TransferRequest struct {
-	Key *string `json:"key,omitempty"`
+	Key        *string                 `json:"key,omitempty"`
+	Properties *map[string]interface{} `json:"properties,omitempty"`
 }
 
 // TransferRequestResponse defines model for TransferRequestResponse.
 type TransferRequestResponse struct {
-	ChannelId string    `json:"channel_id"`
-	ExpiresAt time.Time `json:"expires_at"`
-	Key       *string   `json:"key,omitempty"`
-	ReaderUrl *string   `json:"reader_url,omitempty"`
-	WriterUrl *string   `json:"writer_url,omitempty"`
+	ChannelId  string                  `json:"channel_id"`
+	ExpiresAt  time.Time               `json:"expires_at"`
+	Key        *string                 `json:"key,omitempty"`
+	Properties *map[string]interface{} `json:"properties,omitempty"`
+	ReaderUrl  *string                 `json:"reader_url,omitempty"`
+	WriterUrl  *string                 `json:"writer_url,omitempty"`
 }
 
 // PostApiJobsJSONRequestBody defines body for PostApiJobs for application/json ContentType.

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -24,6 +24,9 @@ components:
       properties:
         key:
           type: string
+        properties:
+          type: object
+          additionalProperties: true
         channel_id:
           type: string
         method:
@@ -39,6 +42,9 @@ components:
       properties:
         key:
           type: string
+        properties:
+          type: object
+          additionalProperties: true
     JobError:
       type: object
       properties:
@@ -160,6 +166,9 @@ components:
       properties:
         key:
           type: string
+        properties:
+          type: object
+          additionalProperties: true
         channel_id:
           type: string
         reader_url:

--- a/doc/api/jobs.md
+++ b/doc/api/jobs.md
@@ -535,6 +535,21 @@ Install dependencies:
 pip install httpx httpx-sse
 ```
 
+For the secure CMS/X.509 reference examples, also install:
+
+```bash
+pip install cryptography
+```
+
+Secure example reference implementations:
+
+- `examples/python/example_nfrx_jobs_client_secure.py`
+- `examples/python/example_nfrx_jobs_worker_secure.py`
+- `examples/dotnet/example-nfrx-jobs-client-secure/Program.cs`
+- `examples/dotnet/example-nfrx-jobs-worker-secure/Program.cs`
+
+These examples demonstrate one possible client-worker protocol built on top of opaque job `metadata` and transfer `properties`. They are not built-in `nfrx` protocol features.
+
 Minimal usage with provider/consumer delegates:
 
 ```python

--- a/doc/api/jobs.md
+++ b/doc/api/jobs.md
@@ -156,11 +156,11 @@ data: {"id":"...","status":"queued",...}
 
 
 event: payload
-data: {"key":"payload","channel_id":"...","method":"POST","url":"/api/transfer/...","expires_at":"..."}
+data: {"key":"payload","channel_id":"...","method":"POST","url":"/api/transfer/...","expires_at":"...","properties":{"protocol":"demo-v1"}}
 
 
 event: result
-data: {"key":"result","channel_id":"...","method":"GET","url":"/api/transfer/...","expires_at":"..."}
+data: {"key":"result","channel_id":"...","method":"GET","url":"/api/transfer/...","expires_at":"...","properties":{"protocol":"demo-v1"}}
 
 
 event: status
@@ -320,7 +320,16 @@ X-User-Roles: <client_role>
 Request body (optional):
 
 ```json
-{ "key": "payload" }
+{
+  "key": "payload",
+  "properties": {
+    "protocol": "demo-v1",
+    "options": {
+      "mode": "header-body",
+      "note": "opaque to nfrx"
+    }
+  }
+}
 ```
 
 Response:
@@ -330,11 +339,19 @@ Response:
   "key": "payload",
   "channel_id": "<uuid>",
   "reader_url": "/api/transfer/<uuid>",
-  "expires_at": "2026-01-31T01:00:00Z"
+  "expires_at": "2026-01-31T01:00:00Z",
+  "properties": {
+    "protocol": "demo-v1",
+    "options": {
+      "mode": "header-body",
+      "note": "opaque to nfrx"
+    }
+  }
 }
 ```
 
 - `key` is optional; if omitted the server defaults to `"payload"`. Explicit empty is allowed.
+- `properties` is optional opaque worker-client metadata; nfrx stores and relays it without interpretation.
 - Worker should **GET** `reader_url` to receive payload.
 - Client receives a `payload` event with a POST URL to send bytes.
 
@@ -415,7 +432,16 @@ X-User-Roles: <client_role>
 Request body (optional):
 
 ```json
-{ "key": "result" }
+{
+  "key": "result",
+  "properties": {
+    "protocol": "demo-v1",
+    "options": {
+      "mode": "header-body",
+      "note": "opaque to nfrx"
+    }
+  }
+}
 ```
 
 Response:
@@ -425,11 +451,19 @@ Response:
   "key": "result",
   "channel_id": "<uuid>",
   "writer_url": "/api/transfer/<uuid>",
-  "expires_at": "2026-01-31T01:00:00Z"
+  "expires_at": "2026-01-31T01:00:00Z",
+  "properties": {
+    "protocol": "demo-v1",
+    "options": {
+      "mode": "header-body",
+      "note": "opaque to nfrx"
+    }
+  }
 }
 ```
 
 - `key` is optional; if omitted the server defaults to `"result"`. Explicit empty is allowed.
+- `properties` is optional opaque worker-client metadata; nfrx stores and relays it without interpretation.
 - Worker should **POST** bytes to `writer_url`.
 - Client receives a `result` event with a GET URL to read bytes.
 
@@ -476,7 +510,10 @@ Transfer channels are created by `/payload` and `/result` (optional `key`) or di
 - **Time‑limited**: channels expire if the other side does not connect in time.
 - **Streaming**: payloads are streamed; no server persistence.
 - **Methods**: client uses the URL and method in the `payload`/`result` event (`POST` for payload, `GET` for result).
+- **Properties**: jobs-side `/payload` and `/result` requests may attach opaque `properties`, which are relayed via job events and views but are not part of direct `/api/transfer` channels.
 ## Notes
+
+- Direct `/api/transfer` channels do not carry jobs-side `properties`; those are available only through `/payload`, `/result`, and job events/views.
 
 - Transfer channels are one‑time, time‑limited, and in‑memory only.
 - Jobs are in‑memory; a server restart clears the queue.

--- a/doc/api/transfer.md
+++ b/doc/api/transfer.md
@@ -2,6 +2,8 @@
 
 This document describes the transfer API for streaming payloads/results over one-time channels.
 
+The direct transfer API carries only opaque bytes. Jobs-side transfer `properties` are attached through `/api/jobs/{job_id}/payload` and `/api/jobs/{job_id}/result`, not through `/api/transfer` itself.
+
 ## Python client usage (minimal)
 
 To use the Python transfer client in your own project, copy this example file into your codebase:

--- a/doc/server-endpoints.md
+++ b/doc/server-endpoints.md
@@ -124,8 +124,8 @@ Notes:
 | `GET /api/jobs/{job_id}/events` | Path `{job_id}` | SSE stream of job events. | API key or API roles |
 | `POST /api/jobs/{job_id}/cancel` | Path `{job_id}` | Cancel a job. | API key or API roles |
 | `POST /api/jobs/claim` | Body `{ types?: [string], max_wait_seconds?: int }` | Claim the next queued job. | Client key or client roles |
-| `POST /api/jobs/{job_id}/payload` | Path `{job_id}`; Body `{ key?: string }` | Request a payload transfer channel (worker reads, client writes). | Client key or client roles |
-| `POST /api/jobs/{job_id}/result` | Path `{job_id}`; Body `{ key?: string }` | Request a result transfer channel (worker writes, client reads). | Client key or client roles |
+| `POST /api/jobs/{job_id}/payload` | Path `{job_id}`; Body `{ key?: string, properties?: object }` | Request a payload transfer channel (worker reads, client writes). | Client key or client roles |
+| `POST /api/jobs/{job_id}/result` | Path `{job_id}`; Body `{ key?: string, properties?: object }` | Request a result transfer channel (worker writes, client reads). | Client key or client roles |
 | `POST /api/jobs/{job_id}/status` | Path `{job_id}` | Update job status/progress/error. | Client key or client roles |
 
 Notes:

--- a/examples/dotnet/NfrxExamples.sln
+++ b/examples/dotnet/NfrxExamples.sln
@@ -13,6 +13,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "example-nfrx-transfer", "ex
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "example-nfrx-jobs-worker", "example-nfrx-jobs-worker\example-nfrx-jobs-worker.csproj", "{01EA6FCB-20FF-4ED3-90D8-C9FEC1D5B212}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "example-nfrx-jobs-client-secure", "example-nfrx-jobs-client-secure\example-nfrx-jobs-client-secure.csproj", "{A1150B45-7E14-4A4E-A98C-967FB365F12D}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "example-nfrx-jobs-worker-secure", "example-nfrx-jobs-worker-secure\example-nfrx-jobs-worker-secure.csproj", "{7ED1C1E2-B0A0-43A8-B914-FF0532A7E6B3}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -35,6 +39,14 @@ Global
 		{01EA6FCB-20FF-4ED3-90D8-C9FEC1D5B212}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{01EA6FCB-20FF-4ED3-90D8-C9FEC1D5B212}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{01EA6FCB-20FF-4ED3-90D8-C9FEC1D5B212}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A1150B45-7E14-4A4E-A98C-967FB365F12D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A1150B45-7E14-4A4E-A98C-967FB365F12D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A1150B45-7E14-4A4E-A98C-967FB365F12D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A1150B45-7E14-4A4E-A98C-967FB365F12D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7ED1C1E2-B0A0-43A8-B914-FF0532A7E6B3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7ED1C1E2-B0A0-43A8-B914-FF0532A7E6B3}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7ED1C1E2-B0A0-43A8-B914-FF0532A7E6B3}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7ED1C1E2-B0A0-43A8-B914-FF0532A7E6B3}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -43,6 +55,8 @@ Global
 		{2FF6495D-6515-4746-BE12-63E2B6407245} = {02EA681E-C7D8-13C7-8484-4AC65E1B71E8}
 		{491D1BB2-E795-4F74-B60B-A8F4C60E5F64} = {02EA681E-C7D8-13C7-8484-4AC65E1B71E8}
 		{01EA6FCB-20FF-4ED3-90D8-C9FEC1D5B212} = {02EA681E-C7D8-13C7-8484-4AC65E1B71E8}
+		{A1150B45-7E14-4A4E-A98C-967FB365F12D} = {02EA681E-C7D8-13C7-8484-4AC65E1B71E8}
+		{7ED1C1E2-B0A0-43A8-B914-FF0532A7E6B3} = {02EA681E-C7D8-13C7-8484-4AC65E1B71E8}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {683505AA-6F60-45B7-A060-FEAEEA163532}

--- a/examples/dotnet/example-nfrx-jobs-client-secure/Program.cs
+++ b/examples/dotnet/example-nfrx-jobs-client-secure/Program.cs
@@ -1,0 +1,163 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using NfrxSdk;
+
+class Program
+{
+    public static async Task<int> Main()
+    {
+        var baseUrl = Environment.GetEnvironmentVariable("NFRX_BASE_URL") ?? "http://localhost:8080";
+        var apiKey = Environment.GetEnvironmentVariable("NFRX_API_KEY");
+        var payloadFile = Environment.GetEnvironmentVariable("NFRX_PAYLOAD_FILE");
+        var resultFile = Environment.GetEnvironmentVariable("NFRX_RESULT_FILE");
+
+        using var identity = SecureTransfer.GenerateSelfSignedIdentity("nfrx secure client");
+        Console.WriteLine("generated client certificate (PEM):");
+        Console.WriteLine(identity.CertificatePem.Trim());
+
+        using var http = new HttpClient();
+        var jobs = new NfrxJobsClient(baseUrl, apiKey, http);
+        var transfer = new NfrxTransferClient(baseUrl, apiKey, http);
+
+        var metadata = new Dictionary<string, object>
+        {
+            ["language"] = "en",
+            ["secure_transfer"] = new Dictionary<string, object>
+            {
+                ["supported_schemes"] = new[] { SecureTransfer.Scheme },
+                ["result_recipient_cert_pem"] = identity.CertificatePem,
+                ["envelope"] = SecureTransfer.Envelope,
+            },
+        };
+
+        var created = await jobs.CreateJobAsync("asr.transcribe", metadata);
+        Console.WriteLine($"created secure job: {created.JobId}");
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+        await foreach (var (type, data) in jobs.StreamEventsAsync(created.JobId, cts.Token))
+        {
+            if (type == "status")
+            {
+                Console.WriteLine("status: " + data.GetValueOrDefault("status"));
+                if (IsTerminal(data))
+                {
+                    return 0;
+                }
+                continue;
+            }
+
+            if (type == "payload")
+            {
+                var recipientPem = ValidatePayloadProperties(data);
+                var envelope = SecureTransfer.BuildHeaderBodyEnvelope(
+                    "application/octet-stream",
+                    ReadPayload(payloadFile),
+                    "client-payload");
+                var ciphertext = SecureTransfer.EncryptCms(envelope, recipientPem);
+                var channel = GetChannel(data);
+                await transfer.UploadAsync(channel, ciphertext, SecureTransfer.CmsContentType, cts.Token);
+                Console.WriteLine($"uploaded encrypted payload ({ciphertext.Length} bytes)");
+                continue;
+            }
+
+            if (type == "result")
+            {
+                ValidateResultProperties(data);
+                var channel = GetChannel(data);
+                var ciphertext = await transfer.DownloadAsync(channel, cts.Token);
+                var plaintext = SecureTransfer.DecryptCms(ciphertext, identity.Certificate);
+                var envelope = SecureTransfer.ParseHeaderBodyEnvelope(plaintext);
+                Console.WriteLine("result headers: " + JsonSerializer.Serialize(envelope.Headers));
+                WriteResult(resultFile, envelope.Body);
+                Console.WriteLine($"received encrypted result ({ciphertext.Length} bytes)");
+            }
+        }
+
+        return 0;
+    }
+
+    private static byte[] ReadPayload(string? path)
+    {
+        return string.IsNullOrWhiteSpace(path) ? "hello world"u8.ToArray() : File.ReadAllBytes(path);
+    }
+
+    private static void WriteResult(string? path, byte[] data)
+    {
+        if (string.IsNullOrWhiteSpace(path))
+        {
+            Console.WriteLine("result body: " + System.Text.Encoding.UTF8.GetString(data));
+            return;
+        }
+        File.WriteAllBytes(path, data);
+    }
+
+    private static string GetChannel(Dictionary<string, JsonElement> payload)
+    {
+        if (payload.TryGetValue("channel_id", out var channelId) && channelId.ValueKind == JsonValueKind.String)
+        {
+            return channelId.GetString() ?? throw new InvalidOperationException("channel_id is null");
+        }
+        if (payload.TryGetValue("url", out var url) && url.ValueKind == JsonValueKind.String)
+        {
+            return url.GetString() ?? throw new InvalidOperationException("url is null");
+        }
+        throw new InvalidOperationException("Missing transfer channel info");
+    }
+
+    private static string ValidatePayloadProperties(Dictionary<string, JsonElement> payload)
+    {
+        var properties = GetProperties(payload);
+        RequireString(properties, "encryption_scheme", SecureTransfer.Scheme);
+        RequireString(properties, "envelope", SecureTransfer.Envelope);
+        return RequireNonEmptyString(properties, "recipient_cert_pem");
+    }
+
+    private static void ValidateResultProperties(Dictionary<string, JsonElement> payload)
+    {
+        var properties = GetProperties(payload);
+        RequireString(properties, "encryption_scheme", SecureTransfer.Scheme);
+        RequireString(properties, "envelope", SecureTransfer.Envelope);
+        RequireString(properties, "recipient", "job-metadata-result-cert");
+    }
+
+    private static JsonElement GetProperties(Dictionary<string, JsonElement> payload)
+    {
+        if (!payload.TryGetValue("properties", out var properties) || properties.ValueKind != JsonValueKind.Object)
+        {
+            throw new InvalidOperationException("Event missing properties object");
+        }
+        return properties;
+    }
+
+    private static void RequireString(JsonElement obj, string propertyName, string expected)
+    {
+        var actual = RequireNonEmptyString(obj, propertyName);
+        if (!string.Equals(actual, expected, StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException($"Unexpected {propertyName}: {actual}");
+        }
+    }
+
+    private static string RequireNonEmptyString(JsonElement obj, string propertyName)
+    {
+        if (!obj.TryGetProperty(propertyName, out var value) || value.ValueKind != JsonValueKind.String)
+        {
+            throw new InvalidOperationException($"Missing string property {propertyName}");
+        }
+        return value.GetString() ?? throw new InvalidOperationException($"{propertyName} is null");
+    }
+
+    private static bool IsTerminal(Dictionary<string, JsonElement> payload)
+    {
+        if (!payload.TryGetValue("status", out var status) || status.ValueKind != JsonValueKind.String)
+        {
+            return false;
+        }
+        var value = status.GetString();
+        return value == "completed" || value == "failed" || value == "canceled";
+    }
+}

--- a/examples/dotnet/example-nfrx-jobs-client-secure/example-nfrx-jobs-client-secure.csproj
+++ b/examples/dotnet/example-nfrx-jobs-client-secure/example-nfrx-jobs-client-secure.csproj
@@ -1,14 +1,15 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <OutputType>Exe</OutputType>
     <TargetFramework>net8.0</TargetFramework>
-    <RootNamespace>NfrxSdk</RootNamespace>
+    <RootNamespace>example_nfrx_jobs_client_secure</RootNamespace>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Security.Cryptography.Pkcs" Version="8.0.1" />
+    <ProjectReference Include="..\nfrx-sdk\nfrx-sdk.csproj" />
   </ItemGroup>
 
 </Project>

--- a/examples/dotnet/example-nfrx-jobs-client/Program.cs
+++ b/examples/dotnet/example-nfrx-jobs-client/Program.cs
@@ -29,13 +29,19 @@ class Program
             payloadProvider: async (key, payload) =>
             {
                 _ = key;
-                _ = payload;
+                if (payload.TryGetValue("properties", out var properties))
+                {
+                    Console.WriteLine("payload properties: " + properties);
+                }
                 return (Encoding.UTF8.GetBytes("hello world"), "application/octet-stream");
             },
             resultConsumer: async (key, data, payload) =>
             {
                 _ = key;
-                _ = payload;
+                if (payload.TryGetValue("properties", out var properties))
+                {
+                    Console.WriteLine("result properties: " + properties);
+                }
                 Console.WriteLine("result: " + Encoding.UTF8.GetString(data));
                 await Task.CompletedTask;
             }

--- a/examples/dotnet/example-nfrx-jobs-worker-secure/Program.cs
+++ b/examples/dotnet/example-nfrx-jobs-worker-secure/Program.cs
@@ -1,0 +1,131 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text.Json;
+using System.Threading.Tasks;
+using NfrxSdk;
+
+class Program
+{
+    public static async Task<int> Main()
+    {
+        var baseUrl = Environment.GetEnvironmentVariable("NFRX_BASE_URL") ?? "http://localhost:8080";
+        var clientKey = Environment.GetEnvironmentVariable("NFRX_CLIENT_KEY");
+        var debugResultFile = Environment.GetEnvironmentVariable("NFRX_DEBUG_RESULT_FILE");
+
+        using var identity = SecureTransfer.GenerateSelfSignedIdentity("nfrx secure worker");
+        Console.WriteLine("generated worker certificate (PEM):");
+        Console.WriteLine(identity.CertificatePem.Trim());
+
+        using var worker = new NfrxJobsWorker(baseUrl, clientKey);
+        while (true)
+        {
+            var job = await worker.ClaimJobAsync(new List<string> { "asr.transcribe" }, 30).ConfigureAwait(false);
+            if (job == null)
+            {
+                Console.WriteLine("no job available");
+                continue;
+            }
+
+            Console.WriteLine($"claimed secure job: {job.JobId}");
+            try
+            {
+                var secure = GetSecureMetadata(job);
+                await worker.UpdateStatusAsync(job.JobId, "claimed").ConfigureAwait(false);
+
+                var payloadChannel = await worker.RequestPayloadChannelAsync(
+                    job.JobId,
+                    null,
+                    new Dictionary<string, object>
+                    {
+                        ["encryption_scheme"] = SecureTransfer.Scheme,
+                        ["envelope"] = SecureTransfer.Envelope,
+                        ["recipient_cert_pem"] = identity.CertificatePem,
+                    }).ConfigureAwait(false);
+                var payloadCiphertext = await worker.ReadPayloadAsync(payloadChannel.ReaderUrl ?? payloadChannel.ChannelId).ConfigureAwait(false);
+                var payloadPlaintext = SecureTransfer.DecryptCms(payloadCiphertext, identity.Certificate);
+                var payloadEnvelope = SecureTransfer.ParseHeaderBodyEnvelope(payloadPlaintext);
+                Console.WriteLine("payload headers: " + JsonSerializer.Serialize(payloadEnvelope.Headers));
+
+                await worker.UpdateStatusAsync(job.JobId, "running").ConfigureAwait(false);
+
+                var resultEnvelope = SecureTransfer.BuildHeaderBodyEnvelope(
+                    payloadEnvelope.Headers["Content-Type"],
+                    payloadEnvelope.Body,
+                    "worker-result");
+                var resultCiphertext = SecureTransfer.EncryptCms(resultEnvelope, secure.ResultRecipientCertPem);
+                var resultChannel = await worker.RequestResultChannelAsync(
+                    job.JobId,
+                    null,
+                    new Dictionary<string, object>
+                    {
+                        ["encryption_scheme"] = SecureTransfer.Scheme,
+                        ["envelope"] = SecureTransfer.Envelope,
+                        ["recipient"] = "job-metadata-result-cert",
+                    }).ConfigureAwait(false);
+                await worker.WriteResultAsync(
+                    resultChannel.WriterUrl ?? resultChannel.ChannelId,
+                    resultCiphertext,
+                    SecureTransfer.CmsContentType).ConfigureAwait(false);
+                if (!string.IsNullOrWhiteSpace(debugResultFile))
+                {
+                    File.WriteAllBytes(debugResultFile, payloadEnvelope.Body);
+                }
+                await worker.UpdateStatusAsync(job.JobId, "completed").ConfigureAwait(false);
+                Console.WriteLine($"completed secure job: {job.JobId}");
+                return 0;
+            }
+            catch (Exception exc)
+            {
+                await worker.UpdateStatusAsync(
+                    job.JobId,
+                    "failed",
+                    error: new JobError { Code = "secure_transfer_error", Message = exc.Message }).ConfigureAwait(false);
+                Console.WriteLine("error: " + exc.Message);
+                return 1;
+            }
+        }
+    }
+
+    private static SecureMetadata GetSecureMetadata(JobClaimResponse job)
+    {
+        if (job.Metadata == null || !job.Metadata.TryGetValue("secure_transfer", out var secureElement) || secureElement.ValueKind != JsonValueKind.Object)
+        {
+            throw new InvalidOperationException("Job metadata missing secure_transfer");
+        }
+        if (!secureElement.TryGetProperty("supported_schemes", out var schemes) || schemes.ValueKind != JsonValueKind.Array)
+        {
+            throw new InvalidOperationException("Job metadata missing supported_schemes");
+        }
+        var supportsCms = false;
+        foreach (var item in schemes.EnumerateArray())
+        {
+            if (item.ValueKind == JsonValueKind.String && item.GetString() == SecureTransfer.Scheme)
+            {
+                supportsCms = true;
+                break;
+            }
+        }
+        if (!supportsCms)
+        {
+            throw new InvalidOperationException($"Client does not advertise {SecureTransfer.Scheme}");
+        }
+        var envelope = RequireNonEmptyString(secureElement, "envelope");
+        if (!string.Equals(envelope, SecureTransfer.Envelope, StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException($"Unsupported envelope: {envelope}");
+        }
+        return new SecureMetadata(RequireNonEmptyString(secureElement, "result_recipient_cert_pem"));
+    }
+
+    private static string RequireNonEmptyString(JsonElement obj, string propertyName)
+    {
+        if (!obj.TryGetProperty(propertyName, out var value) || value.ValueKind != JsonValueKind.String)
+        {
+            throw new InvalidOperationException($"Missing string property {propertyName}");
+        }
+        return value.GetString() ?? throw new InvalidOperationException($"{propertyName} is null");
+    }
+
+    private sealed record SecureMetadata(string ResultRecipientCertPem);
+}

--- a/examples/dotnet/example-nfrx-jobs-worker-secure/example-nfrx-jobs-worker-secure.csproj
+++ b/examples/dotnet/example-nfrx-jobs-worker-secure/example-nfrx-jobs-worker-secure.csproj
@@ -1,14 +1,15 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <OutputType>Exe</OutputType>
     <TargetFramework>net8.0</TargetFramework>
-    <RootNamespace>NfrxSdk</RootNamespace>
+    <RootNamespace>example_nfrx_jobs_worker_secure</RootNamespace>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Security.Cryptography.Pkcs" Version="8.0.1" />
+    <ProjectReference Include="..\nfrx-sdk\nfrx-sdk.csproj" />
   </ItemGroup>
 
 </Project>

--- a/examples/dotnet/nfrx-sdk/NfrxJobsClient.cs
+++ b/examples/dotnet/nfrx-sdk/NfrxJobsClient.cs
@@ -322,13 +322,17 @@ public sealed class NfrxJobsWorker : IDisposable
     public async Task<TransferRequestResponse> RequestPayloadChannelAsync(
         string jobId,
         string? key,
+        Dictionary<string, object>? properties = null,
         CancellationToken cancellationToken = default)
     {
         using var req = new HttpRequestMessage(HttpMethod.Post, _baseUrl + $"/api/jobs/{jobId}/payload");
         AddAuth(req);
-        if (key != null)
+        if (key != null || properties != null)
         {
-            req.Content = new StringContent(JsonSerializer.Serialize(new TransferRequest { Key = key }), Encoding.UTF8, "application/json");
+            req.Content = new StringContent(
+                JsonSerializer.Serialize(new TransferRequest { Key = key, Properties = properties }),
+                Encoding.UTF8,
+                "application/json");
         }
         using var resp = await _http.SendAsync(req, cancellationToken).ConfigureAwait(false);
         resp.EnsureSuccessStatusCode();
@@ -340,13 +344,17 @@ public sealed class NfrxJobsWorker : IDisposable
     public async Task<TransferRequestResponse> RequestResultChannelAsync(
         string jobId,
         string? key,
+        Dictionary<string, object>? properties = null,
         CancellationToken cancellationToken = default)
     {
         using var req = new HttpRequestMessage(HttpMethod.Post, _baseUrl + $"/api/jobs/{jobId}/result");
         AddAuth(req);
-        if (key != null)
+        if (key != null || properties != null)
         {
-            req.Content = new StringContent(JsonSerializer.Serialize(new TransferRequest { Key = key }), Encoding.UTF8, "application/json");
+            req.Content = new StringContent(
+                JsonSerializer.Serialize(new TransferRequest { Key = key, Properties = properties }),
+                Encoding.UTF8,
+                "application/json");
         }
         using var resp = await _http.SendAsync(req, cancellationToken).ConfigureAwait(false);
         resp.EnsureSuccessStatusCode();
@@ -406,6 +414,8 @@ public sealed class NfrxJobsWorker : IDisposable
         int maxWaitSeconds,
         string? workerId = null,
         string? workerGroup = null,
+        Dictionary<string, object>? payloadProperties = null,
+        Dictionary<string, object>? resultProperties = null,
         WorkerStatusHandler? onStatus = null,
         CancellationToken cancellationToken = default)
     {
@@ -421,7 +431,7 @@ public sealed class NfrxJobsWorker : IDisposable
             await onStatus("claimed", null).ConfigureAwait(false);
         }
 
-        var payloadChannel = await RequestPayloadChannelAsync(jobId, null, cancellationToken).ConfigureAwait(false);
+        var payloadChannel = await RequestPayloadChannelAsync(jobId, null, payloadProperties, cancellationToken).ConfigureAwait(false);
         if (onStatus != null)
         {
             await onStatus("awaiting_payload", payloadChannel).ConfigureAwait(false);
@@ -447,7 +457,7 @@ public sealed class NfrxJobsWorker : IDisposable
             return true;
         }
 
-        var resultChannel = await RequestResultChannelAsync(jobId, null, cancellationToken).ConfigureAwait(false);
+        var resultChannel = await RequestResultChannelAsync(jobId, null, resultProperties, cancellationToken).ConfigureAwait(false);
         if (onStatus != null)
         {
             await onStatus("awaiting_result", resultChannel).ConfigureAwait(false);
@@ -520,11 +530,13 @@ public sealed class JobClaimResponse
 public sealed class TransferRequest
 {
     public string? Key { get; set; }
+    public Dictionary<string, object>? Properties { get; set; }
 }
 
 public sealed class TransferRequestResponse
 {
     public string? Key { get; set; }
+    public Dictionary<string, JsonElement>? Properties { get; set; }
     [JsonPropertyName("channel_id")]
     public string ChannelId { get; set; } = string.Empty;
     [JsonPropertyName("reader_url")]

--- a/examples/dotnet/nfrx-sdk/SecureTransfer.cs
+++ b/examples/dotnet/nfrx-sdk/SecureTransfer.cs
@@ -1,0 +1,190 @@
+using System;
+using System.Collections.Generic;
+using System.Security.Cryptography;
+using System.Security.Cryptography.Pkcs;
+using System.Security.Cryptography.X509Certificates;
+using System.Text;
+
+namespace NfrxSdk;
+
+public sealed class SecureIdentity : IDisposable
+{
+    public SecureIdentity(X509Certificate2 certificate, string certificatePem)
+    {
+        Certificate = certificate;
+        CertificatePem = certificatePem;
+    }
+
+    public X509Certificate2 Certificate { get; }
+    public string CertificatePem { get; }
+
+    public void Dispose()
+    {
+        Certificate.Dispose();
+    }
+}
+
+public sealed class HeaderBodyEnvelope
+{
+    public HeaderBodyEnvelope(Dictionary<string, string> headers, byte[] body)
+    {
+        Headers = headers;
+        Body = body;
+    }
+
+    public Dictionary<string, string> Headers { get; }
+    public byte[] Body { get; }
+}
+
+public static class SecureTransfer
+{
+    public const string Scheme = "cms-x509-selfsigned-v1";
+    public const string Envelope = "header-body-v1";
+    public const string CmsContentType = "application/pkcs7-mime";
+    private const string Aes256CbcOid = "2.16.840.1.101.3.4.1.42";
+
+    public static SecureIdentity GenerateSelfSignedIdentity(string commonName)
+    {
+        using var rsa = RSA.Create(2048);
+        var subject = new X500DistinguishedName($"CN={commonName}, O=nfrx example");
+        var request = new CertificateRequest(subject, rsa, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
+        request.CertificateExtensions.Add(new X509BasicConstraintsExtension(false, false, 0, true));
+        request.CertificateExtensions.Add(new X509SubjectKeyIdentifierExtension(request.PublicKey, false));
+        using var generated = request.CreateSelfSigned(DateTimeOffset.UtcNow.AddMinutes(-5), DateTimeOffset.UtcNow.AddDays(7));
+        var cert = new X509Certificate2(generated.Export(X509ContentType.Pfx), (string?)null, X509KeyStorageFlags.Exportable);
+        return new SecureIdentity(cert, cert.ExportCertificatePem());
+    }
+
+    public static byte[] EncryptCms(byte[] plaintext, string recipientCertificatePem)
+    {
+        using var recipient = X509Certificate2.CreateFromPem(recipientCertificatePem);
+        var cms = new EnvelopedCms(new ContentInfo(plaintext), new AlgorithmIdentifier(new Oid(Aes256CbcOid)));
+        cms.Encrypt(new CmsRecipient(SubjectIdentifierType.IssuerAndSerialNumber, recipient));
+        return cms.Encode();
+    }
+
+    public static byte[] DecryptCms(byte[] ciphertext, X509Certificate2 recipientCertificate)
+    {
+        var cms = new EnvelopedCms();
+        cms.Decode(ciphertext);
+        cms.Decrypt(new X509Certificate2Collection(recipientCertificate));
+        return cms.ContentInfo.Content;
+    }
+
+    public static byte[] BuildHeaderBodyEnvelope(
+        string contentType,
+        byte[] body,
+        string role,
+        IReadOnlyDictionary<string, string>? extraHeaders = null)
+    {
+        var headers = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["X-Nfrx-Envelope-Version"] = "1",
+            ["Content-Type"] = contentType,
+            ["Content-Length"] = body.Length.ToString(),
+            ["X-Example-Protocol"] = Scheme,
+            ["X-Example-Role"] = role,
+        };
+        if (extraHeaders != null)
+        {
+            foreach (var pair in extraHeaders)
+            {
+                if (string.IsNullOrWhiteSpace(pair.Key) || pair.Key.Contains('\r') || pair.Key.Contains('\n'))
+                {
+                    throw new InvalidOperationException($"Invalid header name: {pair.Key}");
+                }
+                if (pair.Value.Contains('\r') || pair.Value.Contains('\n'))
+                {
+                    throw new InvalidOperationException($"Invalid header value for {pair.Key}");
+                }
+                headers[pair.Key] = pair.Value;
+            }
+        }
+
+        var builder = new StringBuilder();
+        foreach (var pair in headers)
+        {
+            builder.Append(pair.Key).Append(": ").Append(pair.Value).Append("\r\n");
+        }
+        builder.Append("\r\n");
+
+        var headerBytes = Encoding.UTF8.GetBytes(builder.ToString());
+        var envelope = new byte[headerBytes.Length + body.Length];
+        Buffer.BlockCopy(headerBytes, 0, envelope, 0, headerBytes.Length);
+        Buffer.BlockCopy(body, 0, envelope, headerBytes.Length, body.Length);
+        return envelope;
+    }
+
+    public static HeaderBodyEnvelope ParseHeaderBodyEnvelope(byte[] envelope)
+    {
+        var separatorIndex = FindSeparator(envelope);
+        if (separatorIndex < 0)
+        {
+            throw new InvalidOperationException("Missing CRLFCRLF envelope separator.");
+        }
+
+        var headerText = Encoding.UTF8.GetString(envelope, 0, separatorIndex);
+        var bodyOffset = separatorIndex + 4;
+        var body = new byte[envelope.Length - bodyOffset];
+        Buffer.BlockCopy(envelope, bodyOffset, body, 0, body.Length);
+
+        var headers = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var line in headerText.Split("\r\n", StringSplitOptions.None))
+        {
+            if (line.Length == 0)
+            {
+                throw new InvalidOperationException("Unexpected empty header line.");
+            }
+            if (line[0] == ' ' || line[0] == '\t')
+            {
+                throw new InvalidOperationException("Folded headers are not supported.");
+            }
+            var idx = line.IndexOf(':');
+            if (idx <= 0)
+            {
+                throw new InvalidOperationException($"Malformed header line: {line}");
+            }
+            var key = line[..idx].Trim();
+            var value = line[(idx + 1)..].Trim();
+            if (key.Length == 0)
+            {
+                throw new InvalidOperationException("Header name cannot be empty.");
+            }
+            if (!headers.TryAdd(key, value))
+            {
+                throw new InvalidOperationException($"Duplicate header: {key}");
+            }
+        }
+
+        foreach (var required in new[] { "X-Nfrx-Envelope-Version", "Content-Type", "Content-Length" })
+        {
+            if (!headers.ContainsKey(required))
+            {
+                throw new InvalidOperationException($"Missing required header: {required}");
+            }
+        }
+
+        if (!int.TryParse(headers["Content-Length"], out var expectedLength) || expectedLength < 0)
+        {
+            throw new InvalidOperationException("Invalid Content-Length header.");
+        }
+        if (expectedLength != body.Length)
+        {
+            throw new InvalidOperationException($"Content-Length mismatch: expected {expectedLength}, got {body.Length}.");
+        }
+
+        return new HeaderBodyEnvelope(headers, body);
+    }
+
+    private static int FindSeparator(byte[] envelope)
+    {
+        for (var i = 0; i <= envelope.Length - 4; i++)
+        {
+            if (envelope[i] == '\r' && envelope[i + 1] == '\n' && envelope[i + 2] == '\r' && envelope[i + 3] == '\n')
+            {
+                return i;
+            }
+        }
+        return -1;
+    }
+}

--- a/examples/python/example_nfrx_jobs_client.py
+++ b/examples/python/example_nfrx_jobs_client.py
@@ -226,6 +226,8 @@ async def _handle_payload(
     provider: PayloadProvider,
 ) -> None:
     key = payload.get("key", "payload")
+    if "properties" in payload:
+        print("payload event properties:", json.dumps(payload["properties"]))
     provided = await provider(key, payload)
     if provided is None:
         print("payload event: provider returned no data")
@@ -245,6 +247,8 @@ async def _handle_result(
     consumer: ResultConsumer,
 ) -> None:
     key = payload.get("key", "result")
+    if "properties" in payload:
+        print("result event properties:", json.dumps(payload["properties"]))
     channel = payload.get("channel_id") or payload.get("url")
     if not channel:
         print("result event: missing channel info")

--- a/examples/python/example_nfrx_jobs_client_secure.py
+++ b/examples/python/example_nfrx_jobs_client_secure.py
@@ -1,0 +1,203 @@
+#!/usr/bin/env python3
+"""Secure Jobs API client example for nfrx using CMS/X.509."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, AsyncGenerator, Dict, Optional, Tuple
+
+import httpx
+from httpx_sse import aconnect_sse
+
+from nfrx_sdk.secure_transfer import (
+    CMS_CONTENT_TYPE,
+    ENVELOPE,
+    SCHEME,
+    build_header_body_envelope,
+    decrypt_cms_der,
+    encrypt_cms_der,
+    generate_self_signed_identity,
+    parse_header_body_envelope,
+)
+from nfrx_sdk.transfer_client import AuthConfig as TransferAuth, NfrxTransferClient
+
+
+@dataclass
+class AuthConfig:
+    api_key: Optional[str] = None
+
+
+class NfrxJobsClient:
+    def __init__(self, base_url: str, auth: AuthConfig) -> None:
+        self._base_url = base_url.rstrip("/")
+        self._auth = auth
+        self._client = httpx.AsyncClient(base_url=self._base_url, timeout=30.0)
+
+    async def close(self) -> None:
+        await self._client.aclose()
+
+    def _headers(self) -> Dict[str, str]:
+        headers: Dict[str, str] = {}
+        if self._auth.api_key:
+            headers["Authorization"] = f"Bearer {self._auth.api_key}"
+        return headers
+
+    async def create_job(
+        self,
+        job_type: str,
+        metadata: Dict[str, Any],
+        worker_id: Optional[str] = None,
+        worker_group: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        payload: Dict[str, Any] = {"type": job_type, "metadata": metadata}
+        if worker_id:
+            payload["worker_id"] = worker_id
+        if worker_group:
+            payload["worker_group"] = worker_group
+        resp = await self._client.post("/api/jobs", json=payload, headers=self._headers())
+        resp.raise_for_status()
+        return resp.json()
+
+    async def stream_events(self, job_id: str) -> AsyncGenerator[Tuple[str, Dict[str, Any]], None]:
+        async with aconnect_sse(
+            self._client,
+            "GET",
+            f"/api/jobs/{job_id}/events",
+            headers=self._headers(),
+        ) as event_source:
+            event_source.response.raise_for_status()
+            async for sse in event_source.aiter_sse():
+                event_type = sse.event or "message"
+                payload = sse.json()
+                yield event_type, payload
+
+
+def _read_payload(path: Optional[str]) -> bytes:
+    if not path:
+        return b"hello world"
+    return Path(path).read_bytes()
+
+
+def _write_result(path: Optional[str], data: bytes) -> None:
+    if not path:
+        sys.stdout.buffer.write(data)
+        sys.stdout.buffer.write(b"\n")
+        return
+    Path(path).write_bytes(data)
+
+
+def _validate_payload_properties(payload: Dict[str, Any]) -> str:
+    properties = payload.get("properties")
+    if not isinstance(properties, dict):
+        raise ValueError("payload event missing properties")
+    if properties.get("encryption_scheme") != SCHEME:
+        raise ValueError(f"unsupported payload encryption scheme: {properties.get('encryption_scheme')!r}")
+    if properties.get("envelope") != ENVELOPE:
+        raise ValueError(f"unsupported payload envelope: {properties.get('envelope')!r}")
+    recipient_cert_pem = properties.get("recipient_cert_pem")
+    if not isinstance(recipient_cert_pem, str) or not recipient_cert_pem.strip():
+        raise ValueError("payload event missing recipient_cert_pem")
+    return recipient_cert_pem
+
+
+def _validate_result_properties(payload: Dict[str, Any]) -> None:
+    properties = payload.get("properties")
+    if not isinstance(properties, dict):
+        raise ValueError("result event missing properties")
+    if properties.get("encryption_scheme") != SCHEME:
+        raise ValueError(f"unsupported result encryption scheme: {properties.get('encryption_scheme')!r}")
+    if properties.get("envelope") != ENVELOPE:
+        raise ValueError(f"unsupported result envelope: {properties.get('envelope')!r}")
+    if properties.get("recipient") != "job-metadata-result-cert":
+        raise ValueError(f"unexpected result recipient marker: {properties.get('recipient')!r}")
+
+
+async def run(args: argparse.Namespace) -> int:
+    identity = generate_self_signed_identity("nfrx secure client")
+    print("generated client certificate (PEM):")
+    print(identity.certificate_pem.strip())
+
+    transfer = NfrxTransferClient(args.base_url, TransferAuth(bearer_token=args.api_key), timeout=args.timeout)
+    jobs = NfrxJobsClient(args.base_url, AuthConfig(api_key=args.api_key))
+    try:
+        metadata = json.loads(args.metadata) if args.metadata else {}
+        metadata["secure_transfer"] = {
+            "supported_schemes": [SCHEME],
+            "result_recipient_cert_pem": identity.certificate_pem,
+            "envelope": ENVELOPE,
+        }
+        created = await jobs.create_job(args.job_type, metadata, args.worker_id, args.worker_group)
+        job_id = created["job_id"]
+        print(f"created secure job: {job_id}")
+
+        async for event_type, payload in jobs.stream_events(job_id):
+            if event_type == "status":
+                print("status:", payload.get("status"))
+                if payload.get("status") in {"completed", "failed", "canceled"}:
+                    return 0
+                continue
+
+            if event_type == "payload":
+                recipient_cert_pem = _validate_payload_properties(payload)
+                plaintext = build_header_body_envelope(
+                    args.payload_content_type,
+                    _read_payload(args.payload_file),
+                    "client-payload",
+                )
+                ciphertext = encrypt_cms_der(plaintext, recipient_cert_pem)
+                channel = payload.get("channel_id") or payload.get("url")
+                if not channel:
+                    raise ValueError("payload event missing transfer channel")
+                await transfer.upload(channel, ciphertext, CMS_CONTENT_TYPE)
+                print(f"uploaded encrypted payload ({len(ciphertext)} bytes)")
+                continue
+
+            if event_type == "result":
+                _validate_result_properties(payload)
+                channel = payload.get("channel_id") or payload.get("url")
+                if not channel:
+                    raise ValueError("result event missing transfer channel")
+                ciphertext = await transfer.download(channel)
+                plaintext = decrypt_cms_der(ciphertext, identity)
+                headers, body = parse_header_body_envelope(plaintext)
+                print("result headers:", json.dumps(headers, indent=2))
+                _write_result(args.result_file, body)
+                print(f"received encrypted result ({len(ciphertext)} bytes)")
+                continue
+    finally:
+        await transfer.close()
+        await jobs.close()
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="nfrx secure jobs API client example")
+    parser.add_argument("--base-url", default="http://localhost:8080")
+    parser.add_argument("--api-key", default=None)
+    parser.add_argument("--job-type", default="asr.transcribe")
+    parser.add_argument("--metadata", default=None, help="optional JSON object merged into job metadata")
+    parser.add_argument("--worker-id", default=None)
+    parser.add_argument("--worker-group", default=None)
+    parser.add_argument("--payload-file", default=None)
+    parser.add_argument("--payload-content-type", default="application/octet-stream")
+    parser.add_argument("--result-file", default=None)
+    parser.add_argument("--timeout", type=float, default=30.0)
+    return parser
+
+
+def main() -> int:
+    parser = build_parser()
+    args = parser.parse_args()
+    try:
+        return asyncio.run(run(args))
+    except (ValueError, httpx.HTTPError) as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/python/example_nfrx_jobs_worker.py
+++ b/examples/python/example_nfrx_jobs_worker.py
@@ -31,6 +31,14 @@ class JobClaim(TypedDict):
 ProcessHandler = Callable[[JobClaim, bytes], Awaitable[Tuple[bytes, Optional[str]]]]
 StatusHandler = Callable[[str, Optional[Dict[str, Any]]], Awaitable[None]]
 
+DEMO_TRANSFER_PROPERTIES: Dict[str, Any] = {
+    "protocol": "demo-v1",
+    "options": {
+        "mode": "header-body",
+        "note": "opaque to nfrx",
+    },
+}
+
 
 class NfrxJobsWorker:
     def __init__(self, base_url: str, auth: AuthConfig) -> None:
@@ -69,13 +77,31 @@ class NfrxJobsWorker:
         resp.raise_for_status()
         return resp.json()
 
-    async def request_payload_channel(self, job_id: str) -> Dict[str, Any]:
-        resp = await self._client.post(f"/api/jobs/{job_id}/payload", headers=self._headers())
+    async def request_payload_channel(
+        self, job_id: str, properties: Optional[Dict[str, Any]] = None
+    ) -> Dict[str, Any]:
+        payload: Dict[str, Any] = {}
+        if properties is not None:
+            payload["properties"] = properties
+        resp = await self._client.post(
+            f"/api/jobs/{job_id}/payload",
+            json=payload if payload else None,
+            headers=self._headers(),
+        )
         resp.raise_for_status()
         return resp.json()
 
-    async def request_result_channel(self, job_id: str) -> Dict[str, Any]:
-        resp = await self._client.post(f"/api/jobs/{job_id}/result", headers=self._headers())
+    async def request_result_channel(
+        self, job_id: str, properties: Optional[Dict[str, Any]] = None
+    ) -> Dict[str, Any]:
+        payload: Dict[str, Any] = {}
+        if properties is not None:
+            payload["properties"] = properties
+        resp = await self._client.post(
+            f"/api/jobs/{job_id}/result",
+            json=payload if payload else None,
+            headers=self._headers(),
+        )
         resp.raise_for_status()
         return resp.json()
 
@@ -122,8 +148,9 @@ class NfrxJobsWorker:
             if on_status:
                 await on_status("claimed", None)
 
-            payload_channel = await self.request_payload_channel(job_id)
+            payload_channel = await self.request_payload_channel(job_id, DEMO_TRANSFER_PROPERTIES)
             payload_url = payload_channel.get("reader_url") or payload_channel.get("url")
+            print("payload channel properties:", json.dumps(payload_channel.get("properties")))
             if on_status:
                 await on_status("awaiting_payload", payload_channel)
             payload_bytes = await self.read_payload(payload_url)
@@ -143,7 +170,7 @@ class NfrxJobsWorker:
                     await on_status("failed", {"error": {"code": "handler_error", "message": error_message}})
                 return True
 
-            result_channel = await self.request_result_channel(job_id)
+            result_channel = await self.request_result_channel(job_id, DEMO_TRANSFER_PROPERTIES)
             result_url = result_channel.get("writer_url") or result_channel.get("url")
             if on_status:
                 await on_status("awaiting_result", result_channel)

--- a/examples/python/example_nfrx_jobs_worker_secure.py
+++ b/examples/python/example_nfrx_jobs_worker_secure.py
@@ -1,0 +1,224 @@
+#!/usr/bin/env python3
+"""Secure Jobs API worker example for nfrx using CMS/X.509."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+import httpx
+
+from nfrx_sdk.secure_transfer import (
+    CMS_CONTENT_TYPE,
+    ENVELOPE,
+    SCHEME,
+    build_header_body_envelope,
+    decrypt_cms_der,
+    encrypt_cms_der,
+    generate_self_signed_identity,
+    parse_header_body_envelope,
+)
+
+
+@dataclass
+class AuthConfig:
+    client_key: Optional[str] = None
+
+
+class NfrxJobsWorker:
+    def __init__(self, base_url: str, auth: AuthConfig) -> None:
+        self._base_url = base_url.rstrip("/")
+        self._auth = auth
+        self._client = httpx.AsyncClient(base_url=self._base_url, timeout=60.0)
+
+    async def close(self) -> None:
+        await self._client.aclose()
+
+    def _headers(self) -> Dict[str, str]:
+        headers: Dict[str, str] = {}
+        if self._auth.client_key:
+            headers["Authorization"] = f"Bearer {self._auth.client_key}"
+        return headers
+
+    async def claim_job(
+        self,
+        types: Optional[list[str]] = None,
+        max_wait_seconds: int = 30,
+        worker_id: Optional[str] = None,
+        worker_group: Optional[str] = None,
+    ) -> Optional[Dict[str, Any]]:
+        payload: Dict[str, Any] = {"max_wait_seconds": max_wait_seconds}
+        if types:
+            payload["types"] = types
+        if worker_id:
+            payload["worker_id"] = worker_id
+        if worker_group:
+            payload["worker_group"] = worker_group
+        resp = await self._client.post("/api/jobs/claim", json=payload, headers=self._headers())
+        if resp.status_code == 204:
+            return None
+        resp.raise_for_status()
+        return resp.json()
+
+    async def request_payload_channel(self, job_id: str, properties: Dict[str, Any]) -> Dict[str, Any]:
+        resp = await self._client.post(
+            f"/api/jobs/{job_id}/payload",
+            json={"properties": properties},
+            headers=self._headers(),
+        )
+        resp.raise_for_status()
+        return resp.json()
+
+    async def request_result_channel(self, job_id: str, properties: Dict[str, Any]) -> Dict[str, Any]:
+        resp = await self._client.post(
+            f"/api/jobs/{job_id}/result",
+            json={"properties": properties},
+            headers=self._headers(),
+        )
+        resp.raise_for_status()
+        return resp.json()
+
+    async def update_status(self, job_id: str, state: str, payload: Optional[Dict[str, Any]] = None) -> None:
+        body = {"state": state}
+        if payload:
+            body.update(payload)
+        resp = await self._client.post(f"/api/jobs/{job_id}/status", json=body, headers=self._headers())
+        resp.raise_for_status()
+
+    async def read_payload(self, url: str) -> bytes:
+        resp = await self._client.get(url, headers=self._headers())
+        resp.raise_for_status()
+        return resp.content
+
+    async def write_result(self, url: str, data: bytes) -> None:
+        resp = await self._client.post(
+            url,
+            content=data,
+            headers={**self._headers(), "Content-Type": CMS_CONTENT_TYPE},
+        )
+        resp.raise_for_status()
+
+
+def _secure_metadata(job: Dict[str, Any]) -> Dict[str, Any]:
+    metadata = job.get("metadata")
+    if not isinstance(metadata, dict):
+        raise ValueError("job metadata missing")
+    secure = metadata.get("secure_transfer")
+    if not isinstance(secure, dict):
+        raise ValueError("job metadata missing secure_transfer section")
+    schemes = secure.get("supported_schemes")
+    if not isinstance(schemes, list) or SCHEME not in schemes:
+        raise ValueError(f"client did not advertise {SCHEME!r}")
+    if secure.get("envelope") != ENVELOPE:
+        raise ValueError(f"client advertised unsupported envelope: {secure.get('envelope')!r}")
+    recipient = secure.get("result_recipient_cert_pem")
+    if not isinstance(recipient, str) or not recipient.strip():
+        raise ValueError("job metadata missing result_recipient_cert_pem")
+    return secure
+
+
+def _write_result(path: Optional[str], data: bytes) -> None:
+    if not path:
+        return
+    Path(path).write_bytes(data)
+
+
+async def run(args: argparse.Namespace) -> int:
+    identity = generate_self_signed_identity("nfrx secure worker")
+    print("generated worker certificate (PEM):")
+    print(identity.certificate_pem.strip())
+
+    worker = NfrxJobsWorker(args.base_url, AuthConfig(client_key=args.client_key))
+    try:
+        types = args.types.split(",") if args.types else None
+        while True:
+            job = await worker.claim_job(types, args.max_wait_seconds, args.worker_id, args.worker_group)
+            if not job:
+                print("no job available")
+                if args.once:
+                    return 0
+                continue
+
+            job_id = job["job_id"]
+            print(f"claimed secure job: {job_id}")
+            try:
+                secure = _secure_metadata(job)
+                await worker.update_status(job_id, "claimed")
+
+                payload_properties = {
+                    "encryption_scheme": SCHEME,
+                    "envelope": ENVELOPE,
+                    "recipient_cert_pem": identity.certificate_pem,
+                }
+                payload_channel = await worker.request_payload_channel(job_id, payload_properties)
+                payload_url = payload_channel.get("reader_url") or payload_channel.get("url")
+                if not payload_url:
+                    raise ValueError("payload channel missing reader_url")
+                ciphertext = await worker.read_payload(payload_url)
+                plaintext = decrypt_cms_der(ciphertext, identity)
+                headers, body = parse_header_body_envelope(plaintext)
+                print("payload headers:", json.dumps(headers, indent=2))
+
+                await worker.update_status(job_id, "running")
+
+                result_envelope = build_header_body_envelope(
+                    headers["content-type"],
+                    body,
+                    "worker-result",
+                )
+                result_ciphertext = encrypt_cms_der(result_envelope, secure["result_recipient_cert_pem"])
+                result_properties = {
+                    "encryption_scheme": SCHEME,
+                    "envelope": ENVELOPE,
+                    "recipient": "job-metadata-result-cert",
+                }
+                result_channel = await worker.request_result_channel(job_id, result_properties)
+                result_url = result_channel.get("writer_url") or result_channel.get("url")
+                if not result_url:
+                    raise ValueError("result channel missing writer_url")
+                await worker.write_result(result_url, result_ciphertext)
+                _write_result(args.debug_result_file, body)
+                await worker.update_status(job_id, "completed")
+                print(f"completed secure job: {job_id}")
+                return 0
+            except Exception as exc:
+                await worker.update_status(
+                    job_id,
+                    "failed",
+                    payload={"error": {"code": "secure_transfer_error", "message": str(exc)}},
+                )
+                raise
+    finally:
+        await worker.close()
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="nfrx secure jobs API worker example")
+    parser.add_argument("--base-url", default="http://localhost:8080")
+    parser.add_argument("--client-key", default=None)
+    parser.add_argument("--types", default="asr.transcribe")
+    parser.add_argument("--worker-id", default=None)
+    parser.add_argument("--worker-group", default=None)
+    parser.add_argument("--max-wait-seconds", type=int, default=30)
+    parser.add_argument("--debug-result-file", default=None, help="optional plaintext result output")
+    parser.add_argument("--once", action="store_true")
+    return parser
+
+
+def main() -> int:
+    parser = build_parser()
+    args = parser.parse_args()
+    try:
+        return asyncio.run(run(args))
+    except (ValueError, httpx.HTTPError) as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/python/nfrx_sdk/secure_transfer.py
+++ b/examples/python/nfrx_sdk/secure_transfer.py
@@ -1,0 +1,127 @@
+"""CMS/X.509 secure transfer helpers for nfrx example jobs flows."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from typing import Mapping, Optional
+
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+from cryptography.hazmat.primitives.ciphers import algorithms
+from cryptography.hazmat.primitives.serialization import pkcs7
+from cryptography.x509.oid import NameOID
+
+SCHEME = "cms-x509-selfsigned-v1"
+ENVELOPE = "header-body-v1"
+CMS_CONTENT_TYPE = "application/pkcs7-mime"
+
+
+@dataclass
+class SecureIdentity:
+    certificate: x509.Certificate
+    private_key: rsa.RSAPrivateKey
+    certificate_pem: str
+
+
+def generate_self_signed_identity(common_name: str) -> SecureIdentity:
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    subject = issuer = x509.Name(
+        [
+            x509.NameAttribute(NameOID.COMMON_NAME, common_name),
+            x509.NameAttribute(NameOID.ORGANIZATION_NAME, "nfrx example"),
+        ]
+    )
+    now = datetime.now(timezone.utc)
+    cert = (
+        x509.CertificateBuilder()
+        .subject_name(subject)
+        .issuer_name(issuer)
+        .public_key(key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(now - timedelta(minutes=5))
+        .not_valid_after(now + timedelta(days=7))
+        .add_extension(x509.BasicConstraints(ca=False, path_length=None), critical=True)
+        .sign(key, hashes.SHA256())
+    )
+    cert_pem = cert.public_bytes(serialization.Encoding.PEM).decode("ascii")
+    return SecureIdentity(certificate=cert, private_key=key, certificate_pem=cert_pem)
+
+
+def build_header_body_envelope(
+    content_type: str,
+    body: bytes,
+    role: str,
+    extra_headers: Optional[Mapping[str, str]] = None,
+) -> bytes:
+    headers: dict[str, str] = {
+        "X-Nfrx-Envelope-Version": "1",
+        "Content-Type": content_type,
+        "Content-Length": str(len(body)),
+        "X-Example-Protocol": SCHEME,
+        "X-Example-Role": role,
+    }
+    if extra_headers:
+        for key, value in extra_headers.items():
+            if not key or "\r" in key or "\n" in key:
+                raise ValueError(f"invalid header name: {key!r}")
+            if "\r" in value or "\n" in value:
+                raise ValueError(f"invalid header value for {key!r}")
+            headers[key] = value
+    header_blob = "".join(f"{key}: {value}\r\n" for key, value in headers.items()).encode("utf-8")
+    return header_blob + b"\r\n" + body
+
+
+def parse_header_body_envelope(data: bytes) -> tuple[dict[str, str], bytes]:
+    marker = b"\r\n\r\n"
+    idx = data.find(marker)
+    if idx < 0:
+        raise ValueError("missing CRLFCRLF envelope separator")
+
+    header_blob = data[:idx].decode("utf-8")
+    body = data[idx + len(marker) :]
+    headers: dict[str, str] = {}
+    for raw_line in header_blob.split("\r\n"):
+        if raw_line == "":
+            raise ValueError("unexpected empty header line")
+        if raw_line[0] in {" ", "\t"}:
+            raise ValueError("folded headers are not supported")
+        if ":" not in raw_line:
+            raise ValueError(f"malformed header line: {raw_line!r}")
+        key, value = raw_line.split(":", 1)
+        key = key.strip()
+        value = value.strip()
+        if not key:
+            raise ValueError("header name cannot be empty")
+        canonical = key.lower()
+        if canonical in headers:
+            raise ValueError(f"duplicate header: {key}")
+        headers[canonical] = value
+
+    for required in ("x-nfrx-envelope-version", "content-type", "content-length"):
+        if required not in headers:
+            raise ValueError(f"missing required header: {required}")
+
+    try:
+        content_length = int(headers["content-length"])
+    except ValueError as exc:
+        raise ValueError("invalid Content-Length header") from exc
+    if content_length != len(body):
+        raise ValueError(f"Content-Length mismatch: expected {content_length}, got {len(body)}")
+    return headers, body
+
+
+def encrypt_cms_der(plaintext: bytes, recipient_cert_pem: str) -> bytes:
+    cert = x509.load_pem_x509_certificate(recipient_cert_pem.encode("ascii"))
+    return (
+        pkcs7.PKCS7EnvelopeBuilder()
+        .set_data(plaintext)
+        .set_content_encryption_algorithm(algorithms.AES256)
+        .add_recipient(cert)
+        .encrypt(serialization.Encoding.DER, [])
+    )
+
+
+def decrypt_cms_der(ciphertext: bytes, identity: SecureIdentity) -> bytes:
+    return pkcs7.pkcs7_decrypt_der(ciphertext, identity.certificate, identity.private_key, [])

--- a/server/internal/jobs/registry.go
+++ b/server/internal/jobs/registry.go
@@ -80,11 +80,12 @@ type WorkerActivity struct {
 }
 
 type TransferInfo struct {
-	ChannelID string `json:"channel_id"`
-	Method    string `json:"method"`
-	URL       string `json:"url"`
-	ExpiresAt string `json:"expires_at"`
-	Key       string `json:"key,omitempty"`
+	ChannelID  string         `json:"channel_id"`
+	Method     string         `json:"method"`
+	URL        string         `json:"url"`
+	ExpiresAt  string         `json:"expires_at"`
+	Key        string         `json:"key,omitempty"`
+	Properties map[string]any `json:"properties,omitempty"`
 }
 
 type Event struct {
@@ -114,7 +115,8 @@ type StatusUpdateRequest struct {
 }
 
 type TransferRequest struct {
-	Key *string `json:"key,omitempty"`
+	Key        *string        `json:"key,omitempty"`
+	Properties map[string]any `json:"properties,omitempty"`
 }
 
 type JobView struct {
@@ -398,6 +400,11 @@ func (r *Registry) HandleClaimStream(w http.ResponseWriter, req *http.Request) {
 
 	ctx := req.Context()
 	for {
+		select {
+		case <-ctx.Done():
+			return
+		default:
+		}
 		if job := r.claimNext(types, workerID, workerGroup); job != nil {
 			r.recordWorkerSeen(workerID, workerGroup, "stream", types, job.ID)
 			r.writeEvent(w, Event{Type: "job", Data: r.claimResponse(job)})
@@ -447,11 +454,12 @@ func (r *Registry) HandlePayloadRequest(w http.ResponseWriter, req *http.Request
 	writerURL := "/api/transfer/" + channelID
 
 	info := &TransferInfo{
-		ChannelID: channelID,
-		Method:    http.MethodPost,
-		URL:       writerURL,
-		ExpiresAt: expires.UTC().Format(time.RFC3339),
-		Key:       key,
+		ChannelID:  channelID,
+		Method:     http.MethodPost,
+		URL:        writerURL,
+		ExpiresAt:  expires.UTC().Format(time.RFC3339),
+		Key:        key,
+		Properties: copyMap(body.Properties),
 	}
 	r.mu.Lock()
 	if job.Payloads == nil {
@@ -465,12 +473,16 @@ func (r *Registry) HandlePayloadRequest(w http.ResponseWriter, req *http.Request
 
 	r.publish(jobID, Event{Type: "payload", Data: info})
 	r.publish(jobID, Event{Type: "status", Data: view})
-	writeJSON(w, http.StatusOK, map[string]any{
+	resp := map[string]any{
 		"key":        key,
 		"channel_id": channelID,
 		"reader_url": readerURL,
 		"expires_at": expires.UTC().Format(time.RFC3339),
-	})
+	}
+	if props := copyMap(body.Properties); props != nil {
+		resp["properties"] = props
+	}
+	writeJSON(w, http.StatusOK, resp)
 }
 
 func (r *Registry) HandleResultRequest(w http.ResponseWriter, req *http.Request) {
@@ -503,11 +515,12 @@ func (r *Registry) HandleResultRequest(w http.ResponseWriter, req *http.Request)
 	writerURL := "/api/transfer/" + channelID
 
 	info := &TransferInfo{
-		ChannelID: channelID,
-		Method:    http.MethodGet,
-		URL:       readerURL,
-		ExpiresAt: expires.UTC().Format(time.RFC3339),
-		Key:       key,
+		ChannelID:  channelID,
+		Method:     http.MethodGet,
+		URL:        readerURL,
+		ExpiresAt:  expires.UTC().Format(time.RFC3339),
+		Key:        key,
+		Properties: copyMap(body.Properties),
 	}
 	r.mu.Lock()
 	if job.Results == nil {
@@ -521,12 +534,16 @@ func (r *Registry) HandleResultRequest(w http.ResponseWriter, req *http.Request)
 
 	r.publish(jobID, Event{Type: "result", Data: info})
 	r.publish(jobID, Event{Type: "status", Data: view})
-	writeJSON(w, http.StatusOK, map[string]any{
+	resp := map[string]any{
 		"key":        key,
 		"channel_id": channelID,
 		"writer_url": writerURL,
 		"expires_at": expires.UTC().Format(time.RFC3339),
-	})
+	}
+	if props := copyMap(body.Properties); props != nil {
+		resp["properties"] = props
+	}
+	writeJSON(w, http.StatusOK, resp)
 }
 
 func (r *Registry) HandleStatusUpdate(w http.ResponseWriter, req *http.Request) {
@@ -1199,6 +1216,7 @@ func copyTransfer(info *TransferInfo) *TransferInfo {
 		return nil
 	}
 	cp := *info
+	cp.Properties = copyMap(info.Properties)
 	return &cp
 }
 

--- a/server/internal/jobs/registry_test.go
+++ b/server/internal/jobs/registry_test.go
@@ -2,9 +2,11 @@ package jobs
 
 import (
 	"bufio"
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -221,6 +223,67 @@ func TestClaimStreamEmitsCompatibleJobs(t *testing.T) {
 	}
 }
 
+func TestClaimStreamStopsClaimingAfterDisconnect(t *testing.T) {
+	reg := NewRegistry(transfer.NewRegistry(0), 0, 0)
+	now := time.Now()
+
+	reg.mu.Lock()
+	reg.jobs["job-a"] = &Job{ID: "job-a", Type: "test", Status: StatusQueued, WorkerGroup: "group-a", CreatedAt: now, UpdatedAt: now}
+	reg.jobs["job-b"] = &Job{ID: "job-b", Type: "test", Status: StatusQueued, WorkerGroup: "group-a", CreatedAt: now, UpdatedAt: now}
+	reg.queue = []string{"job-a"}
+	reg.mu.Unlock()
+
+	router := chi.NewRouter()
+	reg.RegisterWorkerRoutes(router)
+	srv := httptest.NewServer(router)
+	defer srv.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, srv.URL+"/jobs/stream?types=test&worker_id=worker-17&worker_group=group-a", nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("stream request: %v", err)
+	}
+	reader := bufio.NewReader(resp.Body)
+	if _, err := reader.ReadString('\n'); err != nil {
+		t.Fatalf("read event line: %v", err)
+	}
+	if _, err := reader.ReadString('\n'); err != nil {
+		t.Fatalf("read data line: %v", err)
+	}
+	cancel()
+	if err := resp.Body.Close(); err != nil {
+		t.Fatalf("close body: %v", err)
+	}
+
+	reg.mu.Lock()
+	reg.queue = append(reg.queue, "job-b")
+	reg.mu.Unlock()
+	reg.signal()
+
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		reg.mu.Lock()
+		statusA := reg.jobs["job-a"].Status
+		statusB := reg.jobs["job-b"].Status
+		queueLen := len(reg.queue)
+		reg.mu.Unlock()
+		if statusA == StatusClaimed {
+			if statusB == StatusQueued && queueLen == 1 {
+				return
+			}
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("unexpected post-disconnect state: job-a=%q job-b=%q queue=%d", statusA, statusB, queueLen)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
 func TestStateSnapshotTracksRecentWorkers(t *testing.T) {
 	reg := NewRegistry(transfer.NewRegistry(0), 0, 0)
 	now := time.Now()
@@ -276,5 +339,192 @@ func TestStateSnapshotPrunesStaleWorkers(t *testing.T) {
 	}
 	if state.Workers[0].WorkerID != "worker-live" {
 		t.Fatalf("remaining worker = %q, want worker-live", state.Workers[0].WorkerID)
+	}
+}
+
+func TestHandlePayloadRequestStoresProperties(t *testing.T) {
+	reg := NewRegistry(transfer.NewRegistry(0), 0, 0)
+	job := &Job{
+		ID:        "job-payload",
+		Type:      "test",
+		Status:    StatusClaimed,
+		CreatedAt: time.Now(),
+		UpdatedAt: time.Now(),
+	}
+	reg.mu.Lock()
+	reg.jobs[job.ID] = job
+	reg.mu.Unlock()
+
+	ch := reg.subscribe(job.ID)
+	defer reg.unsubscribe(job.ID, ch)
+
+	router := chi.NewRouter()
+	reg.RegisterRoutes(router)
+
+	body := `{"key":"payload","properties":{"protocol":"demo-v1","options":{"mode":"header-body","note":"opaque to nfrx"}}}`
+	req := httptest.NewRequest(http.MethodPost, "/jobs/"+job.ID+"/payload", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	resp := httptest.NewRecorder()
+	router.ServeHTTP(resp, req)
+	if resp.Code != http.StatusOK {
+		t.Fatalf("payload status = %d, want %d", resp.Code, http.StatusOK)
+	}
+
+	var payloadResp map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&payloadResp); err != nil {
+		t.Fatalf("decode payload response: %v", err)
+	}
+	want := map[string]any{
+		"protocol": "demo-v1",
+		"options": map[string]any{
+			"mode": "header-body",
+			"note": "opaque to nfrx",
+		},
+	}
+	if !reflect.DeepEqual(payloadResp["properties"], want) {
+		t.Fatalf("payload response properties = %#v, want %#v", payloadResp["properties"], want)
+	}
+
+	ev := expectEventType(t, ch, "payload")
+	info, ok := ev.Data.(*TransferInfo)
+	if !ok {
+		t.Fatalf("payload event data type = %T, want *TransferInfo", ev.Data)
+	}
+	if !reflect.DeepEqual(info.Properties, want) {
+		t.Fatalf("payload event properties = %#v, want %#v", info.Properties, want)
+	}
+	_ = expectEventType(t, ch, "status")
+
+	getReq := httptest.NewRequest(http.MethodGet, "/jobs/"+job.ID, nil)
+	getResp := httptest.NewRecorder()
+	router.ServeHTTP(getResp, getReq)
+	if getResp.Code != http.StatusOK {
+		t.Fatalf("get status = %d, want %d", getResp.Code, http.StatusOK)
+	}
+
+	var view JobView
+	if err := json.NewDecoder(getResp.Body).Decode(&view); err != nil {
+		t.Fatalf("decode get: %v", err)
+	}
+	got := view.Payloads["payload"]
+	if got == nil || !reflect.DeepEqual(got.Properties, want) {
+		t.Fatalf("job payload properties = %#v, want %#v", got, want)
+	}
+}
+
+func TestHandleResultRequestStoresProperties(t *testing.T) {
+	reg := NewRegistry(transfer.NewRegistry(0), 0, 0)
+	job := &Job{
+		ID:        "job-result",
+		Type:      "test",
+		Status:    StatusRunning,
+		CreatedAt: time.Now(),
+		UpdatedAt: time.Now(),
+	}
+	reg.mu.Lock()
+	reg.jobs[job.ID] = job
+	reg.mu.Unlock()
+
+	ch := reg.subscribe(job.ID)
+	defer reg.unsubscribe(job.ID, ch)
+
+	router := chi.NewRouter()
+	reg.RegisterRoutes(router)
+
+	body := `{"key":"result","properties":{"protocol":"demo-v1","options":{"mode":"header-body","note":"opaque to nfrx"}}}`
+	req := httptest.NewRequest(http.MethodPost, "/jobs/"+job.ID+"/result", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	resp := httptest.NewRecorder()
+	router.ServeHTTP(resp, req)
+	if resp.Code != http.StatusOK {
+		t.Fatalf("result status = %d, want %d", resp.Code, http.StatusOK)
+	}
+
+	var resultResp map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&resultResp); err != nil {
+		t.Fatalf("decode result response: %v", err)
+	}
+	want := map[string]any{
+		"protocol": "demo-v1",
+		"options": map[string]any{
+			"mode": "header-body",
+			"note": "opaque to nfrx",
+		},
+	}
+	if !reflect.DeepEqual(resultResp["properties"], want) {
+		t.Fatalf("result response properties = %#v, want %#v", resultResp["properties"], want)
+	}
+
+	ev := expectEventType(t, ch, "result")
+	info, ok := ev.Data.(*TransferInfo)
+	if !ok {
+		t.Fatalf("result event data type = %T, want *TransferInfo", ev.Data)
+	}
+	if !reflect.DeepEqual(info.Properties, want) {
+		t.Fatalf("result event properties = %#v, want %#v", info.Properties, want)
+	}
+	_ = expectEventType(t, ch, "status")
+
+	getReq := httptest.NewRequest(http.MethodGet, "/jobs/"+job.ID, nil)
+	getResp := httptest.NewRecorder()
+	router.ServeHTTP(getResp, getReq)
+	if getResp.Code != http.StatusOK {
+		t.Fatalf("get status = %d, want %d", getResp.Code, http.StatusOK)
+	}
+
+	var view JobView
+	if err := json.NewDecoder(getResp.Body).Decode(&view); err != nil {
+		t.Fatalf("decode get: %v", err)
+	}
+	got := view.Results["result"]
+	if got == nil || !reflect.DeepEqual(got.Properties, want) {
+		t.Fatalf("job result properties = %#v, want %#v", got, want)
+	}
+}
+
+func TestHandlePayloadRequestOmitsPropertiesWhenUnset(t *testing.T) {
+	reg := NewRegistry(transfer.NewRegistry(0), 0, 0)
+	job := &Job{
+		ID:        "job-payload-empty",
+		Type:      "test",
+		Status:    StatusClaimed,
+		CreatedAt: time.Now(),
+		UpdatedAt: time.Now(),
+	}
+	reg.mu.Lock()
+	reg.jobs[job.ID] = job
+	reg.mu.Unlock()
+
+	router := chi.NewRouter()
+	reg.RegisterRoutes(router)
+
+	req := httptest.NewRequest(http.MethodPost, "/jobs/"+job.ID+"/payload", strings.NewReader(`{"key":"payload"}`))
+	req.Header.Set("Content-Type", "application/json")
+	resp := httptest.NewRecorder()
+	router.ServeHTTP(resp, req)
+	if resp.Code != http.StatusOK {
+		t.Fatalf("payload status = %d, want %d", resp.Code, http.StatusOK)
+	}
+
+	var payloadResp map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&payloadResp); err != nil {
+		t.Fatalf("decode payload response: %v", err)
+	}
+	if _, ok := payloadResp["properties"]; ok {
+		t.Fatalf("expected properties to be omitted, got %#v", payloadResp["properties"])
+	}
+}
+
+func expectEventType(t *testing.T, ch chan Event, typ string) Event {
+	t.Helper()
+	select {
+	case ev := <-ch:
+		if ev.Type != typ {
+			t.Fatalf("event type = %q, want %q", ev.Type, typ)
+		}
+		return ev
+	case <-time.After(2 * time.Second):
+		t.Fatalf("timed out waiting for event %q", typ)
+		return Event{}
 	}
 }


### PR DESCRIPTION
This pull request introduces support for passing and relaying opaque `properties` objects in job transfer channels, enhancing the flexibility of client-worker protocols. It also provides secure reference implementations for Python and .NET that demonstrate CMS/X.509 encrypted transfers using these new properties. Documentation and OpenAPI specs are updated to reflect these changes.

**API and Protocol Enhancements:**

* Added support for an optional `properties` object in `/api/jobs/{job_id}/payload` and `/api/jobs/{job_id}/result` requests, allowing clients to attach arbitrary metadata to transfer channels. These properties are relayed in job events and views but are not passed to the direct `/api/transfer` endpoint. [[1]](diffhunk://#diff-6c08e65eef0374988297d041bd50f87b385613a7e478c3812cb5312cc3e1f1e3R27-R29) [[2]](diffhunk://#diff-6c08e65eef0374988297d041bd50f87b385613a7e478c3812cb5312cc3e1f1e3R45-R47) [[3]](diffhunk://#diff-6c08e65eef0374988297d041bd50f87b385613a7e478c3812cb5312cc3e1f1e3R169-R171) [[4]](diffhunk://#diff-49e9fb6defacc8d1e1844008c78b8b85d89bfd91ac5e93388577d22b95f3bbc9R513-R517) [[5]](diffhunk://#diff-6dc658bfeb0ad4fa9c860855eb50fdb3e35ec8af5064c6b52c8ed01d312e555bR5-R6) [[6]](diffhunk://#diff-8d8d7d72c25d576f01082a15d13ece48a67708c2142eeb158fc8c76a88a1cd15L127-R128)
* Updated OpenAPI spec (`api/openapi.yaml`) and documentation (`doc/api/jobs.md`, `README.md`) to document the new `properties` field, including example payloads and responses. [[1]](diffhunk://#diff-6c08e65eef0374988297d041bd50f87b385613a7e478c3812cb5312cc3e1f1e3R27-R29) [[2]](diffhunk://#diff-6c08e65eef0374988297d041bd50f87b385613a7e478c3812cb5312cc3e1f1e3R45-R47) [[3]](diffhunk://#diff-6c08e65eef0374988297d041bd50f87b385613a7e478c3812cb5312cc3e1f1e3R169-R171) [[4]](diffhunk://#diff-49e9fb6defacc8d1e1844008c78b8b85d89bfd91ac5e93388577d22b95f3bbc9L323-R332) [[5]](diffhunk://#diff-49e9fb6defacc8d1e1844008c78b8b85d89bfd91ac5e93388577d22b95f3bbc9L333-R354) [[6]](diffhunk://#diff-49e9fb6defacc8d1e1844008c78b8b85d89bfd91ac5e93388577d22b95f3bbc9L418-R444) [[7]](diffhunk://#diff-49e9fb6defacc8d1e1844008c78b8b85d89bfd91ac5e93388577d22b95f3bbc9L428-R466) [[8]](diffhunk://#diff-49e9fb6defacc8d1e1844008c78b8b85d89bfd91ac5e93388577d22b95f3bbc9R513-R517) [[9]](diffhunk://#diff-8d8d7d72c25d576f01082a15d13ece48a67708c2142eeb158fc8c76a88a1cd15L127-R128) [[10]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L316-R320) [[11]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L330-R336)
* Example curl commands in `README.md` are updated to show how to include `properties` in payload/result requests. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L316-R320) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L330-R336)

**Secure Transfer Reference Implementations:**

* Added secure Python and .NET example clients and workers that demonstrate CMS/X.509 encrypted payload/result transfers using the new `properties` mechanism. These examples are referenced in the documentation and included in the solution files. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R269-R270) [[2]](diffhunk://#diff-49e9fb6defacc8d1e1844008c78b8b85d89bfd91ac5e93388577d22b95f3bbc9R538-R552) [[3]](diffhunk://#diff-593ca4fba4600afd2b30c41a1ebc1848b96ee0b8d177ae6b7f79f50af9206ae5R1-R163) [[4]](diffhunk://#diff-76ae13e2bcf1b7ea11eb8f66e680a8ff3207d68691827ced59fa5da515f417dbR1-R15) [[5]](diffhunk://#diff-8de17cb12848980747063eb9f1a5cc49c1dd04069b424124f8a75319aaf279a2R16-R19) [[6]](diffhunk://#diff-8de17cb12848980747063eb9f1a5cc49c1dd04069b424124f8a75319aaf279a2R42-R49) [[7]](diffhunk://#diff-8de17cb12848980747063eb9f1a5cc49c1dd04069b424124f8a75319aaf279a2R58-R59)

**Developer Experience Improvements:**

* Enhanced the minimal and secure example usage guides in the documentation, clarifying the distinction between direct transfer channels and job-level properties, and providing installation instructions for secure dependencies. [[1]](diffhunk://#diff-49e9fb6defacc8d1e1844008c78b8b85d89bfd91ac5e93388577d22b95f3bbc9R538-R552) [[2]](diffhunk://#diff-6dc658bfeb0ad4fa9c860855eb50fdb3e35ec8af5064c6b52c8ed01d312e555bR5-R6)
* Updated the basic .NET example client to print received `properties` for both payload and result events, aiding in debugging and demonstration.

These changes provide a foundation for advanced, protocol-agnostic client-worker interactions and enable secure, metadata-rich transfer scenarios.