### PR TITLE
Auto detect llama-cpp server and ollama backend version

### DIFF
--- a/doc/env.md
+++ b/doc/env.md
@@ -56,7 +56,7 @@ The worker optionally reads settings from a YAML config file. Defaults:
 | `CLIENT_KEY` | `client_key` | shared secret for authenticating with the server | unset | `--client-key` |
 | `COMPLETION_BASE_URL` | `completion_base_url` | base URL of the completion API | `http://127.0.0.1:11434/v1` | `--completion-base-url` |
 | `COMPLETION_API_KEY` | — | API key for the completion API | unset | `--completion-api-key` |
-| `COMPLETION_AGENT_VERSION` | `completion_agent_version` | backend completion agent version to advertise to the server | unset | `--completion-agent-version` |
+| `COMPLETION_AGENT_VERSION` | `completion_agent_version` | backend completion agent version to advertise to the server; overrides auto-discovery from `/props` or `/api/version` when set | unset | `--completion-agent-version` |
 | `API_STYLE` | `api_style` | backend API style for model discovery (`openai` or `ollama`) | `openai` | `--api-style` |
 | `MAX_CONCURRENCY` | `max_concurrency` | maximum number of jobs processed concurrently | `2` | `--max-concurrency` |
 | `EMBEDDING_BATCH_SIZE` | `embedding_batch_size` | ideal number of inputs per embeddings call | `0` | `--embedding-batch-size` |

--- a/modules/llm/agent/cmd/nfrx-llm/backendversion.go
+++ b/modules/llm/agent/cmd/nfrx-llm/backendversion.go
@@ -1,0 +1,72 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"strings"
+	"time"
+)
+
+const backendVersionProbeTimeout = 2 * time.Second
+
+type propsResponse struct {
+	BuildInfo string `json:"build_info"`
+}
+
+type apiVersionResponse struct {
+	Version string `json:"version"`
+}
+
+func discoverCompletionAgentVersion(ctx context.Context, baseURL, apiKey string) string {
+	root := strings.TrimRight(parentBase(normalizeBase(baseURL)), "/")
+	if root == "" {
+		return ""
+	}
+	probeCtx, cancel := context.WithTimeout(ctx, backendVersionProbeTimeout)
+	defer cancel()
+	client := &http.Client{}
+	if buildInfo := fetchBackendBuildInfo(probeCtx, client, root+"/props", apiKey); buildInfo != "" {
+		return "llama.cpp " + buildInfo
+	}
+	if version := fetchBackendAPIVersion(probeCtx, client, root+"/api/version", apiKey); version != "" {
+		return "ollama " + version
+	}
+	return ""
+}
+
+func fetchBackendBuildInfo(ctx context.Context, client *http.Client, url, apiKey string) string {
+	var resp propsResponse
+	if !fetchBackendJSON(ctx, client, url, apiKey, &resp) {
+		return ""
+	}
+	return strings.TrimSpace(resp.BuildInfo)
+}
+
+func fetchBackendAPIVersion(ctx context.Context, client *http.Client, url, apiKey string) string {
+	var resp apiVersionResponse
+	if !fetchBackendJSON(ctx, client, url, apiKey, &resp) {
+		return ""
+	}
+	return strings.TrimSpace(resp.Version)
+}
+
+func fetchBackendJSON(ctx context.Context, client *http.Client, url, apiKey string, out any) bool {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return false
+	}
+	req.Header.Set("Accept", "application/json")
+	if apiKey != "" {
+		req.Header.Set("Authorization", "Bearer "+apiKey)
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return false
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return false
+	}
+	return json.NewDecoder(resp.Body).Decode(out) == nil
+}

--- a/modules/llm/agent/cmd/nfrx-llm/backendversion.go
+++ b/modules/llm/agent/cmd/nfrx-llm/backendversion.go
@@ -23,16 +23,26 @@ func discoverCompletionAgentVersion(ctx context.Context, baseURL, apiKey string)
 	if root == "" {
 		return ""
 	}
-	probeCtx, cancel := context.WithTimeout(ctx, backendVersionProbeTimeout)
-	defer cancel()
 	client := &http.Client{}
