### PR TITLE
Improvements to job monitoring

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,4 @@ desktop/windows/**/obj/
 /nfrx-asr
 **/__pycache__/*
 **/obj
+**/bin

--- a/README.md
+++ b/README.md
@@ -544,8 +544,10 @@ The Windows service runs `nfrx-llm` with the `--reconnect` flag and shuts down i
   - per-worker totals (processed, inflight, failures, avg duration)
   - per-model availability (how many workers support each model)
   - MCP relay clients and active sessions
+  - jobs backlog, active claimers, oldest queued job age, and recent job states
+  - since-boot jobs aggregates such as completed/failed/canceled counts and average queue wait/end-to-end time
   - versions/build info for server & workers
-- **Web state page** (`/state`): lightweight dashboard powered by the state stream
+- **Web state page** (`/state`): lightweight dashboard powered by the state stream, including top-level jobs backlog and worker activity when the jobs API is in use
 - **Logs**:
   - `Info` — lifecycle details like connections, disconnections, draining, and job dispatch/completion.
   - `Warn` — expected failures such as missing models or no available workers.

--- a/doc/api/jobs.md
+++ b/doc/api/jobs.md
@@ -197,6 +197,9 @@ Response:
 {"status":"canceled"}
 ```
 
+If the job is already terminal, cancel remains a successful no-op and returns the
+current terminal status (`completed`, `failed`, or `canceled`).
+
 curl:
 
 ```bash

--- a/doc/server-endpoints.md
+++ b/doc/server-endpoints.md
@@ -36,6 +36,7 @@ JSON envelope shape:
 - The dashboard loads plugin-specific HTML fragments via `/api/state/view/{id}.html` and renders using the streamed envelope. If a plugin provides no view, it will not have a dedicated section in the dashboard.
 
 Notes:
+- The jobs state includes current queue/running/transfer counts, recent worker claim activity, oldest queued/inflight job age, and since-boot aggregates such as completed/failed/canceled counts and average queue/service/end-to-end timing. Queue-wait averages include jobs that were canceled before claim so queued backlog is not underreported.
 - The LLM plugin’s state includes server status (`ready`, `not_ready`, `draining`), workers, models, and aggregates. Other plugins (e.g., MCP) expose their own structures.
 
 ## Inference API

--- a/server/internal/api/state_test.go
+++ b/server/internal/api/state_test.go
@@ -5,13 +5,16 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/go-chi/chi/v5"
 
 	llmctrl "github.com/gaspardpetit/nfrx/sdk/base/worker"
+	"github.com/gaspardpetit/nfrx/server/internal/jobs"
 	"github.com/gaspardpetit/nfrx/server/internal/serverstate"
+	"github.com/gaspardpetit/nfrx/server/internal/transfer"
 )
 
 func TestGetState(t *testing.T) {
@@ -89,5 +92,85 @@ func TestGetStateStream(t *testing.T) {
 	}
 	if line == "" {
 		t.Fatalf("empty stream")
+	}
+}
+
+func TestGetStateIncludesJobsSummaryAggregates(t *testing.T) {
+	jobReg := jobs.NewRegistry(transfer.NewRegistry(0), 0, 0)
+	sr := serverstate.NewRegistry()
+	sr.Add(serverstate.Element{ID: "jobs", Data: func() any { return jobReg.StateSnapshot() }})
+	h := &StateHandler{State: sr}
+
+	r := chi.NewRouter()
+	r.Post("/api/jobs", jobReg.HandleCreateJob)
+	r.Post("/api/jobs/claim", jobReg.HandleClaimJob)
+	r.Post("/api/jobs/{job_id}/status", jobReg.HandleStatusUpdate)
+	r.Get("/api/state", h.GetState)
+	srv := httptest.NewServer(r)
+	defer srv.Close()
+
+	createReq, _ := http.NewRequest(http.MethodPost, srv.URL+"/api/jobs", strings.NewReader(`{"type":"asr.transcribe"}`))
+	createReq.Header.Set("Content-Type", "application/json")
+	createResp, err := http.DefaultClient.Do(createReq)
+	if err != nil {
+		t.Fatalf("create job: %v", err)
+	}
+	defer createResp.Body.Close()
+	var created struct {
+		JobID string `json:"job_id"`
+	}
+	if err := json.NewDecoder(createResp.Body).Decode(&created); err != nil {
+		t.Fatalf("decode create response: %v", err)
+	}
+
+	claimReq, _ := http.NewRequest(http.MethodPost, srv.URL+"/api/jobs/claim", strings.NewReader(`{"worker_id":"worker-1","worker_group":"asr","max_wait_seconds":0}`))
+	claimReq.Header.Set("Content-Type", "application/json")
+	claimResp, err := http.DefaultClient.Do(claimReq)
+	if err != nil {
+		t.Fatalf("claim job: %v", err)
+	}
+	_ = claimResp.Body.Close()
+	if claimResp.StatusCode != http.StatusOK {
+		t.Fatalf("claim status = %d, want %d", claimResp.StatusCode, http.StatusOK)
+	}
+
+	statusReq, _ := http.NewRequest(http.MethodPost, srv.URL+"/api/jobs/"+created.JobID+"/status", strings.NewReader(`{"state":"completed"}`))
+	statusReq.Header.Set("Content-Type", "application/json")
+	statusResp, err := http.DefaultClient.Do(statusReq)
+	if err != nil {
+		t.Fatalf("update status: %v", err)
+	}
+	_ = statusResp.Body.Close()
+	if statusResp.StatusCode != http.StatusOK {
+		t.Fatalf("status update code = %d, want %d", statusResp.StatusCode, http.StatusOK)
+	}
+
+	resp, err := http.Get(srv.URL + "/api/state")
+	if err != nil {
+		t.Fatalf("get state: %v", err)
+	}
+	defer resp.Body.Close()
+
+	var env PluginsEnvelope
+	if err := json.NewDecoder(resp.Body).Decode(&env); err != nil {
+		t.Fatalf("decode env: %v", err)
+	}
+	raw, ok := env.Plugins["jobs"]
+	if !ok {
+		t.Fatalf("missing jobs plugin state")
+	}
+	b, _ := json.Marshal(raw)
+	var state jobs.StateView
+	if err := json.Unmarshal(b, &state); err != nil {
+		t.Fatalf("decode jobs state: %v", err)
+	}
+	if state.Summary.CompletedJobs != 1 {
+		t.Fatalf("completed_jobs = %d, want 1", state.Summary.CompletedJobs)
+	}
+	if state.Summary.AvgQueueWaitMS < 0 || state.Summary.AvgEndToEndMS < 0 {
+		t.Fatalf("expected non-negative timing aggregates: %+v", state.Summary)
+	}
+	if state.Summary.LastCompletedAt == "" {
+		t.Fatalf("expected last_completed_at to be set")
 	}
 }

