### PR TITLE
Allow host info to change without restarting client

### DIFF
--- a/doc/env.md
+++ b/doc/env.md
@@ -56,7 +56,7 @@ The worker optionally reads settings from a YAML config file. Defaults:
 | `CLIENT_KEY` | `client_key` | shared secret for authenticating with the server | unset | `--client-key` |
 | `COMPLETION_BASE_URL` | `completion_base_url` | base URL of the completion API | `http://127.0.0.1:11434/v1` | `--completion-base-url` |
 | `COMPLETION_API_KEY` | — | API key for the completion API | unset | `--completion-api-key` |
-| `COMPLETION_AGENT_VERSION` | `completion_agent_version` | backend completion agent version to advertise to the server; overrides auto-discovery from `/props` or `/api/version` when set | unset | `--completion-agent-version` |
+| `COMPLETION_AGENT_VERSION` | `completion_agent_version` | backend completion agent version to advertise to the server; overrides backend-probe discovery from `/props` or `/api/version` when set | unset | `--completion-agent-version` |
 | `API_STYLE` | `api_style` | backend API style for model discovery (`openai` or `ollama`) | `openai` | `--api-style` |
 | `MAX_CONCURRENCY` | `max_concurrency` | maximum number of jobs processed concurrently | `2` | `--max-concurrency` |
 | `EMBEDDING_BATCH_SIZE` | `embedding_batch_size` | ideal number of inputs per embeddings call | `0` | `--embedding-batch-size` |