-	if buildInfo := fetchBackendBuildInfo(probeCtx, client, root+"/props", apiKey); buildInfo != "" {
+	if buildInfo := func() string {
+		probeCtx, cancel := probeContext(ctx)
+		defer cancel()
+		return fetchBackendBuildInfo(probeCtx, client, root+"/props", apiKey)
+	}(); buildInfo != "" {
 		return "llama.cpp " + buildInfo
 	}
-	if version := fetchBackendAPIVersion(probeCtx, client, root+"/api/version", apiKey); version != "" {
+	if version := func() string {
+		probeCtx, cancel := probeContext(ctx)
+		defer cancel()
+		return fetchBackendAPIVersion(probeCtx, client, root+"/api/version", apiKey)
+	}(); version != "" {
 		return "ollama " + version
 	}
 	return ""
+}
+
+func probeContext(parent context.Context) (context.Context, context.CancelFunc) {
+	return context.WithTimeout(parent, backendVersionProbeTimeout)
 }
 
 func fetchBackendBuildInfo(ctx context.Context, client *http.Client, url, apiKey string) string {

--- a/modules/llm/agent/cmd/nfrx-llm/backendversion_test.go
+++ b/modules/llm/agent/cmd/nfrx-llm/backendversion_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 )
 
 func TestDiscoverCompletionAgentVersionPrefersPropsBuildInfo(t *testing.T) {
@@ -31,6 +32,27 @@ func TestDiscoverCompletionAgentVersionFallsBackToAPIVersion(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case "/props":
+			http.NotFound(w, r)
+		case "/api/version":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"version":"0.18.3"}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer ts.Close()
+
+	got := discoverCompletionAgentVersion(context.Background(), ts.URL+"/v1", "")
+	if got != "ollama 0.18.3" {
+		t.Fatalf("unexpected version %q", got)
+	}
+}
+
+func TestDiscoverCompletionAgentVersionFallbackGetsFreshTimeout(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/props":
+			time.Sleep(backendVersionProbeTimeout + 200*time.Millisecond)
 			http.NotFound(w, r)
 		case "/api/version":
 			w.Header().Set("Content-Type", "application/json")

--- a/modules/llm/agent/cmd/nfrx-llm/backendversion_test.go
+++ b/modules/llm/agent/cmd/nfrx-llm/backendversion_test.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestDiscoverCompletionAgentVersionPrefersPropsBuildInfo(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/props":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"build_info":"b8860-fd6ae4ca1"}`))
+		case "/api/version":
+			t.Fatalf("unexpected fallback request to %s", r.URL.Path)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer ts.Close()
+
+	got := discoverCompletionAgentVersion(context.Background(), ts.URL+"/v1", "")
+	if got != "llama.cpp b8860-fd6ae4ca1" {
+		t.Fatalf("unexpected version %q", got)
+	}
+}
+
+func TestDiscoverCompletionAgentVersionFallsBackToAPIVersion(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/props":
+			http.NotFound(w, r)
+		case "/api/version":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"version":"0.18.3"}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer ts.Close()
+
+	got := discoverCompletionAgentVersion(context.Background(), ts.URL+"/v1", "")
+	if got != "ollama 0.18.3" {
+		t.Fatalf("unexpected version %q", got)
+	}
+}
+
+func TestDiscoverCompletionAgentVersionReturnsEmptyWhenUnknown(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.NotFound(w, r)
+	}))
+	defer ts.Close()
+
+	if got := discoverCompletionAgentVersion(context.Background(), ts.URL+"/v1", ""); got != "" {
+		t.Fatalf("expected empty version, got %q", got)
+	}
+}
+
+func TestDiscoverCompletionAgentVersionSendsBearerToken(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("Authorization"); got != "Bearer secret-123" {
+			t.Fatalf("unexpected authorization header %q", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"version":"0.18.3"}`))
+	}))
+	defer ts.Close()
+
+	got := discoverCompletionAgentVersion(context.Background(), ts.URL, "secret-123")
+	if got != "ollama 0.18.3" {
+		t.Fatalf("unexpected version %q", got)
+	}
+}

--- a/modules/llm/agent/cmd/nfrx-llm/main.go
+++ b/modules/llm/agent/cmd/nfrx-llm/main.go
@@ -145,8 +145,12 @@ func main() {
 	if cfg.EmbeddingBatchSize > 0 {
 		agentCfg["embedding_batch_size"] = strconv.Itoa(cfg.EmbeddingBatchSize)
 	}
-	if cfg.CompletionAgentVersion != "" {
-		agentCfg["completion_agent_version"] = cfg.CompletionAgentVersion
+	completionAgentVersion := strings.TrimSpace(cfg.CompletionAgentVersion)
+	if completionAgentVersion == "" {
+		completionAgentVersion = discoverCompletionAgentVersion(ctx, normalizedBase, cfg.CompletionAPIKey)
+	}
+	if completionAgentVersion != "" {
+		agentCfg["completion_agent_version"] = completionAgentVersion
 	}
 	gcfg := wp.Config{
 		ServerURL:      cfg.ServerURL,

--- a/modules/llm/ext/llmplugin.go
+++ b/modules/llm/ext/llmplugin.go
@@ -148,8 +148,8 @@ func (p *Plugin) RegisterState(reg spi.StateRegistry) {
         var ram=(typeof w.host_ram_used_percent === 'number') ? w.host_ram_used_percent.toFixed(1) : '';
         var inputTokens=(w.input_tokens_total||0);
         var outputTokens=(w.output_tokens_total||0);
-        var hostText=((hostName && hostSummary) ? (hostName+' / '+hostSummary) : (hostName || hostSummary || 'unknown'));
-        var backendHTML=completionAgentVersion ? '<div class="worker-backend">'+completionAgentVersion+'</div>' : '';
+        var hostParts=[hostName, w.host_os, w.host_platform, w.host_platform_version, completionAgentVersion].filter(Boolean);
+        var hostText=hostParts.length ? hostParts.join(' / ') : 'unknown';
         var workerID=(w.id || '');
         var workerBaseURL=new URL('/api/llm/id/'+encodeURIComponent(workerID)+'/v1', window.location.origin).toString();
         var workerModelsURL=workerBaseURL+'/models';
@@ -178,7 +178,6 @@ func (p *Plugin) RegisterState(reg spi.StateRegistry) {
             '<div class="worker-meta">'+
               '<div class="worker-version">'+(version || 'unknown')+'</div>'+
               '<div class="worker-hostline">'+hostText+'</div>'+
-              backendHTML+
             '</div>'+
           '</div>'+
           '<div class="worker-metrics">'+

--- a/modules/llm/ext/llmplugin_test.go
+++ b/modules/llm/ext/llmplugin_test.go
@@ -37,4 +37,10 @@ func TestRegisterStateHTMLIncludesHostTelemetryFields(t *testing.T) {
 			t.Fatalf("missing %q in html", want)
 		}
 	}
+	if !strings.Contains(html, "hostParts=[hostName, w.host_os, w.host_platform, w.host_platform_version, completionAgentVersion].filter(Boolean)") {
+		t.Fatalf("missing host line backend version composition")
+	}
+	if strings.Contains(html, "worker-backend") {
+		t.Fatalf("unexpected separate backend line in html")
+	}
 }


### PR DESCRIPTION
This pull request introduces automatic discovery of the backend completion agent version for LLM workers, improves how backend version information is displayed in the UI, and updates related documentation and tests. The main changes are the addition of backend version detection logic, UI adjustments to present the version inline with host details, and comprehensive testing for the new logic.

**Backend version auto-discovery and usage:**

* Added `discoverCompletionAgentVersion` logic in `backendversion.go` to probe the backend for version info via `/props` or `/api/version` endpoints, with support for API key authentication. This allows the worker to automatically detect and report its backend version if not manually specified.
* Updated `main.go` to use the discovered backend version if the `COMPLETION_AGENT_VERSION` config is unset, ensuring the most accurate version is reported to the server.

**UI changes for backend version display:**

* Refactored the HTML/JS in `llmplugin.go` to display the backend version inline with other host details, rather than as a separate line, improving clarity and compactness of worker metadata in the UI. [[1]](diffhunk://#diff-547fb1a38c6e19c9a084dc85b81e4d8e3c5e93fba02e616b3f40a52c89ca1ebbL151-R152) [[2]](diffhunk://#diff-547fb1a38c6e19c9a084dc85b81e4d8e3c5e93fba02e616b3f40a52c89ca1ebbL181)

**Testing and documentation:**

* Added comprehensive tests in `backendversion_test.go` to verify correct version detection, fallback logic, and API key handling.
* Updated documentation in `doc/env.md` to clarify that setting `COMPLETION_AGENT_VERSION` overrides the new auto-discovery mechanism.
* Enhanced UI testing in `llmplugin_test.go` to ensure the backend version is included inline and not as a separate line.