--- a/server/internal/jobs/registry.go
+++ b/server/internal/jobs/registry.go
@@ -43,6 +43,7 @@ type Registry struct {
 	clientTTL     time.Duration
 	clientTimers  map[string]*time.Timer
 	workers       map[string]*WorkerActivity
+	stats         jobStats
 }
 
 type Job struct {
@@ -59,6 +60,7 @@ type Job struct {
 	Payloads           map[string]*TransferInfo
 	Results            map[string]*TransferInfo
 	CreatedAt          time.Time
+	ClaimedAt          time.Time
 	UpdatedAt          time.Time
 }
 
@@ -77,6 +79,22 @@ type WorkerActivity struct {
 	LastJobID     string
 	Types         []string
 	StreamCount   int
+}
+
+type jobStats struct {
+	CompletedJobs uint64
+	FailedJobs    uint64
+	CanceledJobs  uint64
+
+	QueueWaitTotal   time.Duration
+	QueueWaitSamples uint64
+	ServiceTotal     time.Duration
+	ServiceSamples   uint64
+	EndToEndTotal    time.Duration
+	EndToEndSamples  uint64
+	LastCompletedAt  time.Time
+	LastFailedAt     time.Time
+	LastCanceledAt   time.Time
 }
 
 type TransferInfo struct {
@@ -151,15 +169,26 @@ type WorkerActivityView struct {
 }
 
 type JobsSummary struct {
-	TotalJobs         int `json:"total_jobs"`
-	QueuedJobs        int `json:"queued_jobs"`
-	ClaimedJobs       int `json:"claimed_jobs"`
-	RunningJobs       int `json:"running_jobs"`
-	AwaitingTransfers int `json:"awaiting_transfers"`
-	TerminalJobs      int `json:"terminal_jobs"`
-	ActiveWorkers     int `json:"active_workers"`
-	RecentWorkers     int `json:"recent_workers"`
-	StreamingWorkers  int `json:"streaming_workers"`
+	TotalJobs             int    `json:"total_jobs"`
+	QueuedJobs            int    `json:"queued_jobs"`
+	ClaimedJobs           int    `json:"claimed_jobs"`
+	RunningJobs           int    `json:"running_jobs"`
+	AwaitingTransfers     int    `json:"awaiting_transfers"`
+	TerminalJobs          int    `json:"terminal_jobs"`
+	ActiveWorkers         int    `json:"active_workers"`
+	RecentWorkers         int    `json:"recent_workers"`
+	StreamingWorkers      int    `json:"streaming_workers"`
+	CompletedJobs         uint64 `json:"completed_jobs"`
+	FailedJobs            uint64 `json:"failed_jobs"`
+	CanceledJobs          uint64 `json:"canceled_jobs"`
+	OldestQueuedSeconds   int64  `json:"oldest_queued_seconds"`
+	OldestInflightSeconds int64  `json:"oldest_inflight_seconds"`
+	AvgQueueWaitMS        int64  `json:"avg_queue_wait_ms"`
+	AvgServiceMS          int64  `json:"avg_service_ms"`
+	AvgEndToEndMS         int64  `json:"avg_end_to_end_ms"`
+	LastCompletedAt       string `json:"last_completed_at,omitempty"`
+	LastFailedAt          string `json:"last_failed_at,omitempty"`
+	LastCanceledAt        string `json:"last_canceled_at,omitempty"`
 }
 
 type StateView struct {
@@ -324,6 +353,7 @@ func isTerminalStatus(status string) bool {
 func (r *Registry) HandleCancelJob(w http.ResponseWriter, req *http.Request) {
 	jobID := chi.URLParam(req, "job_id")
 	var view JobView
+	var status string
 	r.mu.Lock()
 	job := r.jobs[jobID]
 	if job == nil {
@@ -331,16 +361,21 @@ func (r *Registry) HandleCancelJob(w http.ResponseWriter, req *http.Request) {
 		writeJSON(w, http.StatusNotFound, map[string]any{"error": "not_found"})
 		return
 	}
-	if job.Status == StatusQueued {
-		r.removeFromQueue(jobID)
+	if isTerminalStatus(job.Status) {
+		status = job.Status
+		view = r.viewLocked(job)
+	} else {
+		if job.Status == StatusQueued {
+			r.removeFromQueue(jobID)
+		}
+		r.setJobStatusLocked(job, StatusCanceled, time.Now())
+		status = job.Status
+		view = r.viewLocked(job)
 	}
-	job.Status = StatusCanceled
-	job.UpdatedAt = time.Now()
-	view = r.viewLocked(job)
 	r.mu.Unlock()
 	r.clearClientTimer(jobID)
 	r.publish(jobID, Event{Type: "status", Data: view})
-	writeJSON(w, http.StatusOK, map[string]any{"status": "canceled"})
+	writeJSON(w, http.StatusOK, map[string]any{"status": status})
 }
 
 func (r *Registry) HandleClaimJob(w http.ResponseWriter, req *http.Request) {
@@ -466,8 +501,7 @@ func (r *Registry) HandlePayloadRequest(w http.ResponseWriter, req *http.Request
 		job.Payloads = make(map[string]*TransferInfo)
 	}
 	job.Payloads[key] = info
-	job.Status = StatusAwaitingPayload
-	job.UpdatedAt = time.Now()
+	r.setJobStatusLocked(job, StatusAwaitingPayload, time.Now())
 	view = r.viewLocked(job)
 	r.mu.Unlock()
 
@@ -527,8 +561,7 @@ func (r *Registry) HandleResultRequest(w http.ResponseWriter, req *http.Request)
 		job.Results = make(map[string]*TransferInfo)
 	}
 	job.Results[key] = info
-	job.Status = StatusAwaitingResult
-	job.UpdatedAt = time.Now()
+	r.setJobStatusLocked(job, StatusAwaitingResult, time.Now())
 	view = r.viewLocked(job)
 	r.mu.Unlock()
 
@@ -578,14 +611,13 @@ func (r *Registry) HandleStatusUpdate(w http.ResponseWriter, req *http.Request) 
 		writeJSON(w, http.StatusConflict, map[string]any{"error": "invalid_state"})
 		return
 	}
-	job.Status = state
+	r.setJobStatusLocked(job, state, time.Now())
 	if body.Progress != nil {
 		job.Progress = body.Progress
 	}
 	if body.Error != nil {
 		job.Error = body.Error
 	}
-	job.UpdatedAt = time.Now()
 	view = r.viewLocked(job)
 	r.mu.Unlock()
 
@@ -611,10 +643,9 @@ func (r *Registry) claimNext(types []string, workerID, workerGroup string) *Job 
 			continue
 		}
 		r.queue = append(r.queue[:i], r.queue[i+1:]...)
-		job.Status = StatusClaimed
+		r.setJobStatusLocked(job, StatusClaimed, time.Now())
 		job.ClaimedWorkerID = workerID
 		job.ClaimedWorkerGroup = workerGroup
-		job.UpdatedAt = time.Now()
 		r.publishLocked(job.ID, Event{Type: "status", Data: r.viewLocked(job)})
 		return job
 	}
@@ -747,9 +778,8 @@ func (r *Registry) expireJobIfIdle(jobID string) {
 	if job.Status == StatusQueued {
 		r.removeFromQueue(jobID)
 	}
-	job.Status = StatusCanceled
+	r.setJobStatusLocked(job, StatusCanceled, time.Now())
 	job.Error = &JobError{Code: "client_inactive", Message: "client inactive"}
-	job.UpdatedAt = time.Now()
 	view := r.viewLocked(job)
 	r.mu.Unlock()
 
@@ -827,6 +857,87 @@ func (r *Registry) claimResponse(job *Job) map[string]any {
 	}
 }
 
+func (r *Registry) setJobStatusLocked(job *Job, status string, now time.Time) {
+	if job == nil {
+		return
+	}
+	prev := job.Status
+	if status == StatusClaimed && job.ClaimedAt.IsZero() {
+		job.ClaimedAt = now
+	}
+	if !isTerminalStatus(prev) && isTerminalStatus(status) {
+		r.recordTerminalLocked(job, status, now)
+	}
+	job.Status = status
+	job.UpdatedAt = now
+}
+
+func (r *Registry) recordTerminalLocked(job *Job, status string, now time.Time) {
+	if job == nil {
+		return
+	}
+	switch status {
+	case StatusCompleted:
+		r.stats.CompletedJobs++
+		r.stats.LastCompletedAt = now
+	case StatusFailed:
+		r.stats.FailedJobs++
+		r.stats.LastFailedAt = now
+	case StatusCanceled:
+		r.stats.CanceledJobs++
+		r.stats.LastCanceledAt = now
+	default:
+		return
+	}
+	if !job.CreatedAt.IsZero() && !now.Before(job.CreatedAt) {
+		r.stats.EndToEndTotal += now.Sub(job.CreatedAt)
+		r.stats.EndToEndSamples++
+	}
+	if !job.ClaimedAt.IsZero() && !now.Before(job.ClaimedAt) {
+		r.stats.QueueWaitTotal += job.ClaimedAt.Sub(job.CreatedAt)
+		r.stats.QueueWaitSamples++
+		r.stats.ServiceTotal += now.Sub(job.ClaimedAt)
+		r.stats.ServiceSamples++
+	} else if status == StatusCanceled && !job.CreatedAt.IsZero() && !now.Before(job.CreatedAt) {
+		r.stats.QueueWaitTotal += now.Sub(job.CreatedAt)
+		r.stats.QueueWaitSamples++
+	}
+}
+
+func formatOptionalTime(ts time.Time) string {
+	if ts.IsZero() {
+		return ""
+	}
+	return ts.UTC().Format(time.RFC3339)
+}
+
+func averageDurationMS(total time.Duration, count uint64) int64 {
+	if count == 0 {
+		return 0
+	}
+	return total.Milliseconds() / int64(count)
+}
+
+func inflightStart(job *Job) time.Time {
+	if job == nil {
+		return time.Time{}
+	}
+	if !job.ClaimedAt.IsZero() {
+		return job.ClaimedAt
+	}
+	if !job.UpdatedAt.IsZero() {
+		return job.UpdatedAt
+	}
+	return job.CreatedAt
+}
+
+func ageSeconds(now, ts time.Time) int64 {
+	if ts.IsZero() || now.Before(ts) {
+		return 0
+	}
+	return int64(now.Sub(ts) / time.Second)
+}
+
 func (r *Registry) StateSnapshot() StateView {
 	r.mu.Lock()
 	defer r.mu.Unlock()
@@ -838,6 +949,15 @@ func (r *Registry) StateSnapshot() StateView {
 		Workers: make([]WorkerActivityView, 0, len(r.workers)),
 		Jobs:    make([]JobView, 0, minInt(len(r.jobs), maxStateJobs)),
 	}
+	state.Summary.CompletedJobs = r.stats.CompletedJobs
+	state.Summary.FailedJobs = r.stats.FailedJobs
+	state.Summary.CanceledJobs = r.stats.CanceledJobs
+	state.Summary.AvgQueueWaitMS = averageDurationMS(r.stats.QueueWaitTotal, r.stats.QueueWaitSamples)
+	state.Summary.AvgServiceMS = averageDurationMS(r.stats.ServiceTotal, r.stats.ServiceSamples)
+	state.Summary.AvgEndToEndMS = averageDurationMS(r.stats.EndToEndTotal, r.stats.EndToEndSamples)
+	state.Summary.LastCompletedAt = formatOptionalTime(r.stats.LastCompletedAt)
+	state.Summary.LastFailedAt = formatOptionalTime(r.stats.LastFailedAt)
+	state.Summary.LastCanceledAt = formatOptionalTime(r.stats.LastCanceledAt)
 	workerKeys := make([]string, 0, len(r.workers))
 	for key := range r.workers {
 		workerKeys = append(workerKeys, key)
@@ -889,12 +1009,24 @@ func (r *Registry) StateSnapshot() StateView {
 		switch job.Status {
 		case StatusQueued:
 			state.Summary.QueuedJobs++
+			if age := ageSeconds(now, job.CreatedAt); age > state.Summary.OldestQueuedSeconds {
+				state.Summary.OldestQueuedSeconds = age
+			}
 		case StatusClaimed:
 			state.Summary.ClaimedJobs++
+			if age := ageSeconds(now, inflightStart(job)); age > state.Summary.OldestInflightSeconds {
+				state.Summary.OldestInflightSeconds = age
+			}
 		case StatusRunning:
 			state.Summary.RunningJobs++
+			if age := ageSeconds(now, inflightStart(job)); age > state.Summary.OldestInflightSeconds {
+				state.Summary.OldestInflightSeconds = age
+			}
 		case StatusAwaitingPayload, StatusAwaitingResult:
 			state.Summary.AwaitingTransfers++
+			if age := ageSeconds(now, inflightStart(job)); age > state.Summary.OldestInflightSeconds {
+				state.Summary.OldestInflightSeconds = age
+			}
 		case StatusCompleted, StatusFailed, StatusCanceled:
 			state.Summary.TerminalJobs++
 		}
@@ -965,6 +1097,23 @@ func (r *Registry) StateHTML() string {
       if (d < 3600) return Math.floor(d/60) + 'm ago';
       return Math.floor(d/3600) + 'h ago';
     }
+    function secs(v){
+      v = Number(v || 0);
+      if (!isFinite(v) || v <= 0) return '0s';
+      if (v < 60) return Math.round(v) + 's';
+      if (v < 3600) return Math.floor(v/60) + 'm';
+      return Math.floor(v/3600) + 'h';
+    }
+    function dur(ms){
+      ms = Number(ms || 0);
+      if (!isFinite(ms) || ms <= 0) return '0ms';
+      if (ms < 1000) return Math.round(ms) + 'ms';
+      var s = ms / 1000;
+      if (s < 60) return s.toFixed(s < 10 ? 1 : 0) + 's';
+      var m = s / 60;
+      if (m < 60) return m.toFixed(m < 10 ? 1 : 0) + 'm';
+      return (m / 60).toFixed(1) + 'h';
+    }
     function statusTone(s){
       s = String(s || '').toLowerCase();
       if (s === 'running' || s === 'claimed') return 'live';
@@ -980,11 +1129,14 @@ func (r *Registry) StateHTML() string {
       if (summaryHost) {
         summaryHost.innerHTML = [
           ['Active Workers', summary.active_workers || 0, 'Seen in the last minute'],
-          ['Streaming', summary.streaming_workers || 0, 'Open worker SSE streams'],
-          ['Queued', summary.queued_jobs || 0, 'Waiting for a compatible worker'],
+          ['Queued Users', summary.queued_jobs || 0, 'Clients waiting for a worker claim'],
+          ['Oldest Queue', secs(summary.oldest_queued_seconds), 'Age of the oldest queued job'],
           ['Running', summary.running_jobs || 0, 'Currently processing'],
           ['Awaiting Transfer', summary.awaiting_transfers || 0, 'Payload or result handoff'],
-          ['Terminal', summary.terminal_jobs || 0, 'Completed, failed, or canceled']
+          ['Completed', summary.completed_jobs || 0, 'Successful jobs since boot'],
+          ['Failed', summary.failed_jobs || 0, 'Failed jobs since boot'],
+          ['Avg Queue Wait', dur(summary.avg_queue_wait_ms), 'Average claim delay since boot'],
+          ['Avg End-to-End', dur(summary.avg_end_to_end_ms), 'Average created-to-terminal time']
         ].map(function(card){
           return '<article class="jobs-card"><div class="jobs-k">'+card[0]+'</div><div class="jobs-v">'+card[1]+'</div><div class="jobs-sub">'+card[2]+'</div></article>';
         }).join('');
@@ -1010,7 +1162,7 @@ func (r *Registry) StateHTML() string {
       var jobsHost = container.querySelector('.jobs-jobs');
       if (jobsHost) {
         if (!jobs.length) {
-          jobsHost.innerHTML = '<div class="jobs-empty">No jobs recorded.</div>';
+          jobsHost.innerHTML = '<div class="jobs-empty">No jobs recorded yet.</div>';
         } else {
           jobsHost.innerHTML = '<table class="jobs-table"><thead><tr><th>Status</th><th>Type</th><th>Affinity</th><th>Claimed By</th><th>Updated</th></tr></thead><tbody>' +
             jobs.map(function(j){

--- a/server/internal/jobs/registry_test.go
+++ b/server/internal/jobs/registry_test.go
@@ -515,6 +515,154 @@ func TestHandlePayloadRequestOmitsPropertiesWhenUnset(t *testing.T) {
 	}
 }
 
+func TestHandleCancelJobIsIdempotentForTerminalJobs(t *testing.T) {
+	reg := NewRegistry(transfer.NewRegistry(0), 0, 0)
+	job := &Job{
+		ID:        "job-completed",
+		Type:      "test",
+		Status:    StatusCompleted,
+		CreatedAt: time.Now().Add(-time.Minute),
+		UpdatedAt: time.Now().Add(-30 * time.Second),
+	}
+	reg.mu.Lock()
+	reg.jobs[job.ID] = job
+	reg.mu.Unlock()
+
+	router := chi.NewRouter()
+	reg.RegisterClientRoutes(router)
+
+	req := httptest.NewRequest(http.MethodPost, "/jobs/"+job.ID+"/cancel", nil)
+	resp := httptest.NewRecorder()
+	router.ServeHTTP(resp, req)
+	if resp.Code != http.StatusOK {
+		t.Fatalf("cancel status = %d, want %d", resp.Code, http.StatusOK)
+	}
+
+	var body map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode cancel response: %v", err)
+	}
+	if body["status"] != StatusCompleted {
+		t.Fatalf("cancel response status = %v, want %q", body["status"], StatusCompleted)
+	}
+
+	reg.mu.Lock()
+	defer reg.mu.Unlock()
+	if reg.jobs[job.ID].Status != StatusCompleted {
+		t.Fatalf("job status = %q, want %q", reg.jobs[job.ID].Status, StatusCompleted)
+	}
+}
+
+func TestStateSnapshotTracksLifetimeOutcomesAndDurations(t *testing.T) {
+	reg := NewRegistry(transfer.NewRegistry(0), 0, 0)
+	base := time.Now().Add(-time.Hour)
+
+	jobCompleted := &Job{ID: "job-completed", Type: "test", Status: StatusQueued, CreatedAt: base, UpdatedAt: base}
+	jobFailed := &Job{ID: "job-failed", Type: "test", Status: StatusQueued, CreatedAt: base.Add(10 * time.Second), UpdatedAt: base.Add(10 * time.Second)}
+	jobCanceled := &Job{ID: "job-canceled", Type: "test", Status: StatusQueued, CreatedAt: base.Add(20 * time.Second), UpdatedAt: base.Add(20 * time.Second)}
+
+	reg.mu.Lock()
+	reg.jobs[jobCompleted.ID] = jobCompleted
+	reg.jobs[jobFailed.ID] = jobFailed
+	reg.jobs[jobCanceled.ID] = jobCanceled
+	reg.setJobStatusLocked(jobCompleted, StatusClaimed, base.Add(5*time.Second))
+	reg.setJobStatusLocked(jobCompleted, StatusCompleted, base.Add(20*time.Second))
+	reg.setJobStatusLocked(jobFailed, StatusClaimed, base.Add(20*time.Second))
+	reg.setJobStatusLocked(jobFailed, StatusRunning, base.Add(25*time.Second))
+	reg.setJobStatusLocked(jobFailed, StatusFailed, base.Add(40*time.Second))
+	reg.setJobStatusLocked(jobCanceled, StatusCanceled, base.Add(65*time.Second))
+	reg.mu.Unlock()
+
+	state := reg.StateSnapshot()
+	if state.Summary.CompletedJobs != 1 {
+		t.Fatalf("completed_jobs = %d, want 1", state.Summary.CompletedJobs)
+	}
+	if state.Summary.FailedJobs != 1 {
+		t.Fatalf("failed_jobs = %d, want 1", state.Summary.FailedJobs)
+	}
+	if state.Summary.CanceledJobs != 1 {
+		t.Fatalf("canceled_jobs = %d, want 1", state.Summary.CanceledJobs)
+	}
+	if state.Summary.AvgQueueWaitMS != 20000 {
+		t.Fatalf("avg_queue_wait_ms = %d, want 20000", state.Summary.AvgQueueWaitMS)
+	}
+	if state.Summary.AvgServiceMS != 17500 {
+		t.Fatalf("avg_service_ms = %d, want 17500", state.Summary.AvgServiceMS)
+	}
+	if state.Summary.AvgEndToEndMS != 31666 {
+		t.Fatalf("avg_end_to_end_ms = %d, want 31666", state.Summary.AvgEndToEndMS)
+	}
+	if state.Summary.LastCompletedAt != base.Add(20*time.Second).UTC().Format(time.RFC3339) {
+		t.Fatalf("last_completed_at = %q", state.Summary.LastCompletedAt)
+	}
+	if state.Summary.LastFailedAt != base.Add(40*time.Second).UTC().Format(time.RFC3339) {
+		t.Fatalf("last_failed_at = %q", state.Summary.LastFailedAt)
+	}
+	if state.Summary.LastCanceledAt != base.Add(65*time.Second).UTC().Format(time.RFC3339) {
+		t.Fatalf("last_canceled_at = %q", state.Summary.LastCanceledAt)
+	}
+}
+
+func TestStateSnapshotDoesNotDoubleCountTerminalTransitions(t *testing.T) {
+	reg := NewRegistry(transfer.NewRegistry(0), 0, 0)
+	base := time.Now().Add(-time.Minute)
+	job := &Job{ID: "job-1", Type: "test", Status: StatusQueued, CreatedAt: base, UpdatedAt: base}
+
+	reg.mu.Lock()
+	reg.jobs[job.ID] = job
+	reg.setJobStatusLocked(job, StatusClaimed, base.Add(5*time.Second))
+	reg.setJobStatusLocked(job, StatusRunning, base.Add(10*time.Second))
+	reg.setJobStatusLocked(job, StatusCompleted, base.Add(20*time.Second))
+	reg.setJobStatusLocked(job, StatusCompleted, base.Add(25*time.Second))
+	reg.mu.Unlock()
+
+	state := reg.StateSnapshot()
+	if state.Summary.CompletedJobs != 1 {
+		t.Fatalf("completed_jobs = %d, want 1", state.Summary.CompletedJobs)
+	}
+	if state.Summary.FailedJobs != 0 || state.Summary.CanceledJobs != 0 {
+		t.Fatalf("unexpected terminal counts: %+v", state.Summary)
+	}
+	if state.Summary.AvgQueueWaitMS != 5000 {
+		t.Fatalf("avg_queue_wait_ms = %d, want 5000", state.Summary.AvgQueueWaitMS)
+	}
+	if state.Summary.AvgServiceMS != 15000 {
+		t.Fatalf("avg_service_ms = %d, want 15000", state.Summary.AvgServiceMS)
+	}
+}
+
+func TestStateSnapshotTracksOldestQueueAndInflightAge(t *testing.T) {
+	reg := NewRegistry(transfer.NewRegistry(0), 0, 0)
+	now := time.Now()
+
+	reg.mu.Lock()
+	reg.jobs["job-queued"] = &Job{
+		ID:        "job-queued",
+		Type:      "test",
+		Status:    StatusQueued,
+		CreatedAt: now.Add(-2 * time.Minute),
+		UpdatedAt: now.Add(-2 * time.Minute),
+	}
+	reg.jobs["job-running"] = &Job{
+		ID:        "job-running",
+		Type:      "test",
+		Status:    StatusRunning,
+		CreatedAt: now.Add(-3 * time.Minute),
+		ClaimedAt: now.Add(-90 * time.Second),
+		UpdatedAt: now.Add(-30 * time.Second),
+	}
+	reg.queue = []string{"job-queued"}
+	reg.mu.Unlock()
+
+	state := reg.StateSnapshot()
+	if state.Summary.OldestQueuedSeconds < 119 || state.Summary.OldestQueuedSeconds > 121 {
+		t.Fatalf("oldest_queued_seconds = %d, want about 120", state.Summary.OldestQueuedSeconds)
+	}
+	if state.Summary.OldestInflightSeconds < 89 || state.Summary.OldestInflightSeconds > 91 {
+		t.Fatalf("oldest_inflight_seconds = %d, want about 90", state.Summary.OldestInflightSeconds)
+	}
+}
+
 func expectEventType(t *testing.T, ch chan Event, typ string) Event {
 	t.Helper()
 	select {

--- a/server/internal/server/state.html
+++ b/server/internal/server/state.html
@@ -628,6 +628,9 @@ function formatRelativeTime(ts) {
 }
 
 function pluginDisplayName(id) {
+  if (id === 'jobs') {
+    return 'Jobs';
+  }
   var d = descriptors[id] || {};
   return d.name || id;
 }
@@ -637,6 +640,9 @@ function shouldShowPluginID(id) {
 }
 
 function pluginSummaryText(id) {
+  if (id === 'jobs') {
+    return 'Queue-backed jobs with worker claim activity, backlog age, and since-boot outcome timing.';
+  }
   var d = descriptors[id] || {};
   return d.summary || '';
 }
@@ -755,7 +761,7 @@ function pluginMetaParts(id, pluginState) {
   if (id === 'jobs') {
     var summary = (pluginState && pluginState.summary) || {};
     return {
-      text: (summary.active_workers || 0) + ' active | queued ' + (summary.queued_jobs || 0) + ' | running ' + (summary.running_jobs || 0)
+      text: (summary.active_workers || 0) + ' active | queued ' + (summary.queued_jobs || 0) + ' | running ' + (summary.running_jobs || 0) + ' | completed ' + (summary.completed_jobs || 0)
     };
   }
   var workers = pluginWorkerCount(pluginState);
@@ -822,8 +828,20 @@ function updateSummaryCards(plugins) {
   var inflightTotal = 0;
   var queueTotal = 0;
   var completedTotal = 0;
+  var failedTotal = 0;
+  var canceledTotal = 0;
   pluginIds.forEach(function(id) {
     var pluginState = plugins[id] || {};
+    if (id === 'jobs') {
+      var summary = pluginState.summary || {};
+      workerTotal += summary.active_workers || 0;
+      inflightTotal += (summary.claimed_jobs || 0) + (summary.running_jobs || 0) + (summary.awaiting_transfers || 0);
+      queueTotal += summary.queued_jobs || 0;
+      completedTotal += summary.completed_jobs || 0;
+      failedTotal += summary.failed_jobs || 0;
+      canceledTotal += summary.canceled_jobs || 0;
+      return;
+    }
     var server = pluginState.server || {};
     var workers = pluginState.workers || [];
     workerTotal += workers.length;
@@ -837,11 +855,13 @@ function updateSummaryCards(plugins) {
   document.getElementById('stat-plugins').textContent = String(pluginIds.length);
   document.getElementById('stat-plugins-note').textContent = pluginIds.length ? pluginIds.map(pluginDisplayName).join(', ') : 'No plugin state loaded yet.';
   document.getElementById('stat-workers').textContent = String(workerTotal);
-  document.getElementById('stat-workers-note').textContent = workerTotal ? 'Connected workers across all plugins.' : 'No active workers reported.';
+  document.getElementById('stat-workers-note').textContent = workerTotal ? 'Connected workers plus recent jobs claimers.' : 'No active workers reported.';
   document.getElementById('stat-inflight').textContent = String(inflightTotal + queueTotal);
-  document.getElementById('stat-inflight-note').textContent = queueTotal ? 'Includes ' + queueTotal + ' queued request' + (queueTotal === 1 ? '' : 's') + '.' : 'No queued requests in state.';
+  document.getElementById('stat-inflight-note').textContent = queueTotal ? 'Includes ' + queueTotal + ' queued request' + (queueTotal === 1 ? '' : 's') + ' or waiting job' + (queueTotal === 1 ? '' : 's') + '.' : 'No queued requests or jobs in state.';
   document.getElementById('stat-completed').textContent = String(completedTotal);
-  document.getElementById('stat-completed-note').textContent = 'Server-reported completed jobs across plugins.';
+  document.getElementById('stat-completed-note').textContent = failedTotal || canceledTotal
+    ? 'Completed jobs across plugins. Failed: ' + failedTotal + ', canceled: ' + canceledTotal + '.'
+    : 'Server-reported completed jobs across plugins.';
 }
 
 function update(envelope) {


### PR DESCRIPTION
This pull request introduces comprehensive job lifecycle and performance tracking to the jobs API and its state reporting. The main focus is on tracking job statistics (completed, failed, canceled counts), queue and processing timing metrics, and exposing these aggregates in both the API and the web dashboard. Several internal refactorings were made to ensure accurate and consistent state updates, and new tests were added to verify the new summary data.

**Jobs state tracking and reporting:**

* Added detailed job lifecycle statistics to `JobsSummary` and `StateView`, including counts of completed, failed, and canceled jobs, as well as timing aggregates for queue wait, service, and end-to-end durations. Also included are fields for the age of the oldest queued/inflight job and timestamps for the last completed/failed/canceled job. (`server/internal/jobs/registry.go`, [[1]](diffhunk://#diff-e7767f8e58b0970bed61959fe271e5b6ae55cdd916877716b9952346767cc5baR84-R99) [[2]](diffhunk://#diff-e7767f8e58b0970bed61959fe271e5b6ae55cdd916877716b9952346767cc5baR181-R191) [[3]](diffhunk://#diff-e7767f8e58b0970bed61959fe271e5b6ae55cdd916877716b9952346767cc5baR952-R960) [[4]](diffhunk://#diff-e7767f8e58b0970bed61959fe271e5b6ae55cdd916877716b9952346767cc5baR1012-R1029)
* Refactored job status transitions to use a centralized `setJobStatusLocked` method, ensuring all state changes consistently update statistics and timestamps. (`server/internal/jobs/registry.go`, [[1]](diffhunk://#diff-e7767f8e58b0970bed61959fe271e5b6ae55cdd916877716b9952346767cc5baR860-R940) [[2]](diffhunk://#diff-e7767f8e58b0970bed61959fe271e5b6ae55cdd916877716b9952346767cc5baR356-R378) [[3]](diffhunk://#diff-e7767f8e58b0970bed61959fe271e5b6ae55cdd916877716b9952346767cc5baL469-R504) [[4]](diffhunk://#diff-e7767f8e58b0970bed61959fe271e5b6ae55cdd916877716b9952346767cc5baL530-R564) [[5]](diffhunk://#diff-e7767f8e58b0970bed61959fe271e5b6ae55cdd916877716b9952346767cc5baL581-L588) [[6]](diffhunk://#diff-e7767f8e58b0970bed61959fe271e5b6ae55cdd916877716b9952346767cc5baL614-L617) [[7]](diffhunk://#diff-e7767f8e58b0970bed61959fe271e5b6ae55cdd916877716b9952346767cc5baL750-L752)

**API and documentation updates:**

* Updated the `/api/jobs/{job_id}/cancel` endpoint to return the current terminal status if the job is already terminal, making cancel a safe no-op in such cases. (`server/internal/jobs/registry.go`, [[1]](diffhunk://#diff-e7767f8e58b0970bed61959fe271e5b6ae55cdd916877716b9952346767cc5baR356-R378); `doc/api/jobs.md`, [[2]](diffhunk://#diff-49e9fb6defacc8d1e1844008c78b8b85d89bfd91ac5e93388577d22b95f3bbc9R200-R202)
* Expanded API and dashboard documentation to describe the new job state aggregates and timing metrics now available via the state API and web dashboard. (`README.md`, [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R547-R550); `doc/server-endpoints.md`, [[2]](diffhunk://#diff-8d8d7d72c25d576f01082a15d13ece48a67708c2142eeb158fc8c76a88a1cd15R39)

**Dashboard enhancements:**

* Improved the `/state` web dashboard to display the new job statistics and timing metrics, including cards for completed/failed jobs, average queue wait, and end-to-end times. Enhanced formatting for durations and queue ages. (`server/internal/jobs/registry.go`, [[1]](diffhunk://#diff-e7767f8e58b0970bed61959fe271e5b6ae55cdd916877716b9952346767cc5baR1100-R1116) [[2]](diffhunk://#diff-e7767f8e58b0970bed61959fe271e5b6ae55cdd916877716b9952346767cc5baL983-R1139) [[3]](diffhunk://#diff-e7767f8e58b0970bed61959fe271e5b6ae55cdd916877716b9952346767cc5baL1013-R1165)

**Testing:**

* Added a new test to verify that the jobs summary aggregates are included and accurate in the state API response. (`server/internal/api/state_test.go`, [[1]](diffhunk://#diff-90383ef994d9a369ee774688c0fc2eab831b9f0d38ad49a9ebfc70203e153c15R97-R176); import changes [[2]](diffhunk://#diff-90383ef994d9a369ee774688c0fc2eab831b9f0d38ad49a9ebfc70203e153c15R8-R17)

These changes provide better visibility into job processing performance and reliability, both programmatically and via the dashboard, and ensure that job state transitions are robust and auditable.