--- a/modules/llm/agent/cmd/nfrx-llm/backendversion.go
+++ b/modules/llm/agent/cmd/nfrx-llm/backendversion.go
@@ -10,6 +10,11 @@ import (
 
 const backendVersionProbeTimeout = 2 * time.Second
 
+type backendInfo struct {
+	Family  string
+	Version string
+}
+
 type propsResponse struct {
 	BuildInfo string `json:"build_info"`
 }
@@ -18,10 +23,10 @@ type apiVersionResponse struct {
 	Version string `json:"version"`
 }
 
-func discoverCompletionAgentVersion(ctx context.Context, baseURL, apiKey string) string {
+func discoverBackendInfo(ctx context.Context, baseURL, apiKey string) backendInfo {
 	root := strings.TrimRight(parentBase(normalizeBase(baseURL)), "/")
 	if root == "" {
-		return ""
+		return backendInfo{}
 	}
 	client := &http.Client{}
 	if buildInfo := func() string {
@@ -29,16 +34,58 @@ func discoverCompletionAgentVersion(ctx context.Context, baseURL, apiKey string)
 		defer cancel()
 		return fetchBackendBuildInfo(probeCtx, client, root+"/props", apiKey)
 	}(); buildInfo != "" {
-		return "llama.cpp " + buildInfo
+		return backendInfo{Family: "llama.cpp", Version: buildInfo}
 	}
 	if version := func() string {
 		probeCtx, cancel := probeContext(ctx)
 		defer cancel()
 		return fetchBackendAPIVersion(probeCtx, client, root+"/api/version", apiKey)
 	}(); version != "" {
-		return "ollama " + version
+		return backendInfo{Family: "ollama", Version: version}
 	}
-	return ""
+	return backendInfo{}
+}
+
+func backendInfoFromOverride(version string) backendInfo {
+	version = strings.TrimSpace(version)
+	if version == "" {
+		return backendInfo{}
+	}
+	return backendInfo{
+		Family:  inferBackendFamily(version),
+		Version: version,
+	}
+}
+
+func inferBackendFamily(version string) string {
+	version = strings.ToLower(strings.TrimSpace(version))
+	switch {
+	case strings.HasPrefix(version, "llama.cpp"):
+		return "llama.cpp"
+	case strings.HasPrefix(version, "ollama"):
+		return "ollama"
+	default:
+		return "unknown"
+	}
+}
+
+func backendAgentConfig(info backendInfo) map[string]string {
+	if strings.TrimSpace(info.Version) == "" {
+		return nil
+	}
+	cfg := map[string]string{
+		"backend_version": strings.TrimSpace(info.Version),
+	}
+	family := strings.TrimSpace(info.Family)
+	if family == "" {
+		family = "unknown"
+	}
+	cfg["backend_family"] = family
+	return cfg
+}
+
+func shouldDiscoverBackendInfo(agentConfig map[string]string) bool {
+	return strings.TrimSpace(agentConfig["backend_version"]) == ""
 }
 
 func probeContext(parent context.Context) (context.Context, context.CancelFunc) {

--- a/modules/llm/agent/cmd/nfrx-llm/backendversion_test.go
+++ b/modules/llm/agent/cmd/nfrx-llm/backendversion_test.go
@@ -8,7 +8,7 @@ import (
 	"time"
 )
 
-func TestDiscoverCompletionAgentVersionPrefersPropsBuildInfo(t *testing.T) {
+func TestDiscoverBackendInfoPrefersPropsBuildInfo(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case "/props":
@@ -22,13 +22,13 @@ func TestDiscoverCompletionAgentVersionPrefersPropsBuildInfo(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	got := discoverCompletionAgentVersion(context.Background(), ts.URL+"/v1", "")
-	if got != "llama.cpp b8860-fd6ae4ca1" {
-		t.Fatalf("unexpected version %q", got)
+	got := discoverBackendInfo(context.Background(), ts.URL+"/v1", "")
+	if got.Family != "llama.cpp" || got.Version != "b8860-fd6ae4ca1" {
+		t.Fatalf("unexpected backend info %+v", got)
 	}
 }
 
-func TestDiscoverCompletionAgentVersionFallsBackToAPIVersion(t *testing.T) {
+func TestDiscoverBackendInfoFallsBackToAPIVersion(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case "/props":
@@ -42,13 +42,13 @@ func TestDiscoverCompletionAgentVersionFallsBackToAPIVersion(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	got := discoverCompletionAgentVersion(context.Background(), ts.URL+"/v1", "")
-	if got != "ollama 0.18.3" {
-		t.Fatalf("unexpected version %q", got)
+	got := discoverBackendInfo(context.Background(), ts.URL+"/v1", "")
+	if got.Family != "ollama" || got.Version != "0.18.3" {
+		t.Fatalf("unexpected backend info %+v", got)
 	}
 }
 
-func TestDiscoverCompletionAgentVersionFallbackGetsFreshTimeout(t *testing.T) {
+func TestDiscoverBackendInfoFallbackGetsFreshTimeout(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case "/props":
@@ -63,24 +63,24 @@ func TestDiscoverCompletionAgentVersionFallbackGetsFreshTimeout(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	got := discoverCompletionAgentVersion(context.Background(), ts.URL+"/v1", "")
-	if got != "ollama 0.18.3" {
-		t.Fatalf("unexpected version %q", got)
+	got := discoverBackendInfo(context.Background(), ts.URL+"/v1", "")
+	if got.Family != "ollama" || got.Version != "0.18.3" {
+		t.Fatalf("unexpected backend info %+v", got)
 	}
 }
 
-func TestDiscoverCompletionAgentVersionReturnsEmptyWhenUnknown(t *testing.T) {
+func TestDiscoverBackendInfoReturnsEmptyWhenUnknown(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		http.NotFound(w, r)
 	}))
 	defer ts.Close()
 
-	if got := discoverCompletionAgentVersion(context.Background(), ts.URL+"/v1", ""); got != "" {
-		t.Fatalf("expected empty version, got %q", got)
+	if got := discoverBackendInfo(context.Background(), ts.URL+"/v1", ""); got != (backendInfo{}) {
+		t.Fatalf("expected empty backend info, got %+v", got)
 	}
 }
 
-func TestDiscoverCompletionAgentVersionSendsBearerToken(t *testing.T) {
+func TestDiscoverBackendInfoSendsBearerToken(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if got := r.Header.Get("Authorization"); got != "Bearer secret-123" {
 			t.Fatalf("unexpected authorization header %q", got)
@@ -90,8 +90,28 @@ func TestDiscoverCompletionAgentVersionSendsBearerToken(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	got := discoverCompletionAgentVersion(context.Background(), ts.URL, "secret-123")
-	if got != "ollama 0.18.3" {
-		t.Fatalf("unexpected version %q", got)
+	got := discoverBackendInfo(context.Background(), ts.URL, "secret-123")
+	if got.Family != "ollama" || got.Version != "0.18.3" {
+		t.Fatalf("unexpected backend info %+v", got)
+	}
+}
+
+func TestBackendInfoFromOverrideInfersFamily(t *testing.T) {
+	tests := []struct {
+		name    string
+		version string
+		family  string
+	}{
+		{name: "llama.cpp", version: "llama.cpp b8860-fd6ae4ca1", family: "llama.cpp"},
+		{name: "ollama", version: "ollama 0.18.3", family: "ollama"},
+		{name: "unknown", version: "custom 1.0", family: "unknown"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := backendInfoFromOverride(tt.version)
+			if got.Version != tt.version || got.Family != tt.family {
+				t.Fatalf("unexpected backend info %+v", got)
+			}
+		})
 	}
 }

--- a/modules/llm/agent/cmd/nfrx-llm/hosttelemetry.go
+++ b/modules/llm/agent/cmd/nfrx-llm/hosttelemetry.go
@@ -3,6 +3,7 @@ package main
 import (
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/shirou/gopsutil/v4/cpu"
 	"github.com/shirou/gopsutil/v4/host"
@@ -19,13 +20,18 @@ func buildHostTelemetry() (map[string]string, func() (wp.HeartbeatSample, error)
 	if _, err := cpu.Percent(0, false); err != nil {
 		return nil, nil, fmt.Errorf("prime cpu counters: %w", err)
 	}
+	osName := strings.TrimSpace(info.Platform)
+	if osName == "" {
+		osName = strings.TrimSpace(info.OS)
+	}
+	osVersion := strings.TrimSpace(info.PlatformVersion)
+	if osVersion == "" {
+		osVersion = strings.TrimSpace(info.KernelVersion)
+	}
 	agentConfig := map[string]string{
-		"host_os":               info.OS,
-		"host_platform":         info.Platform,
-		"host_platform_family":  info.PlatformFamily,
-		"host_platform_version": info.PlatformVersion,
-		"host_kernel_version":   info.KernelVersion,
-		"host_hostname":         info.Hostname,
+		"hostname":   strings.TrimSpace(info.Hostname),
+		"os_name":    osName,
+		"os_version": osVersion,
 	}
 	sampler := func() (wp.HeartbeatSample, error) {
 		sample := wp.HeartbeatSample{}

--- a/modules/llm/agent/cmd/nfrx-llm/main.go
+++ b/modules/llm/agent/cmd/nfrx-llm/main.go
@@ -145,12 +145,8 @@ func main() {
 	if cfg.EmbeddingBatchSize > 0 {
 		agentCfg["embedding_batch_size"] = strconv.Itoa(cfg.EmbeddingBatchSize)
 	}
-	completionAgentVersion := strings.TrimSpace(cfg.CompletionAgentVersion)
-	if completionAgentVersion == "" {
-		completionAgentVersion = discoverCompletionAgentVersion(ctx, normalizedBase, cfg.CompletionAPIKey)
-	}
-	if completionAgentVersion != "" {
-		agentCfg["completion_agent_version"] = completionAgentVersion
+	for k, v := range backendAgentConfig(backendInfoFromOverride(cfg.CompletionAgentVersion)) {
+		agentCfg[k] = v
 	}
 	gcfg := wp.Config{
 		ServerURL:      cfg.ServerURL,
@@ -180,8 +176,27 @@ func main() {
 		}
 		gcfg.HeartbeatSampleFunc = heartbeatSampler
 	}
+	gcfg.ProbeFunc = wrapProbeWithBackendInfo(gcfg.ProbeFunc, normalizedBase, cfg.CompletionAPIKey)
 	if err := wp.Run(ctx, gcfg); err != nil {
 		logx.Log.Fatal().Err(err).Msg("worker exited")
+	}
+}
+
+func wrapProbeWithBackendInfo(probe wp.ProbeFunc, baseURL, apiKey string) wp.ProbeFunc {
+	if probe == nil {
+		return nil
+	}
+	return func(ctx context.Context) (wp.ProbeResult, error) {
+		res, err := probe(ctx)
+		if err != nil || !res.Ready {
+			return res, err
+		}
+		if shouldDiscoverBackendInfo(wp.GetAgentConfig()) {
+			if cfg := backendAgentConfig(discoverBackendInfo(ctx, baseURL, apiKey)); len(cfg) > 0 {
+				res.AgentConfig = cfg
+			}
+		}
+		return res, nil
 	}
 }
 

--- a/modules/llm/ext/llmplugin.go
+++ b/modules/llm/ext/llmplugin.go
@@ -140,15 +140,17 @@ func (p *Plugin) RegisterState(reg spi.StateRegistry) {
         var avg=(w.avg_processing_ms||0);
         var avgText=(avg && avg.toFixed)? avg.toFixed(0) : avg;
         var processed=(w.processed_total||0);
-        var version=(w.version || '');
-        var hostSummary=[w.host_os, w.host_platform, w.host_platform_version].filter(Boolean).join(' / ');
-        var hostName=(w.host_hostname || '');
-        var completionAgentVersion=(w.completion_agent_version || '');
+        var hostInfo=(w.host_info || {});
         var cpu=(typeof w.host_cpu_percent === 'number') ? w.host_cpu_percent.toFixed(1) : '';
         var ram=(typeof w.host_ram_used_percent === 'number') ? w.host_ram_used_percent.toFixed(1) : '';
         var inputTokens=(w.input_tokens_total||0);
         var outputTokens=(w.output_tokens_total||0);
-        var hostParts=[hostName, w.host_os, w.host_platform, w.host_platform_version, completionAgentVersion].filter(Boolean);
+        var versionParts=['client: '+(hostInfo.worker_version || 'unknown')];
+        if (hostInfo.backend_version) {
+          versionParts.push((hostInfo.backend_family || 'backend')+': '+hostInfo.backend_version);
+        }
+        var versionText=versionParts.join(' / ');
+        var hostParts=[hostInfo.hostname, hostInfo.os_name, hostInfo.os_version].filter(Boolean);
         var hostText=hostParts.length ? hostParts.join(' / ') : 'unknown';
         var workerID=(w.id || '');
         var workerBaseURL=new URL('/api/llm/id/'+encodeURIComponent(workerID)+'/v1', window.location.origin).toString();
@@ -176,7 +178,7 @@ func (p *Plugin) RegisterState(reg spi.StateRegistry) {
               '<div class="name"><span class="emoji">🦙</span><span class="status-dot" style="background:'+status+'"></span><span class="name-text">'+name+'</span>'+statusBadge+'</div>'+
             '</div>'+
             '<div class="worker-meta">'+
-              '<div class="worker-version">'+(version || 'unknown')+'</div>'+
+              '<div class="worker-version">'+versionText+'</div>'+
               '<div class="worker-hostline">'+hostText+'</div>'+
             '</div>'+
           '</div>'+

--- a/modules/llm/ext/llmplugin_test.go
+++ b/modules/llm/ext/llmplugin_test.go
@@ -32,15 +32,15 @@ func TestRegisterStateHTMLIncludesHostTelemetryFields(t *testing.T) {
 		t.Fatalf("missing llm state html")
 	}
 	html := elem.HTML()
-	for _, want := range []string{"host_cpu_percent", "host_ram_used_percent", "host_hostname", "completion_agent_version", "input_tokens_total", "output_tokens_total", "Tokens In", "Tokens Out", "worker-version", "worker-hostline"} {
+	for _, want := range []string{"host_cpu_percent", "host_ram_used_percent", "host_info", "backend_family", "backend_version", "input_tokens_total", "output_tokens_total", "Tokens In", "Tokens Out", "worker-hostline", "worker-version", "client: "} {
 		if !strings.Contains(html, want) {
 			t.Fatalf("missing %q in html", want)
 		}
 	}
-	if !strings.Contains(html, "hostParts=[hostName, w.host_os, w.host_platform, w.host_platform_version, completionAgentVersion].filter(Boolean)") {
-		t.Fatalf("missing host line backend version composition")
+	if !strings.Contains(html, "versionParts=['client: '+(hostInfo.worker_version || 'unknown')]") {
+		t.Fatalf("missing version line composition")
 	}
-	if strings.Contains(html, "worker-backend") {
-		t.Fatalf("unexpected separate backend line in html")
+	if !strings.Contains(html, "hostParts=[hostInfo.hostname, hostInfo.os_name, hostInfo.os_version].filter(Boolean)") {
+		t.Fatalf("missing host line composition")
 	}
 }

--- a/sdk/base/agent/workerproxy/config.go
+++ b/sdk/base/agent/workerproxy/config.go
@@ -34,6 +34,8 @@ type Config struct {
 	ClientName     string
 	// Optional extra config sent to the server via AgentConfig (e.g., embedding_batch_size)
 	AgentConfig map[string]string
+	// Optional dynamic config accessor merged into registration and status updates.
+	AgentConfigFunc func() map[string]string
 	// Optional heartbeat telemetry sampler.
 	HeartbeatSampleFunc func() (HeartbeatSample, error)
 
@@ -56,6 +58,7 @@ type ProbeResult struct {
 	Ready          bool
 	Models         []string
 	MaxConcurrency int
+	AgentConfig    map[string]string
 }
 
 // ProbeFunc queries the upstream backend for readiness and metadata.

--- a/sdk/base/agent/workerproxy/run.go
+++ b/sdk/base/agent/workerproxy/run.go
@@ -27,6 +27,7 @@ func Run(ctx context.Context, cfg Config) error {
 	SetWorkerInfo(cfg.ClientID, cfg.ClientName, 0)
 	SetState("not_ready")
 	SetConnectedToServer(false)
+	SetAgentConfig(currentAgentConfig(cfg))
 	// Start with backend unknown; probe will update
 	SetConnectedToBackend(false)
 
@@ -159,6 +160,7 @@ func probeBackend(ctx context.Context, cfg Config, ch chan<- ctrl.StatusUpdateMe
 			return errIfNil(err, nil)
 		}
 		// Ready
+		agentConfigChanged := MergeAgentConfig(res.AgentConfig)
 		prevConnected := GetState().ConnectedToBackend
 		prevModels := append([]string(nil), GetState().Labels...)
 		prevMaxC := GetState().MaxConcurrency
@@ -196,9 +198,12 @@ func probeBackend(ctx context.Context, cfg Config, ch chan<- ctrl.StatusUpdateMe
 		if !changed && prevMaxC != maxc {
 			changed = true
 		}
+		if !changed && agentConfigChanged {
+			changed = true
+		}
 		if changed {
 			logx.Log.Info().Int("models", len(GetState().Labels)).Msg("backend ready")
-			msg := ctrl.StatusUpdateMessage{Type: "status_update", MaxConcurrency: GetState().MaxConcurrency, Models: GetState().Labels, Status: "idle"}
+			msg := ctrl.StatusUpdateMessage{Type: "status_update", MaxConcurrency: GetState().MaxConcurrency, Models: GetState().Labels, Status: "idle", AgentConfig: res.AgentConfig}
 			sendStatusUpdate(ch, msg)
 		}
 		return nil
@@ -258,10 +263,7 @@ func connectAndServe(ctx context.Context, cancelAll context.CancelFunc, cfg Conf
 	SetLastError("")
 
 	// Populate AgentConfig for extensible values
-	agentCfg := map[string]string{}
-	for k, v := range cfg.AgentConfig {
-		agentCfg[k] = v
-	}
+	agentCfg := currentAgentConfig(cfg)
 	regMsg := ctrl.RegisterMessage{Type: "register", WorkerID: cfg.ClientID, WorkerName: cfg.ClientName, Models: GetState().Labels, MaxConcurrency: GetState().MaxConcurrency, AgentConfig: agentCfg}
 	vi := GetVersionInfo()
 	regMsg.Version = vi.Version
@@ -303,7 +305,7 @@ func connectAndServe(ctx context.Context, cancelAll context.CancelFunc, cfg Conf
 				if su.AgentConfig == nil {
 					su.AgentConfig = map[string]string{}
 				}
-				for k, v := range cfg.AgentConfig {
+				for k, v := range currentAgentConfig(cfg) {
 					if _, ok := su.AgentConfig[k]; !ok {
 						su.AgentConfig[k] = v
 					}
@@ -435,3 +437,22 @@ func sendStatusUpdate(ch chan<- ctrl.StatusUpdateMessage, msg ctrl.StatusUpdateM
 	}
 }
 func sendMsg(ctx context.Context, ch chan<- []byte, msg []byte) { agent.Send(ctx, ch, msg) }
+
+func currentAgentConfig(cfg Config) map[string]string {
+	merged := map[string]string{}
+	for k, v := range cfg.AgentConfig {
+		merged[k] = v
+	}
+	for k, v := range GetAgentConfig() {
+		merged[k] = v
+	}
+	if cfg.AgentConfigFunc != nil {
+		for k, v := range cfg.AgentConfigFunc() {
+			merged[k] = v
+		}
+	}
+	if len(merged) == 0 {
+		return nil
+	}
+	return merged
+}

--- a/sdk/base/agent/workerproxy/state.go
+++ b/sdk/base/agent/workerproxy/state.go
@@ -9,17 +9,18 @@ import (
 )
 
 type State struct {
-	State              string    `json:"state"`
-	ConnectedToServer  bool      `json:"connected_to_server"`
-	ConnectedToBackend bool      `json:"connected_to_backend"`
-	CurrentJobs        int       `json:"current_jobs"`
-	MaxConcurrency     int       `json:"max_concurrency"`
-	LastError          string    `json:"last_error"`
-	LastHeartbeat      time.Time `json:"last_heartbeat"`
-	WorkerID           string    `json:"worker_id"`
-	WorkerName         string    `json:"worker_name"`
-	Version            string    `json:"version"`
-	Labels             []string  `json:"labels,omitempty"`
+	State              string            `json:"state"`
+	ConnectedToServer  bool              `json:"connected_to_server"`
+	ConnectedToBackend bool              `json:"connected_to_backend"`
+	CurrentJobs        int               `json:"current_jobs"`
+	MaxConcurrency     int               `json:"max_concurrency"`
+	LastError          string            `json:"last_error"`
+	LastHeartbeat      time.Time         `json:"last_heartbeat"`
+	WorkerID           string            `json:"worker_id"`
+	WorkerName         string            `json:"worker_name"`
+	Version            string            `json:"version"`
+	AgentConfig        map[string]string `json:"agent_config,omitempty"`
+	Labels             []string          `json:"labels,omitempty"`
 }
 
 type VersionInfo struct{ Version, BuildSHA, BuildDate string }
@@ -40,6 +41,38 @@ func SetBuildInfo(v, sha, date string) {
 	stateMu.Unlock()
 }
 func GetVersionInfo() VersionInfo { return buildInfo }
+func SetAgentConfig(cfg map[string]string) {
+	stateMu.Lock()
+	defer stateMu.Unlock()
+	if len(cfg) == 0 {
+		stateData.AgentConfig = nil
+		return
+	}
+	stateData.AgentConfig = cloneAgentConfig(cfg)
+}
+func MergeAgentConfig(cfg map[string]string) bool {
+	if len(cfg) == 0 {
+		return false
+	}
+	stateMu.Lock()
+	defer stateMu.Unlock()
+	if stateData.AgentConfig == nil {
+		stateData.AgentConfig = map[string]string{}
+	}
+	changed := false
+	for k, v := range cfg {
+		if cur, ok := stateData.AgentConfig[k]; !ok || cur != v {
+			stateData.AgentConfig[k] = v
+			changed = true
+		}
+	}
+	return changed
+}
+func GetAgentConfig() map[string]string {
+	stateMu.RLock()
+	defer stateMu.RUnlock()
+	return cloneAgentConfig(stateData.AgentConfig)
+}
 func SetWorkerInfo(id, name string, maxConc int) {
 	stateMu.Lock()
 	stateData.WorkerID = id
@@ -124,4 +157,15 @@ func triggerDrainCheck() {
 	if fn != nil {
 		fn()
 	}
+}
+
+func cloneAgentConfig(src map[string]string) map[string]string {
+	if len(src) == 0 {
+		return nil
+	}
+	dst := make(map[string]string, len(src))
+	for k, v := range src {
+		dst[k] = v
+	}
+	return dst
 }

--- a/sdk/base/worker/metrics.go
+++ b/sdk/base/worker/metrics.go
@@ -18,26 +18,20 @@ const (
 )
 
 type WorkerSnapshot struct {
-	ID                     string       `json:"id"`
-	Name                   string       `json:"name"`
-	Version                string       `json:"version"`
-	BuildSHA               string       `json:"build_sha,omitempty"`
-	BuildDate              string       `json:"build_date,omitempty"`
-	HostOS                 string       `json:"host_os,omitempty"`
-	HostPlatform           string       `json:"host_platform,omitempty"`
-	HostPlatformFamily     string       `json:"host_platform_family,omitempty"`
-	HostPlatformVersion    string       `json:"host_platform_version,omitempty"`
-	HostKernelVersion      string       `json:"host_kernel_version,omitempty"`
-	HostHostname           string       `json:"host_hostname,omitempty"`
-	CompletionAgentVersion string       `json:"completion_agent_version,omitempty"`
-	HostCPUPercent         float64      `json:"host_cpu_percent,omitempty"`
-	HostRAMUsedPercent     float64      `json:"host_ram_used_percent,omitempty"`
-	InputTokensTotal       uint64       `json:"input_tokens_total"`
-	OutputTokensTotal      uint64       `json:"output_tokens_total"`
-	Status                 WorkerStatus `json:"status"`
-	ConnectedAt            time.Time    `json:"connected_at"`
-	LastHeartbeat          time.Time    `json:"last_heartbeat"`
-	MaxConcurrency         int          `json:"max_concurrency"`
+	ID                 string       `json:"id"`
+	Name               string       `json:"name"`
+	Version            string       `json:"version"`
+	BuildSHA           string       `json:"build_sha,omitempty"`
+	BuildDate          string       `json:"build_date,omitempty"`
+	HostInfo           HostInfo     `json:"host_info,omitempty"`
+	HostCPUPercent     float64      `json:"host_cpu_percent,omitempty"`
+	HostRAMUsedPercent float64      `json:"host_ram_used_percent,omitempty"`
+	InputTokensTotal   uint64       `json:"input_tokens_total"`
+	OutputTokensTotal  uint64       `json:"output_tokens_total"`
+	Status             WorkerStatus `json:"status"`
+	ConnectedAt        time.Time    `json:"connected_at"`
+	LastHeartbeat      time.Time    `json:"last_heartbeat"`
+	MaxConcurrency     int          `json:"max_concurrency"`
 	// Keep historical UI label for preferred batch size
 	PreferredBatchSize int     `json:"embedding_batch_size"`
 	ProcessedTotal     uint64  `json:"processed_total"`
@@ -82,6 +76,15 @@ type StateResponse struct {
 	Workers        []WorkerSnapshot `json:"workers"`
 }
 
+type HostInfo struct {
+	Hostname       string `json:"hostname,omitempty"`
+	OSName         string `json:"os_name,omitempty"`
+	OSVersion      string `json:"os_version,omitempty"`
+	WorkerVersion  string `json:"worker_version,omitempty"`
+	BackendVersion string `json:"backend_version,omitempty"`
+	BackendFamily  string `json:"backend_family,omitempty"`
+}
+
 type MetricsRegistry struct {
 	mu                                  sync.RWMutex
 	serverStart                         time.Time
@@ -100,11 +103,7 @@ type workerMetrics struct {
 	status                              WorkerStatus
 	connectedAt, lastHeartbeat          time.Time
 	version, buildSHA, buildDate        string
-	hostOS, hostPlatform                string
-	hostPlatformFamily                  string
-	hostPlatformVersion                 string
-	hostKernelVersion, hostHostname     string
-	completionAgentVersion              string
+	hostInfo                            HostInfo
 	hostCPUPercent, hostRAMUsedPercent  float64
 	inputTokensTotal, outputTokensTotal uint64
 	maxConcurrency, preferredBatchSize  int
@@ -128,6 +127,7 @@ func (m *MetricsRegistry) UpsertWorker(id, name, version, buildSHA, buildDate st
 		m.workers[id] = w
 	}
 	w.name, w.version, w.buildSHA, w.buildDate = name, version, buildSHA, buildDate
+	w.hostInfo.WorkerVersion = version
 	w.maxConcurrency, w.preferredBatchSize = maxConcurrency, embeddingBatchSize
 	w.lastHeartbeat = time.Now()
 	if w.status == "" {
@@ -142,13 +142,7 @@ func (m *MetricsRegistry) SetWorkerHostInfo(id string, agentConfig map[string]st
 	if !ok || agentConfig == nil {
 		return
 	}
-	w.hostOS = agentConfig["host_os"]
-	w.hostPlatform = agentConfig["host_platform"]
-	w.hostPlatformFamily = agentConfig["host_platform_family"]
-	w.hostPlatformVersion = agentConfig["host_platform_version"]
-	w.hostKernelVersion = agentConfig["host_kernel_version"]
-	w.hostHostname = agentConfig["host_hostname"]
-	w.completionAgentVersion = agentConfig["completion_agent_version"]
+	mergeHostInfo(&w.hostInfo, w.version, agentConfig)
 }
 
 func (m *MetricsRegistry) RemoveWorker(id string) { m.mu.Lock(); delete(m.workers, id); m.mu.Unlock() }
@@ -275,37 +269,53 @@ func (m *MetricsRegistry) Snapshot() StateResponse {
 			avg = float64(w.processingMsTotal) / float64(w.processedTotal)
 		}
 		snapshot := WorkerSnapshot{
-			ID:                     w.id,
-			Name:                   w.name,
-			Status:                 w.status,
-			ConnectedAt:            w.connectedAt,
-			LastHeartbeat:          w.lastHeartbeat,
-			Version:                w.version,
-			BuildSHA:               w.buildSHA,
-			BuildDate:              w.buildDate,
-			HostOS:                 w.hostOS,
-			HostPlatform:           w.hostPlatform,
-			HostPlatformFamily:     w.hostPlatformFamily,
-			HostPlatformVersion:    w.hostPlatformVersion,
-			HostKernelVersion:      w.hostKernelVersion,
-			HostHostname:           w.hostHostname,
-			CompletionAgentVersion: w.completionAgentVersion,
-			HostCPUPercent:         w.hostCPUPercent,
-			HostRAMUsedPercent:     w.hostRAMUsedPercent,
-			InputTokensTotal:       w.inputTokensTotal,
-			OutputTokensTotal:      w.outputTokensTotal,
-			MaxConcurrency:         w.maxConcurrency,
-			PreferredBatchSize:     w.preferredBatchSize,
-			ProcessedTotal:         w.processedTotal,
-			ProcessingMsTotal:      w.processingMsTotal,
-			AvgProcessingMs:        avg,
-			Inflight:               w.inflight,
-			FailuresTotal:          w.failuresTotal,
-			QueueLen:               w.queueLen,
-			LastError:              w.lastError,
+			ID:                 w.id,
+			Name:               w.name,
+			Status:             w.status,
+			ConnectedAt:        w.connectedAt,
+			LastHeartbeat:      w.lastHeartbeat,
+			Version:            w.version,
+			BuildSHA:           w.buildSHA,
+			BuildDate:          w.buildDate,
+			HostInfo:           w.hostInfo,
+			HostCPUPercent:     w.hostCPUPercent,
+			HostRAMUsedPercent: w.hostRAMUsedPercent,
+			InputTokensTotal:   w.inputTokensTotal,
+			OutputTokensTotal:  w.outputTokensTotal,
+			MaxConcurrency:     w.maxConcurrency,
+			PreferredBatchSize: w.preferredBatchSize,
+			ProcessedTotal:     w.processedTotal,
+			ProcessingMsTotal:  w.processingMsTotal,
+			AvgProcessingMs:    avg,
+			Inflight:           w.inflight,
+			FailuresTotal:      w.failuresTotal,
+			QueueLen:           w.queueLen,
+			LastError:          w.lastError,
 		}
 		resp.Workers = append(resp.Workers, snapshot)
 	}
 	// Leave Models empty in generic base; extensions can expose their own catalogs
 	return resp
+}
+
+func mergeHostInfo(dst *HostInfo, workerVersion string, agentConfig map[string]string) {
+	if dst == nil {
+		return
+	}
+	dst.WorkerVersion = workerVersion
+	if v, ok := agentConfig["hostname"]; ok && v != "" {
+		dst.Hostname = v
+	}
+	if v, ok := agentConfig["os_name"]; ok && v != "" {
+		dst.OSName = v
+	}
+	if v, ok := agentConfig["os_version"]; ok && v != "" {
+		dst.OSVersion = v
+	}
+	if v, ok := agentConfig["backend_version"]; ok && v != "" {
+		dst.BackendVersion = v
+	}
+	if v, ok := agentConfig["backend_family"]; ok && v != "" {
+		dst.BackendFamily = v
+	}
 }

--- a/sdk/base/worker/worker_test.go
+++ b/sdk/base/worker/worker_test.go
@@ -56,13 +56,11 @@ func TestMetricsSnapshotBasic(t *testing.T) {
 	reg := NewMetricsRegistry("v", "sha", "date", func() string { return "" })
 	reg.UpsertWorker("w1", "w1", "1", "", "", 1, 0, []string{"m"})
 	reg.SetWorkerHostInfo("w1", map[string]string{
-		"host_os":                  "windows",
-		"host_platform":            "windows",
-		"host_platform_family":     "windows",
-		"host_platform_version":    "11",
-		"host_kernel_version":      "10.0",
-		"host_hostname":            "box1",
-		"completion_agent_version": "ollama 0.9.6",
+		"hostname":        "box1",
+		"os_name":         "windows",
+		"os_version":      "11",
+		"backend_family":  "ollama",
+		"backend_version": "0.9.6",
 	})
 	reg.RecordJobStart("w1")
 	reg.RecordJobEnd("w1", "m", 10*time.Millisecond, 1, 2, 0, true, "")
@@ -73,7 +71,7 @@ func TestMetricsSnapshotBasic(t *testing.T) {
 	if len(snap.Workers) != 1 || snap.Server.JobsCompletedTotal != 1 {
 		t.Fatalf("bad snapshot %+v", snap)
 	}
-	if snap.Workers[0].HostHostname != "box1" || snap.Workers[0].CompletionAgentVersion != "ollama 0.9.6" || snap.Workers[0].HostCPUPercent != 12.5 || snap.Workers[0].HostRAMUsedPercent != 43.75 || snap.Workers[0].InputTokensTotal != 123 || snap.Workers[0].OutputTokensTotal != 456 {
+	if snap.Workers[0].HostInfo.Hostname != "box1" || snap.Workers[0].HostInfo.OSName != "windows" || snap.Workers[0].HostInfo.OSVersion != "11" || snap.Workers[0].HostInfo.WorkerVersion != "1" || snap.Workers[0].HostCPUPercent != 12.5 || snap.Workers[0].HostRAMUsedPercent != 43.75 || snap.Workers[0].InputTokensTotal != 123 || snap.Workers[0].OutputTokensTotal != 456 {
 		t.Fatalf("bad host snapshot %+v", snap.Workers[0])
 	}
 }
@@ -131,13 +129,11 @@ func TestWSRegisterAndHeartbeatStoreHostTelemetry(t *testing.T) {
 		BuildSHA:       "abc123",
 		BuildDate:      "2026-03-09",
 		AgentConfig: map[string]string{
-			"host_os":                  "windows",
-			"host_platform":            "windows",
-			"host_platform_family":     "windows",
-			"host_platform_version":    "11",
-			"host_kernel_version":      "10.0.26100",
-			"host_hostname":            "box1",
-			"completion_agent_version": "llama.cpp b4514",
+			"hostname":        "box1",
+			"os_name":         "windows",
+			"os_version":      "11",
+			"backend_family":  "llama.cpp",
+			"backend_version": "b4514",
 		},
 	}
 	b, _ := json.Marshal(rm)
@@ -157,13 +153,67 @@ func TestWSRegisterAndHeartbeatStoreHostTelemetry(t *testing.T) {
 		snap := mx.Snapshot()
 		if len(snap.Workers) == 1 {
 			w := snap.Workers[0]
-			if w.Version == "v1.2.3" && w.HostHostname == "box1" && w.CompletionAgentVersion == "llama.cpp b4514" && w.HostCPUPercent == 22.5 && w.HostRAMUsedPercent == 67.25 {
+			if w.Version == "v1.2.3" && w.HostInfo.Hostname == "box1" && w.HostInfo.BackendFamily == "llama.cpp" && w.HostInfo.BackendVersion == "b4514" && w.HostCPUPercent == 22.5 && w.HostRAMUsedPercent == 67.25 {
 				return
 			}
 		}
 		time.Sleep(10 * time.Millisecond)
 	}
 	t.Fatalf("worker snapshot not updated: %+v", mx.Snapshot())
+}
+
+func TestStatusUpdateMergesHostInfoWithoutClearingExistingFields(t *testing.T) {
+	reg := NewRegistry()
+	mx := NewMetricsRegistry("test", "", "", func() string { return "" })
+	srv := httptest.NewServer(WSHandler(reg, mx, "", nil))
+	defer srv.Close()
+	ctx := context.Background()
+	wsURL := strings.Replace(srv.URL, "http", "ws", 1)
+	c, _, err := websocket.Dial(ctx, wsURL, nil)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer func() { _ = c.Close(websocket.StatusNormalClosure, "") }()
+	rm := ctrl.RegisterMessage{
+		Type:           "register",
+		WorkerID:       "w1abcdef",
+		WorkerName:     "Alpha",
+		Models:         []string{"m"},
+		MaxConcurrency: 1,
+		Version:        "v1.2.3",
+		AgentConfig: map[string]string{
+			"hostname":   "box1",
+			"os_name":    "ubuntu",
+			"os_version": "24.04",
+		},
+	}
+	b, _ := json.Marshal(rm)
+	if err := c.Write(ctx, websocket.MessageText, b); err != nil {
+		t.Fatalf("write register: %v", err)
+	}
+	su, _ := json.Marshal(ctrl.StatusUpdateMessage{
+		Type:           "status_update",
+		MaxConcurrency: 1,
+		Status:         "idle",
+		AgentConfig: map[string]string{
+			"backend_family":  "ollama",
+			"backend_version": "0.18.3",
+		},
+	})
+	if err := c.Write(ctx, websocket.MessageText, su); err != nil {
+		t.Fatalf("write status update: %v", err)
+	}
+	for i := 0; i < 50; i++ {
+		snap := mx.Snapshot()
+		if len(snap.Workers) == 1 {
+			w := snap.Workers[0]
+			if w.HostInfo.Hostname == "box1" && w.HostInfo.OSName == "ubuntu" && w.HostInfo.BackendFamily == "ollama" && w.HostInfo.BackendVersion == "0.18.3" {
+				return
+			}
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("worker snapshot not updated after status update: %+v", mx.Snapshot())
 }
 
 func TestMetricsRegistryRace(t *testing.T) {

--- a/sdk/base/worker/ws.go
+++ b/sdk/base/worker/ws.go
@@ -183,6 +183,9 @@ func WSHandler(reg *Registry, metrics *MetricsRegistry, clientKey string, state 
 					}
 					wk.mu.Unlock()
 					metrics.UpdateWorker(wk.ID, m.MaxConcurrency, prefBatch, m.Models)
+					if m.AgentConfig != nil {
+						metrics.SetWorkerHostInfo(wk.ID, m.AgentConfig)
+					}
 					if m.Status != "" {
 						metrics.SetWorkerStatus(wk.ID, WorkerStatus(m.Status))
 					}

--- a/server/internal/api/state_test.go
+++ b/server/internal/api/state_test.go
@@ -21,13 +21,11 @@ func TestGetState(t *testing.T) {
 	metricsReg := llmctrl.NewMetricsRegistry("v", "sha", "date", func() string { return "" })
 	metricsReg.UpsertWorker("w1", "w1", "1", "a", "d", 1, 0, []string{"m"})
 	metricsReg.SetWorkerHostInfo("w1", map[string]string{
-		"host_os":                  "windows",
-		"host_platform":            "windows",
-		"host_platform_family":     "windows",
-		"host_platform_version":    "11",
-		"host_kernel_version":      "10.0",
-		"host_hostname":            "box1",
-		"completion_agent_version": "ollama 0.9.6",
+		"hostname":        "box1",
+		"os_name":         "windows",
+		"os_version":      "11",
+		"backend_family":  "ollama",
+		"backend_version": "0.9.6",
 	})
 	metricsReg.SetWorkerStatus("w1", llmctrl.StatusConnected)
 	metricsReg.RecordHeartbeat("w1", 12.5, 43.75)
@@ -62,7 +60,7 @@ func TestGetState(t *testing.T) {
 	if resp.Workers[0].Name != "w1" {
 		t.Fatalf("expected worker name")
 	}
-	if resp.Workers[0].Version != "1" || resp.Workers[0].HostHostname != "box1" || resp.Workers[0].CompletionAgentVersion != "ollama 0.9.6" || resp.Workers[0].HostCPUPercent != 12.5 || resp.Workers[0].HostRAMUsedPercent != 43.75 || resp.Workers[0].InputTokensTotal != 5 || resp.Workers[0].OutputTokensTotal != 7 {
+	if resp.Workers[0].Version != "1" || resp.Workers[0].HostInfo.Hostname != "box1" || resp.Workers[0].HostInfo.BackendFamily != "ollama" || resp.Workers[0].HostInfo.BackendVersion != "0.9.6" || resp.Workers[0].HostCPUPercent != 12.5 || resp.Workers[0].HostRAMUsedPercent != 43.75 || resp.Workers[0].InputTokensTotal != 5 || resp.Workers[0].OutputTokensTotal != 7 {
 		t.Fatalf("expected host telemetry %+v", resp.Workers[0])
 	}
 }


### PR DESCRIPTION
This pull request refactors and extends how backend version and host information are discovered, stored, and displayed for LLM agent workers. The changes improve the accuracy and flexibility of backend metadata reporting, unify how agent configuration is merged and sent, and enhance the UI to show richer version and host details. Key updates include a new backend info discovery mechanism, a more flexible agent config system, and improvements to host telemetry reporting and UI display.

**Backend version and agent config discovery:**

- Introduced a new `backendInfo` struct and related functions in `backendversion.go` to capture both backend family and version, replacing the previous string-based approach. The discovery logic now prefers `/props` but falls back to `/api/version` and can infer the backend family from overrides. [[1]](diffhunk://#diff-d30ddaf92135fa3f7f490bcaae411bcb32e2a8e5047ec631bb4a41be7b79037eR13-R17) [[2]](diffhunk://#diff-d30ddaf92135fa3f7f490bcaae411bcb32e2a8e5047ec631bb4a41be7b79037eL21-R88)
- Updated main agent startup (`main.go`) to use the new backend info discovery and to merge backend version/family into the agent config sent to the server. Also wraps the backend probe to update agent config dynamically if needed. [[1]](diffhunk://#diff-d050189a6e3db29cc732458714906f86870f790742344b9f139e962bda9c30efL148-R149) [[2]](diffhunk://#diff-d050189a6e3db29cc732458714906f86870f790742344b9f139e962bda9c30efR179-R202)

**Agent config merging and propagation:**

- Added `AgentConfigFunc` to the agent config struct, allowing dynamic agent config values to be merged for registration and status updates. Refactored the agent worker proxy logic to use a new `currentAgentConfig` helper for consistent merging of static, dynamic, and runtime config. [[1]](diffhunk://#diff-60e462afc8ef93e19fde2badc4699a723c7fe4d828ab2fe2cc21a26b65fb325eR37-R38) [[2]](diffhunk://#diff-1bca4a1ffa9664748e06d7a8121c0220558b91537feccd62cd5ff34765c6b2fcR30) [[3]](diffhunk://#diff-1bca4a1ffa9664748e06d7a8121c0220558b91537feccd62cd5ff34765c6b2fcL261-R266) [[4]](diffhunk://#diff-1bca4a1ffa9664748e06d7a8121c0220558b91537feccd62cd5ff34765c6b2fcL306-R308) [[5]](diffhunk://#diff-1bca4a1ffa9664748e06d7a8121c0220558b91537feccd62cd5ff34765c6b2fcR440-R458)
- Extended the probe result struct and status update messages to include the merged agent config, ensuring backend and host info are always up-to-date in server state. [[1]](diffhunk://#diff-60e462afc8ef93e19fde2badc4699a723c7fe4d828ab2fe2cc21a26b65fb325eR61) [[2]](diffhunk://#diff-1bca4a1ffa9664748e06d7a8121c0220558b91537feccd62cd5ff34765c6b2fcR163) [[3]](diffhunk://#diff-1bca4a1ffa9664748e06d7a8121c0220558b91537feccd62cd5ff34765c6b2fcR201-R206)

**Host telemetry and UI improvements:**

- Refactored host telemetry reporting to provide normalized fields (`hostname`, `os_name`, `os_version`) for easier display and comparison. [[1]](diffhunk://#diff-2a250a75257f39bebc1063631db85100d40df6ec81dbf501abffebaa0f4bd126R6) [[2]](diffhunk://#diff-2a250a75257f39bebc1063631db85100d40df6ec81dbf501abffebaa0f4bd126R23-R34)
- Updated the LLM plugin UI to display backend version/family and host info in a unified, readable format, and improved test coverage for these changes. [[1]](diffhunk://#diff-547fb1a38c6e19c9a084dc85b81e4d8e3c5e93fba02e616b3f40a52c89ca1ebbL143-R153) [[2]](diffhunk://#diff-547fb1a38c6e19c9a084dc85b81e4d8e3c5e93fba02e616b3f40a52c89ca1ebbL179-R181) [[3]](diffhunk://#diff-caf9c62fa78cd705af5dce168bed7e5900a74f8d38c81700f694a0d74165d796L35-R44)

**Documentation:**

- Clarified the meaning of the `COMPLETION_AGENT_VERSION` setting in the environment variable documentation.

**Tests:**

- Updated and extended tests to cover the new backend info discovery logic and agent config merging. [[1]](diffhunk://#diff-4bf816c5dbea266cc7637c85ce95b4395ea3c795460e35cc83fdbef345402224L11-R11) [[2]](diffhunk://#diff-4bf816c5dbea266cc7637c85ce95b4395ea3c795460e35cc83fdbef345402224L25-R31) [[3]](diffhunk://#diff-4bf816c5dbea266cc7637c85ce95b4395ea3c795460e35cc83fdbef345402224L45-R51) [[4]](diffhunk://#diff-4bf816c5dbea266cc7637c85ce95b4395ea3c795460e35cc83fdbef345402224L66-R83) [[5]](diffhunk://#diff-4bf816c5dbea266cc7637c85ce95b4395ea3c795460e35cc83fdbef345402224L93-R115)

---

**Backend discovery and agent config:**
- Introduced `backendInfo` struct and functions for robust backend version/family discovery, replacing string-based detection. [[1]](diffhunk://#diff-d30ddaf92135fa3f7f490bcaae411bcb32e2a8e5047ec631bb4a41be7b79037eR13-R17) [[2]](diffhunk://#diff-d30ddaf92135fa3f7f490bcaae411bcb32e2a8e5047ec631bb4a41be7b79037eL21-R88)
- Updated main agent startup and backend probe to use and propagate the new backend info in agent config. [[1]](diffhunk://#diff-d050189a6e3db29cc732458714906f86870f790742344b9f139e962bda9c30efL148-R149) [[2]](diffhunk://#diff-d050189a6e3db29cc732458714906f86870f790742344b9f139e962bda9c30efR179-R202)

**Agent config merging:**
- Added `AgentConfigFunc` for dynamic agent config, and refactored merging logic for registration, status, and probe results. [[1]](diffhunk://#diff-60e462afc8ef93e19fde2badc4699a723c7fe4d828ab2fe2cc21a26b65fb325eR37-R38) [[2]](diffhunk://#diff-1bca4a1ffa9664748e06d7a8121c0220558b91537feccd62cd5ff34765c6b2fcR30) [[3]](diffhunk://#diff-1bca4a1ffa9664748e06d7a8121c0220558b91537feccd62cd5ff34765c6b2fcL261-R266) [[4]](diffhunk://#diff-1bca4a1ffa9664748e06d7a8121c0220558b91537feccd62cd5ff34765c6b2fcL306-R308) [[5]](diffhunk://#diff-1bca4a1ffa9664748e06d7a8121c0220558b91537feccd62cd5ff34765c6b2fcR440-R458)
- Extended probe result and status update messages to include agent config. [[1]](diffhunk://#diff-60e462afc8ef93e19fde2badc4699a723c7fe4d828ab2fe2cc21a26b65fb325eR61) [[2]](diffhunk://#diff-1bca4a1ffa9664748e06d7a8121c0220558b91537feccd62cd5ff34765c6b2fcR163) [[3]](diffhunk://#diff-1bca4a1ffa9664748e06d7a8121c0220558b91537feccd62cd5ff34765c6b2fcR201-R206)

**Host telemetry and UI:**
- Normalized host telemetry fields for easier display. [[1]](diffhunk://#diff-2a250a75257f39bebc1063631db85100d40df6ec81dbf501abffebaa0f4bd126R6) [[2]](diffhunk://#diff-2a250a75257f39bebc1063631db85100d40df6ec81dbf501abffebaa0f4bd126R23-R34)
- Improved UI and tests to display backend and host info more clearly. [[1]](diffhunk://#diff-547fb1a38c6e19c9a084dc85b81e4d8e3c5e93fba02e616b3f40a52c89ca1ebbL143-R153) [[2]](diffhunk://#diff-547fb1a38c6e19c9a084dc85b81e4d8e3c5e93fba02e616b3f40a52c89ca1ebbL179-R181) [[3]](diffhunk://#diff-caf9c62fa78cd705af5dce168bed7e5900a74f8d38c81700f694a0d74165d796L35-R44)

**Documentation and tests:**
- Clarified config documentation for backend version override.
- Updated and added tests for backend info discovery and config merging. [[1]](diffhunk://#diff-4bf816c5dbea266cc7637c85ce95b4395ea3c795460e35cc83fdbef345402224L11-R11) [[2]](diffhunk://#diff-4bf816c5dbea266cc7637c85ce95b4395ea3c795460e35cc83fdbef345402224L25-R31) [[3]](diffhunk://#diff-4bf816c5dbea266cc7637c85ce95b4395ea3c795460e35cc83fdbef345402224L45-R51) [[4]](diffhunk://#diff-4bf816c5dbea266cc7637c85ce95b4395ea3c795460e35cc83fdbef345402224L66-R83) [[5]](diffhunk://#diff-4bf816c5dbea266cc7637c85ce95b4395ea3c795460e35cc83fdbef345402224L93-R115)